### PR TITLE
Do not add GRADLE_ARGS to :properties-call

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -1722,10 +1722,6 @@ export const executeGradleProperties = function (dir, rootPath, subProject) {
     "--build-cache"
   ];
   const gradleCmd = getGradleCommand(dir, rootPath);
-  if (process.env.GRADLE_ARGS) {
-    const addArgs = process.env.GRADLE_ARGS.split(" ");
-    gradlePropertiesArgs = gradlePropertiesArgs.concat(addArgs);
-  }
   console.log(
     "Executing",
     gradleCmd,


### PR DESCRIPTION
This fixes #383 by no longer adding any configured GRADLE_ARGS to the :properties-call, because it doesn't accept any parameters!

Would love to see this merged into v8.x as well -- I need 1.4 output...