### PR TITLE
Fix python version resolution

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -2056,9 +2056,16 @@ export const parsePyRequiresDist = function (dist_string) {
  */
 export const guessPypiMatchingVersion = (versionsList, versionSpecifiers) => {
   versionSpecifiers = versionSpecifiers.replace(/,/g, " ").split(";")[0];
-  // Iterate in the reverse order
-  for (let i = versionsList.length - 1; i > 0; i--) {
-    const rv = versionsList[i];
+  const comparator = (a, b) => {
+    let c = coerce(a).compare(coerce(b));
+    // if coerced versions are "equal", compare them as strings
+    if (c === 0) {
+      c = a < b ? -1 : 1;
+    }
+    return -c;
+  };
+  // Iterate in the "reverse" order
+  for (let rv of versionsList.sort(comparator)) {
     if (satisfies(coerce(rv), versionSpecifiers, true)) {
       return rv;
     }

--- a/utils.test.js
+++ b/utils.test.js
@@ -2414,11 +2414,14 @@ test("pypi version solver tests", () => {
     "1.1.0",
     "1.2.0.dev1+hg.5.b11e5e6f0b0b",
     "2.0.3",
+    "2.0b1",
+    "3.0.12-alpha.13",
     "3.0.12-alpha.12",
+    "3.0.12-alpha.14",
     "4.0.0"
   ];
   expect(guessPypiMatchingVersion(versionsList, "<4")).toEqual(
-    "3.0.12-alpha.12"
+    "3.0.12-alpha.14"
   );
   expect(guessPypiMatchingVersion(versionsList, ">1.0.0 <3.0.0")).toEqual(
     "2.0.3"


### PR DESCRIPTION
Fully relying on the order of versions returned by pypi doesn't always work and sometimes leads to incorrect version resolution.

For example, when solving version ">4,<4.1" for https://pypi.org/pypi/django/json returns 4.0b1 instead of 4.0.10. The reason for this is that pip sorts parsed versions (while pypy sorts "raw" strings).

This PR should solve some version resolution issues