### PR TITLE
Implemented handling of GRADLE_DEPENDENCY_TASK on v8.6.x

### DIFF
--- a/index.js
+++ b/index.js
@@ -1244,17 +1244,26 @@ const createJavaBom = async (path, options) => {
     }
     if (gradleFiles && gradleFiles.length && options.installDeps) {
       let gradleCmd = utils.getGradleCommand(path, null);
+      const defaultDepTaskArgs = [
+        "-q",
+        "--console",
+        "plain",
+        "--build-cache"
+      ];
       allProjects.push(parentComponent);
+      let depTaskWithArgs = [
+        "dependencies"
+      ];
+      if (process.env.GRADLE_DEPENDENCY_TASK) {
+        depTaskWithArgs = process.env.GRADLE_DEPENDENCY_TASK.split(" ");
+      }
       for (let sp of allProjects) {
         let gradleDepArgs = [
           sp.purl === parentComponent.purl
-            ? "dependencies"
-            : `:${sp.name}:dependencies`,
-          "-q",
-          "--console",
-          "plain",
-          "--build-cache"
+            ? depTaskWithArgs[0]
+            : `:${sp.name}:${depTaskWithArgs[0]}`
         ];
+        gradleDepArgs = gradleDepArgs.concat(depTaskWithArgs.slice(1)).concat(defaultDepTaskArgs)
         // Support custom GRADLE_ARGS such as --configuration runtimeClassPath
         if (process.env.GRADLE_ARGS) {
           const addArgs = process.env.GRADLE_ARGS.split(" ");


### PR DESCRIPTION
This fixes #386 by checking if EnvVar GRADLE_DEPENDENCY_TAK is set, and if so, use it (and possible arguments) instead of the default task 'dependencies'

This is a back-port for v8.6.x, since patching didn't quite work