### PR TITLE
Update SBoM server part in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ cdxgen --server
 Or use the container image.
 
 ```bash
-docker run --rm -v /tmp:/tmp -p 9090:9090 -v $(pwd):/app:rw -t ghcr.io/cyclonedx/cdxgen -r /app --server
+docker run --rm -v /tmp:/tmp -p 9090:9090 -v $(pwd):/app:rw -t ghcr.io/cyclonedx/cdxgen -r /app --server --server-host 0.0.0.0
 ```
 
 Use curl or your favourite tool to pass arguments to the `/sbom` route.


### PR DESCRIPTION
User must specify server-host in container mode, or get empty reply since the server-host is 127.0.0.1 by default.