### PR TITLE
fix: fail with explicit message when --project-version is missing and using deptrack

### DIFF
--- a/index.js
+++ b/index.js
@@ -4313,6 +4313,9 @@ exports.submitBom = async (args, bomContents) => {
     autoCreate: "true",
     bom: encodedBomContents
   };
+  if (!bomPayload.projectVersion) {
+    throw new Error("Missing --project-version, please specify one");
+  }
   if (DEBUG_MODE) {
     console.log("Submitting BOM to", serverUrl);
   }


### PR DESCRIPTION
Will fix https://github.com/CycloneDX/cdxgen/issues/256

Error message being displayed:

```
cdxgen -r -o bom.xml --server-url $DEPTRACK_HOST_URL --api-key $DEPTRACK_TOKEN --project-name MyProject --fail-on-error
Error: Missing --project-version, please specify one
    at exports.submitBom (<redacted>/node_modules/@cyclonedx/cdxgen/index.js:4291:11)
    at <redacted>/node_modules/@cyclonedx/cdxgen/bin/cdxgen:291:31
```