### PR TITLE
Swift Fixes

### DIFF
--- a/index.js
+++ b/index.js
@@ -2919,7 +2919,8 @@ const createSwiftBom = async (path, options) => {
         pkgList = pkgList.concat(dlist);
       }
     }
-  } else if (swiftFiles.length) {
+  }
+  if (swiftFiles.length) {
     for (let f of swiftFiles) {
       const basePath = pathLib.dirname(f);
       if (completedPath.includes(basePath)) {
@@ -3911,6 +3912,22 @@ const createMultiXBom = async (pathList, options) => {
           "cloudbuild",
           "xml"
         )
+      );
+    }
+    bomData = await createSwiftBom(path, options);
+    if (bomData && bomData.bomJson && bomData.bomJson.components) {
+      if (DEBUG_MODE) {
+        console.log(
+          `Found ${bomData.bomJson.components.length} Swift packages at ${path}`
+        );
+      }
+      components = components.concat(bomData.bomJson.components);
+      dependencies = dependencies.concat(bomData.bomJson.dependencies);
+      if (!parentComponent || !Object.keys(parentComponent).length) {
+        parentComponent = bomData.parentComponent;
+      }
+      componentsXmls = componentsXmls.concat(
+        listComponents(options, {}, bomData.bomJson.components, "swift", "xml")
       );
     }
     // jar scanning is quite slow so this is limited to only deep scans


### PR DESCRIPTION
This PR contains two fixes identified when using the new Swift BOM Generation functionality:

- Swift was not included in the createMultiXBom function, so Swift BOMs were not generated in multiProject mode. This patch adds Swift into createMultiXBom matching the pattern of other languages.
- If both Package.resolved and Package*.swift files exist inside a repository, the former were ignored. This patch will evaluate all applicable files.