### PR TITLE
Makes pnpm work without breaking docker and repotests. 1 Breaking change

### DIFF
--- a/contrib/piptree.py
+++ b/contrib/piptree.py
@@ -32,19 +32,23 @@ def get_installed_distributions():
     return [d._dist for d in dists]
 
 
-def find_deps(idx, reqs):
+def find_deps(idx, visited, reqs):
     freqs = []
     for r in reqs:
         d = idx.get(r.key)
         r.project_name = d.project_name if d is not None else r.project_name
+        if visited.get(r.project_name):
+            return freqs
         specs = sorted(r.specs, reverse=True)
         specs_str = ",".join(["".join(sp) for sp in specs]) if specs else ""
+        visited[r.project_name] = True
+        dreqs = d.requires()
         freqs.append(
             {
                 "name": r.project_name,
                 "version": importlib_metadata.version(r.key),
                 "versionSpecifiers": specs_str,
-                "dependencies": find_deps(idx, d.requires()),
+                "dependencies": find_deps(idx, visited, dreqs) if dreqs else [],
             }
         )
     return freqs
@@ -55,6 +59,7 @@ def main(argv):
     tree = []
     pkgs = get_installed_distributions()
     idx = {p.key: p for p in pkgs}
+    visited = {}
     for p in pkgs:
         fr = frozen_req_from_dist(p)
         tmpA = fr.split("==")
@@ -68,7 +73,7 @@ def main(argv):
             {
                 "name": name,
                 "version": version,
-                "dependencies": find_deps(idx, p.requires()),
+                "dependencies": find_deps(idx, visited, p.requires()),
             }
         )
     all_deps = {}

--- a/index.js
+++ b/index.js
@@ -1775,6 +1775,16 @@ export const createNodejsBom = async (path, options) => {
         if (pcs.length) {
           parentComponent = pcs[0];
           parentComponent.type = "application";
+          ppurl = new PackageURL(
+            "npm",
+            parentComponent.group,
+            parentComponent.name,
+            parentComponent.version,
+            null,
+            null
+          ).toString();
+          parentComponent["bom-ref"] = decodeURIComponent(ppurl);
+          parentComponent["purl"] = ppurl;
         }
       } else {
         let dirName = dirname(f);
@@ -1906,6 +1916,16 @@ export const createNodejsBom = async (path, options) => {
         if (pcs.length) {
           const tmpParentComponent = pcs[0];
           tmpParentComponent.type = "application";
+          ppurl = new PackageURL(
+            "npm",
+            tmpParentComponent.group,
+            tmpParentComponent.name,
+            tmpParentComponent.version,
+            null,
+            null
+          ).toString();
+          tmpParentComponent["bom-ref"] = decodeURIComponent(ppurl);
+          tmpParentComponent["purl"] = ppurl;
           if (!Object.keys(parentComponent).length) {
             parentComponent = tmpParentComponent;
           } else {

--- a/utils.js
+++ b/utils.js
@@ -448,7 +448,7 @@ export const parsePkgJson = async (pkgJsonFile) => {
       const purl = new PackageURL(
         "npm",
         group,
-        encodeForPurl(name),
+        name,
         pkgData.version,
         null,
         null
@@ -457,7 +457,6 @@ export const parsePkgJson = async (pkgJsonFile) => {
         name,
         group,
         version: pkgData.version,
-        purl,
         "bom-ref": decodeURIComponent(purl),
         properties: [
           {
@@ -865,33 +864,31 @@ export const parseNodeShrinkwrap = async function (swFile) {
           }
           version = parts[2];
         }
-        if (group !== "@types") {
-          pkgList.push({
-            group: group,
-            name: name,
-            version: version,
-            _integrity: integrity,
-            properties: [
-              {
-                name: "SrcFile",
-                value: swFile
-              }
-            ],
-            evidence: {
-              identity: {
-                field: "purl",
-                confidence: 1,
-                methods: [
-                  {
-                    technique: "manifest-analysis",
-                    confidence: 1,
-                    value: swFile
-                  }
-                ]
-              }
+        pkgList.push({
+          group: group,
+          name: name,
+          version: version,
+          _integrity: integrity,
+          properties: [
+            {
+              name: "SrcFile",
+              value: swFile
             }
-          });
-        }
+          ],
+          evidence: {
+            identity: {
+              field: "purl",
+              confidence: 1,
+              methods: [
+                {
+                  technique: "manifest-analysis",
+                  confidence: 1,
+                  value: swFile
+                }
+              ]
+            }
+          }
+        });
       }
     }
   }
@@ -1007,7 +1004,7 @@ export const parsePnpmLock = async function (pnpmLock, parentComponent = null) {
           );
           continue;
         }
-        if (group !== "@types" && name.indexOf("file:") !== 0) {
+        if (name.indexOf("file:") !== 0) {
           const purlString = new PackageURL(
             "npm",
             group,

--- a/utils.test.js
+++ b/utils.test.js
@@ -1356,8 +1356,8 @@ test("parseSetupPyFile", async () => {
 
 test("parsePnpmLock", async () => {
   let parsedList = await parsePnpmLock("./test/pnpm-lock.yaml");
-  expect(parsedList.pkgList.length).toEqual(1610);
-  expect(parsedList.dependenciesList.length).toEqual(1610);
+  expect(parsedList.pkgList.length).toEqual(1706);
+  expect(parsedList.dependenciesList.length).toEqual(1706);
   expect(parsedList.pkgList[0]).toEqual({
     _integrity:
       "sha512-IGhtTmpjGbYzcEDOw7DcQtbQSXcG9ftmAXtWTu9V936vDye4xjjekktFAtgZsWpzTj/X01jocB46mTywm/4SZw==",
@@ -1386,8 +1386,8 @@ test("parsePnpmLock", async () => {
     }
   });
   parsedList = await parsePnpmLock("./test/data/pnpm-lock.yaml");
-  expect(parsedList.pkgList.length).toEqual(308);
-  expect(parsedList.dependenciesList.length).toEqual(308);
+  expect(parsedList.pkgList.length).toEqual(318);
+  expect(parsedList.dependenciesList.length).toEqual(318);
   expect(parsedList.pkgList[0]).toEqual({
     _integrity:
       "sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==",
@@ -1450,8 +1450,8 @@ test("parsePnpmLock", async () => {
     ]
   });
   parsedList = await parsePnpmLock("./test/data/pnpm-lock3.yaml");
-  expect(parsedList.pkgList.length).toEqual(448);
-  expect(parsedList.dependenciesList.length).toEqual(448);
+  expect(parsedList.pkgList.length).toEqual(449);
+  expect(parsedList.dependenciesList.length).toEqual(449);
   expect(parsedList.pkgList[0]).toEqual({
     group: "@nodelib",
     name: "fs.scandir",
@@ -1483,8 +1483,8 @@ test("parsePnpmLock", async () => {
   expect(parsedList.pkgList.length).toEqual(1);
 
   parsedList = await parsePnpmLock("./test/data/pnpm-lock6.yaml");
-  expect(parsedList.pkgList.length).toEqual(195);
-  expect(parsedList.dependenciesList.length).toEqual(195);
+  expect(parsedList.pkgList.length).toEqual(200);
+  expect(parsedList.dependenciesList.length).toEqual(200);
   expect(parsedList.pkgList[0]).toEqual({
     group: "@babel",
     name: "code-frame",
@@ -1530,8 +1530,8 @@ test("parsePnpmLock", async () => {
     }
   });
   parsedList = await parsePnpmLock("./test/data/pnpm-lock6a.yaml");
-  expect(parsedList.pkgList.length).toEqual(229);
-  expect(parsedList.dependenciesList.length).toEqual(229);
+  expect(parsedList.pkgList.length).toEqual(234);
+  expect(parsedList.dependenciesList.length).toEqual(234);
   expect(parsedList.pkgList[0]).toEqual({
     group: "@babel",
     name: "code-frame",


### PR DESCRIPTION
- [ ] BREAKING: @types packages are no longer ignored for pnpm projects. With deep validation, it is not possible to rebuild all dependency trees by ignoring specific packages easily
- [ ] Due to some legacy baggage, `purl` cannot be set in `parsePkgJson`
- [ ] Fixes #411 


@ajmalab @cerrussell  could you kindly test and review this PR?
@Hritik14 Could you test #411 with this?