### PR TITLE
Do not ignore root project named app. 

### DIFF
--- a/test/data/gradle-android-app.dep
+++ b/test/data/gradle-android-app.dep
@@ -1,0 +1,4845 @@
+
+------------------------------------------------------------
+Project ':app'
+------------------------------------------------------------
+
+androidApis - Configuration providing various types of Android JAR file
+No dependencies
+
+androidJdkImage - Configuration providing JDK image for compiling Java 9+ sources
+No dependencies
+
+androidTestAnnotationProcessor - Classpath for the annotation processor for 'androidTest'. (n)
+No dependencies
+
+androidTestApi (n)
+No dependencies
+
+androidTestApiDependenciesMetadata
+No dependencies
+
+androidTestCompileOnly - Compile only dependencies for 'androidTest' sources. (n)
+No dependencies
+
+androidTestCompileOnlyDependenciesMetadata
+No dependencies
+
+androidTestDebugAnnotationProcessor - Classpath for the annotation processor for 'androidTestDebug'. (n)
+No dependencies
+
+androidTestDebugApi (n)
+No dependencies
+
+androidTestDebugApiDependenciesMetadata
+No dependencies
+
+androidTestDebugCompileOnly - Compile only dependencies for 'androidTestDebug' sources. (n)
+No dependencies
+
+androidTestDebugCompileOnlyDependenciesMetadata
+No dependencies
+
+androidTestDebugImplementation - Implementation only dependencies for 'androidTestDebug' sources. (n)
+No dependencies
+
+androidTestDebugImplementationDependenciesMetadata
+No dependencies
+
+androidTestDebugIntransitiveDependenciesMetadata
+No dependencies
+
+androidTestDebugRuntimeOnly - Runtime only dependencies for 'androidTestDebug' sources. (n)
+No dependencies
+
+androidTestDebugRuntimeOnlyDependenciesMetadata
+No dependencies
+
+androidTestDebugWearApp - Link to a wear app to embed for object 'androidTestDebug'. (n)
+No dependencies
+
+androidTestImplementation - Implementation only dependencies for 'androidTest' sources. (n)
++--- androidx.test.ext:junit:1.1.5 (n)
++--- androidx.test.espresso:espresso-core:3.5.1 (n)
++--- androidx.compose:compose-bom:2023.03.00 (n)
+\--- androidx.compose.ui:ui-test-junit4 (n)
+
+androidTestImplementationDependenciesMetadata
++--- androidx.test.ext:junit:1.1.5
+|    +--- junit:junit:4.13.2
+|    |    \--- org.hamcrest:hamcrest-core:1.3
+|    +--- androidx.test:core:1.5.0
+|    |    +--- androidx.annotation:annotation:1.2.0 -> 1.5.0
+|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.7.10 -> 1.8.10
+|    |    |         +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.10
+|    |    |         \--- org.jetbrains:annotations:13.0
+|    |    +--- androidx.test:monitor:1.6.0 -> 1.6.1
+|    |    |    +--- androidx.annotation:annotation:1.2.0 -> 1.5.0 (*)
+|    |    |    +--- androidx.test:annotation:1.0.1
+|    |    |    |    +--- androidx.annotation:annotation:1.2.0 -> 1.5.0 (*)
+|    |    |    |    \--- androidx.annotation:annotation-experimental:1.1.0
+|    |    |    \--- androidx.tracing:tracing:1.0.0
+|    |    +--- androidx.test.services:storage:1.4.2
+|    |    |    +--- androidx.annotation:annotation:1.2.0 -> 1.5.0 (*)
+|    |    |    +--- androidx.test:monitor:1.6.0 -> 1.6.1 (*)
+|    |    |    +--- com.google.code.findbugs:jsr305:2.0.2
+|    |    |    \--- androidx.test:annotation:1.0.1 (*)
+|    |    +--- androidx.lifecycle:lifecycle-common:2.3.1
+|    |    |    \--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    +--- androidx.tracing:tracing:1.0.0
+|    |    +--- com.google.guava:listenablefuture:1.0
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.7.10 -> 1.8.10 (*)
+|    |    \--- androidx.concurrent:concurrent-futures:1.1.0
+|    |         +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |         \--- com.google.guava:listenablefuture:1.0
+|    +--- androidx.test:monitor:1.6.1 (*)
+|    \--- androidx.annotation:annotation:1.2.0 -> 1.5.0 (*)
++--- androidx.test.espresso:espresso-core:3.5.1
+|    +--- androidx.annotation:annotation:1.2.0 -> 1.5.0 (*)
+|    +--- androidx.test:core:1.5.0 (*)
+|    +--- androidx.test:runner:1.5.2
+|    |    +--- androidx.annotation:annotation:1.2.0 -> 1.5.0 (*)
+|    |    +--- androidx.test:annotation:1.0.1 (*)
+|    |    +--- androidx.test:monitor:1.6.1 (*)
+|    |    +--- androidx.test.services:storage:1.4.2 (*)
+|    |    +--- androidx.tracing:tracing:1.0.0
+|    |    \--- junit:junit:4.13.2 (*)
+|    +--- androidx.test.espresso:espresso-idling-resource:3.5.1
+|    +--- com.squareup:javawriter:2.1.1
+|    +--- javax.inject:javax.inject:1
+|    +--- org.hamcrest:hamcrest-library:1.3
+|    |    \--- org.hamcrest:hamcrest-core:1.3
+|    +--- org.hamcrest:hamcrest-integration:1.3
+|    |    \--- org.hamcrest:hamcrest-library:1.3 (*)
+|    +--- com.google.code.findbugs:jsr305:2.0.2
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.7.10 -> 1.8.10 (*)
+|    \--- androidx.test:annotation:1.0.1 (*)
++--- androidx.compose:compose-bom:2023.03.00
+|    +--- androidx.compose.ui:ui-test-junit4:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-test:1.4.0 (c)
+|    +--- androidx.compose.runtime:runtime:1.4.0 (c)
+|    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    +--- androidx.compose.runtime:runtime-saveable:1.4.0 (c)
+|    \--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+\--- androidx.compose.ui:ui-test-junit4 -> 1.4.0
+     +--- androidx.activity:activity:1.2.1
+     |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+     |    +--- androidx.core:core:1.1.0
+     |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+     |    |    +--- androidx.lifecycle:lifecycle-runtime:2.0.0 -> 2.3.0
+     |    |    |    +--- androidx.lifecycle:lifecycle-common:2.3.0 -> 2.3.1 (*)
+     |    |    |    +--- androidx.arch.core:core-common:2.1.0
+     |    |    |    |    \--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+     |    |    |    \--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+     |    |    +--- androidx.versionedparcelable:versionedparcelable:1.1.0
+     |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+     |    |    |    \--- androidx.collection:collection:1.0.0
+     |    |    |         \--- androidx.annotation:annotation:1.0.0 -> 1.5.0 (*)
+     |    |    \--- androidx.collection:collection:1.0.0 (*)
+     |    +--- androidx.lifecycle:lifecycle-runtime:2.3.0 (*)
+     |    +--- androidx.lifecycle:lifecycle-viewmodel:2.3.0
+     |    |    \--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+     |    +--- androidx.savedstate:savedstate:1.1.0
+     |    |    \--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+     |    \--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.3.0
+     |         +--- androidx.annotation:annotation:1.0.0 -> 1.5.0 (*)
+     |         +--- androidx.savedstate:savedstate:1.1.0 (*)
+     |         +--- androidx.lifecycle:lifecycle-livedata-core:2.3.0
+     |         |    \--- androidx.lifecycle:lifecycle-common:2.3.0 -> 2.3.1 (*)
+     |         \--- androidx.lifecycle:lifecycle-viewmodel:2.3.0 (*)
+     +--- androidx.compose.ui:ui-test:1.4.0
+     |    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0
+     |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4
+     |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4
+     |    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.6.21 -> 1.8.10
+     |    |    |    |    \--- org.jetbrains.kotlinx:atomicfu:0.17.3
+     |    |    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.6.20 -> 1.8.10
+     |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.6.4
+     |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 (c)
+     |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4 (c)
+     |    |    |    |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.4 (c)
+     |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.21
+     |    |    |         +--- org.jetbrains.kotlin:kotlin-stdlib:1.6.21 -> 1.8.10 (*)
+     |    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.6.21
+     |    |    |              \--- org.jetbrains.kotlin:kotlin-stdlib:1.6.21 -> 1.8.10 (*)
+     |    |    \--- androidx.compose.runtime:runtime-saveable:1.4.0 (c)
+     |    +--- androidx.compose.ui:ui:1.4.0
+     |    |    +--- androidx.annotation:annotation:1.5.0 (*)
+     |    |    +--- androidx.compose.runtime:runtime-saveable:1.4.0
+     |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+     |    |    |    +--- androidx.compose.runtime:runtime:1.4.0 (*)
+     |    |    |    \--- androidx.compose.runtime:runtime:1.4.0 (c)
+     |    |    +--- androidx.compose.ui:ui-geometry:1.4.0
+     |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+     |    |    |    +--- androidx.compose.ui:ui:1.4.0 (c)
+     |    |    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+     |    |    |    +--- androidx.compose.ui:ui-test:1.4.0 (c)
+     |    |    |    +--- androidx.compose.ui:ui-test-junit4:1.4.0 (c)
+     |    |    |    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+     |    |    |    \--- androidx.compose.ui:ui-unit:1.4.0 (c)
+     |    |    +--- androidx.compose.ui:ui-graphics:1.4.0
+     |    |    |    +--- androidx.annotation:annotation:1.2.0 -> 1.5.0 (*)
+     |    |    |    +--- androidx.compose.ui:ui-unit:1.4.0
+     |    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+     |    |    |    |    +--- androidx.compose.ui:ui-geometry:1.4.0 (*)
+     |    |    |    |    +--- androidx.compose.ui:ui:1.4.0 (c)
+     |    |    |    |    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+     |    |    |    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+     |    |    |    |    +--- androidx.compose.ui:ui-test:1.4.0 (c)
+     |    |    |    |    +--- androidx.compose.ui:ui-test-junit4:1.4.0 (c)
+     |    |    |    |    \--- androidx.compose.ui:ui-text:1.4.0 (c)
+     |    |    |    +--- androidx.compose.ui:ui:1.4.0 (c)
+     |    |    |    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+     |    |    |    +--- androidx.compose.ui:ui-test:1.4.0 (c)
+     |    |    |    +--- androidx.compose.ui:ui-test-junit4:1.4.0 (c)
+     |    |    |    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+     |    |    |    \--- androidx.compose.ui:ui-unit:1.4.0 (c)
+     |    |    +--- androidx.compose.ui:ui-text:1.4.0
+     |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+     |    |    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (*)
+     |    |    |    +--- androidx.compose.ui:ui-unit:1.4.0 (*)
+     |    |    |    +--- androidx.compose.ui:ui:1.4.0 (c)
+     |    |    |    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+     |    |    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+     |    |    |    +--- androidx.compose.ui:ui-test:1.4.0 (c)
+     |    |    |    +--- androidx.compose.ui:ui-test-junit4:1.4.0 (c)
+     |    |    |    \--- androidx.compose.ui:ui-unit:1.4.0 (c)
+     |    |    +--- androidx.compose.ui:ui-unit:1.4.0 (*)
+     |    |    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+     |    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+     |    |    +--- androidx.compose.ui:ui-test:1.4.0 (c)
+     |    |    +--- androidx.compose.ui:ui-test-junit4:1.4.0 (c)
+     |    |    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+     |    |    \--- androidx.compose.ui:ui-unit:1.4.0 (c)
+     |    +--- androidx.compose.ui:ui-graphics:1.4.0 (*)
+     |    +--- androidx.compose.ui:ui-text:1.4.0 (*)
+     |    +--- androidx.compose.ui:ui-unit:1.4.0 (*)
+     |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+     |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.10
+     |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4 (*)
+     |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.4
+     |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4 (*)
+     |    |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.6.21 -> 1.8.10
+     |    |    \--- org.jetbrains.kotlinx:atomicfu:0.17.3 (*)
+     |    +--- androidx.compose.ui:ui:1.4.0 (c)
+     |    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+     |    +--- androidx.compose.ui:ui-test-junit4:1.4.0 (c)
+     |    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+     |    +--- androidx.compose.ui:ui-unit:1.4.0 (c)
+     |    \--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+     +--- androidx.test.ext:junit:1.1.5 (*)
+     +--- junit:junit:4.13.2 (*)
+     +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+     +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.10
+     +--- androidx.compose.ui:ui-test:1.4.0 (c)
+     +--- androidx.compose.ui:ui:1.4.0 (c)
+     +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+     +--- androidx.compose.ui:ui-text:1.4.0 (c)
+     +--- androidx.compose.ui:ui-unit:1.4.0 (c)
+     \--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+
+androidTestIntransitiveDependenciesMetadata
+No dependencies
+
+androidTestReleaseAnnotationProcessor - Classpath for the annotation processor for 'androidTestRelease'. (n)
+No dependencies
+
+androidTestReleaseApi (n)
+No dependencies
+
+androidTestReleaseApiDependenciesMetadata
+No dependencies
+
+androidTestReleaseCompileOnly - Compile only dependencies for 'androidTestRelease' sources. (n)
+No dependencies
+
+androidTestReleaseCompileOnlyDependenciesMetadata
+No dependencies
+
+androidTestReleaseImplementation - Implementation only dependencies for 'androidTestRelease' sources. (n)
+No dependencies
+
+androidTestReleaseImplementationDependenciesMetadata
+No dependencies
+
+androidTestReleaseIntransitiveDependenciesMetadata
+No dependencies
+
+androidTestReleaseRuntimeOnly - Runtime only dependencies for 'androidTestRelease' sources. (n)
+No dependencies
+
+androidTestReleaseRuntimeOnlyDependenciesMetadata
+No dependencies
+
+androidTestReleaseWearApp - Link to a wear app to embed for object 'androidTestRelease'. (n)
+No dependencies
+
+androidTestRuntimeOnly - Runtime only dependencies for 'androidTest' sources. (n)
+No dependencies
+
+androidTestRuntimeOnlyDependenciesMetadata
+No dependencies
+
+androidTestUtil - Additional APKs used during instrumentation testing.
+No dependencies
+
+androidTestWearApp - Link to a wear app to embed for object 'androidTest'. (n)
+No dependencies
+
+annotationProcessor - Classpath for the annotation processor for 'main'. (n)
+No dependencies
+
+api - API dependencies for 'main' sources. (n)
+No dependencies
+
+apiDependenciesMetadata
+\--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.10
+     +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10
+     |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.10
+     |    \--- org.jetbrains:annotations:13.0
+     \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.10
+          \--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+
+compileOnly - Compile only dependencies for 'main' sources. (n)
+No dependencies
+
+compileOnlyDependenciesMetadata
+No dependencies
+
+coreLibraryDesugaring - Configuration to desugar libraries
+No dependencies
+
+debugAndroidTestAnnotationProcessorClasspath - Resolved configuration for annotation-processor for variant: debugAndroidTest
+No dependencies
+
+debugAndroidTestApi (n)
+No dependencies
+
+debugAndroidTestApiDependenciesMetadata
+No dependencies
+
+debugAndroidTestCompilationApi - API dependencies for compilation 'debugAndroidTest' (target  (androidJvm)). (n)
+No dependencies
+
+debugAndroidTestCompilationCompileOnly - Compile only dependencies for compilation 'debugAndroidTest' (target  (androidJvm)). (n)
+No dependencies
+
+debugAndroidTestCompilationImplementation - Implementation only dependencies for compilation 'debugAndroidTest' (target  (androidJvm)). (n)
+No dependencies
+
+debugAndroidTestCompilationRuntimeOnly - Runtime only dependencies for compilation 'debugAndroidTest' (target  (androidJvm)). (n)
+No dependencies
+
+debugAndroidTestCompileClasspath - Compile classpath for compilation 'debugAndroidTest' (target  (androidJvm)).
++--- androidx.test.ext:junit:1.1.5
+|    +--- junit:junit:4.13.2
+|    |    \--- org.hamcrest:hamcrest-core:1.3
+|    +--- androidx.test:core:1.5.0
+|    |    +--- androidx.annotation:annotation:1.2.0 -> 1.5.0
+|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.7.10 -> 1.8.10
+|    |    |         +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.10
+|    |    |         \--- org.jetbrains:annotations:13.0
+|    |    +--- androidx.test:monitor:1.6.0 -> 1.6.1
+|    |    |    +--- androidx.annotation:annotation:1.2.0 -> 1.5.0 (*)
+|    |    |    +--- androidx.test:annotation:1.0.1
+|    |    |    |    +--- androidx.annotation:annotation:1.2.0 -> 1.5.0 (*)
+|    |    |    |    \--- androidx.annotation:annotation-experimental:1.1.0 -> 1.3.0
+|    |    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib:1.7.10 -> 1.8.10 (*)
+|    |    |    \--- androidx.tracing:tracing:1.0.0
+|    |    +--- androidx.test.services:storage:1.4.2
+|    |    |    +--- androidx.annotation:annotation:1.2.0 -> 1.5.0 (*)
+|    |    |    +--- androidx.test:monitor:1.6.0 -> 1.6.1 (*)
+|    |    |    +--- com.google.code.findbugs:jsr305:2.0.2
+|    |    |    \--- androidx.test:annotation:1.0.1 (*)
+|    |    +--- androidx.lifecycle:lifecycle-common:2.3.1 -> 2.6.1
+|    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4
+|    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4
+|    |    |    |    |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.6.4
+|    |    |    |    |         +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.6.4
+|    |    |    |    |         |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 (c)
+|    |    |    |    |         |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.6.4 (c)
+|    |    |    |    |         |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4 (c)
+|    |    |    |    |         |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-test-jvm:1.6.4 (c)
+|    |    |    |    |         |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.4 (c)
+|    |    |    |    |         +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.21 -> 1.8.10
+|    |    |    |    |         |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    |         |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.10
+|    |    |    |    |         |         \--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.6.21 -> 1.8.10
+|    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.6.4 (*)
+|    |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.21 -> 1.8.10 (*)
+|    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1 (c)
+|    |    |    \--- androidx.lifecycle:lifecycle-livedata-core:2.6.1 (c)
+|    |    +--- androidx.tracing:tracing:1.0.0
+|    |    +--- com.google.guava:listenablefuture:1.0
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.7.10 -> 1.8.10 (*)
+|    |    \--- androidx.concurrent:concurrent-futures:1.1.0
+|    |         +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |         \--- com.google.guava:listenablefuture:1.0
+|    +--- androidx.test:monitor:1.6.1 (*)
+|    \--- androidx.annotation:annotation:1.2.0 -> 1.5.0 (*)
++--- androidx.test.espresso:espresso-core:3.5.1
+|    +--- androidx.annotation:annotation:1.2.0 -> 1.5.0 (*)
+|    +--- androidx.test:core:1.5.0 (*)
+|    +--- androidx.test:runner:1.5.2
+|    |    +--- androidx.annotation:annotation:1.2.0 -> 1.5.0 (*)
+|    |    +--- androidx.test:annotation:1.0.1 (*)
+|    |    +--- androidx.test:monitor:1.6.1 (*)
+|    |    +--- androidx.test.services:storage:1.4.2 (*)
+|    |    +--- androidx.tracing:tracing:1.0.0
+|    |    \--- junit:junit:4.13.2 (*)
+|    +--- androidx.test.espresso:espresso-idling-resource:3.5.1
+|    +--- com.squareup:javawriter:2.1.1
+|    +--- javax.inject:javax.inject:1
+|    +--- org.hamcrest:hamcrest-library:1.3
+|    |    \--- org.hamcrest:hamcrest-core:1.3
+|    +--- org.hamcrest:hamcrest-integration:1.3
+|    |    \--- org.hamcrest:hamcrest-library:1.3 (*)
+|    +--- com.google.code.findbugs:jsr305:2.0.2
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.7.10 -> 1.8.10 (*)
+|    \--- androidx.test:annotation:1.0.1 (*)
++--- androidx.compose:compose-bom:2023.03.00
+|    +--- androidx.compose.material3:material3:1.0.0 (c)
+|    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-test-junit4:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-test-manifest:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-tooling:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-test:1.4.0 (c)
+|    +--- androidx.compose.runtime:runtime:1.4.0 (c)
+|    +--- androidx.compose.runtime:runtime-saveable:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    +--- androidx.compose.foundation:foundation:1.4.0 (c)
+|    +--- androidx.compose.material:material-icons-core:1.4.0 (c)
+|    +--- androidx.compose.material:material-ripple:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-tooling-data:1.4.0 (c)
+|    +--- androidx.compose.animation:animation:1.4.0 (c)
+|    +--- androidx.compose.animation:animation-core:1.4.0 (c)
+|    \--- androidx.compose.foundation:foundation-layout:1.4.0 (c)
++--- androidx.compose.ui:ui-test-junit4 -> 1.4.0
+|    +--- androidx.activity:activity:1.2.1 -> 1.7.2
+|    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    +--- androidx.core:core:1.8.0 -> 1.9.0
+|    |    |    +--- androidx.annotation:annotation:1.2.0 -> 1.5.0 (*)
+|    |    |    +--- androidx.annotation:annotation-experimental:1.3.0 (*)
+|    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.3.1 -> 2.6.1
+|    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    +--- androidx.arch.core:core-common:2.2.0
+|    |    |    |    |    \--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (*)
+|    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1 (c)
+|    |    |    |    \--- androidx.lifecycle:lifecycle-livedata-core:2.6.1 (c)
+|    |    |    \--- androidx.versionedparcelable:versionedparcelable:1.1.1
+|    |    |         +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |         \--- androidx.collection:collection:1.0.0 -> 1.1.0
+|    |    |              \--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (*)
+|    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1
+|    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1 (c)
+|    |    |    \--- androidx.lifecycle:lifecycle-livedata-core:2.6.1 (c)
+|    |    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1
+|    |    |    +--- androidx.annotation:annotation:1.0.0 -> 1.5.0 (*)
+|    |    |    +--- androidx.core:core-ktx:1.2.0 -> 1.9.0
+|    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    +--- androidx.core:core:1.9.0 (*)
+|    |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.7.10 -> 1.8.10 (*)
+|    |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.6.1
+|    |    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (*)
+|    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1 (c)
+|    |    |    |    \--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (*)
+|    |    |    +--- androidx.savedstate:savedstate:1.2.1
+|    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    \--- androidx.savedstate:savedstate-ktx:1.2.1 (c)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 (*)
+|    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (c)
+|    |    |    \--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1 (c)
+|    |    +--- androidx.savedstate:savedstate:1.2.1 (*)
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    +--- androidx.activity:activity-compose:1.7.2 (c)
+|    |    \--- androidx.activity:activity-ktx:1.7.2 (c)
+|    +--- androidx.compose.ui:ui-test:1.4.0
+|    |    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0
+|    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 (*)
+|    |    |    \--- androidx.compose.runtime:runtime-saveable:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui:1.4.0
+|    |    |    +--- androidx.annotation:annotation:1.5.0 (*)
+|    |    |    +--- androidx.compose.runtime:runtime-saveable:1.4.0
+|    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    +--- androidx.compose.runtime:runtime:1.4.0 (*)
+|    |    |    |    \--- androidx.compose.runtime:runtime:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-geometry:1.4.0
+|    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-test:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-test-junit4:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-test-manifest:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-tooling:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-tooling-data:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    |    |    |    \--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-graphics:1.4.0
+|    |    |    |    +--- androidx.annotation:annotation:1.2.0 -> 1.5.0 (*)
+|    |    |    |    +--- androidx.compose.ui:ui-unit:1.4.0
+|    |    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    |    +--- androidx.compose.ui:ui-geometry:1.4.0 (*)
+|    |    |    |    |    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    |    |    |    |    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    |    |    |    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    |    |    |    |    +--- androidx.compose.ui:ui-test:1.4.0 (c)
+|    |    |    |    |    +--- androidx.compose.ui:ui-test-junit4:1.4.0 (c)
+|    |    |    |    |    +--- androidx.compose.ui:ui-test-manifest:1.4.0 (c)
+|    |    |    |    |    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    |    |    |    |    +--- androidx.compose.ui:ui-tooling:1.4.0 (c)
+|    |    |    |    |    +--- androidx.compose.ui:ui-tooling-data:1.4.0 (c)
+|    |    |    |    |    \--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-test:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-test-junit4:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-test-manifest:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-tooling:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    |    |    |    \--- androidx.compose.ui:ui-tooling-data:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-text:1.4.0
+|    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (*)
+|    |    |    |    +--- androidx.compose.ui:ui-unit:1.4.0 (*)
+|    |    |    |    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-test:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-test-junit4:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-test-manifest:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-tooling:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-tooling-data:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    |    |    |    \--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-unit:1.4.0 (*)
+|    |    |    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-test:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-test-junit4:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-test-manifest:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-tooling:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    |    |    \--- androidx.compose.ui:ui-tooling-data:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (*)
+|    |    +--- androidx.compose.ui:ui-text:1.4.0 (*)
+|    |    +--- androidx.compose.ui:ui-unit:1.4.0 (*)
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.10
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4 (*)
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.4
+|    |    |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-test-jvm:1.6.4
+|    |    |         +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.6.4 (*)
+|    |    |         +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.21 -> 1.8.10 (*)
+|    |    |         +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4 (*)
+|    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.6.21 -> 1.8.10
+|    |    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-test-junit4:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-test-manifest:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-tooling:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-tooling-data:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    |    \--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    +--- androidx.test.ext:junit:1.1.5 (*)
+|    +--- junit:junit:4.13.2 (*)
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.10
+|    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-test:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-test-manifest:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-tooling:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    \--- androidx.compose.ui:ui-tooling-data:1.4.0 (c)
++--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.10 (*)
++--- project :app (*)
++--- androidx.compose.ui:ui-tooling -> 1.4.0
+|    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0 (*)
+|    +--- androidx.compose.ui:ui:1.4.0 (*)
+|    +--- androidx.compose.ui:ui-tooling-data:1.4.0
+|    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0 (*)
+|    |    +--- androidx.compose.ui:ui:1.4.0 (*)
+|    |    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-test:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-test-junit4:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-test-manifest:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-tooling:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    |    \--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-tooling-preview:1.4.0
+|    |    +--- androidx.annotation:annotation:1.2.0 -> 1.5.0 (*)
+|    |    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0 (*)
+|    |    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-test:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-test-junit4:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-test-manifest:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-tooling:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-tooling-data:1.4.0 (c)
+|    |    \--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-test:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-test-junit4:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-test-manifest:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-tooling-data:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    \--- androidx.compose.ui:ui-unit:1.4.0 (c)
++--- androidx.compose.ui:ui-test-manifest -> 1.4.0
+|    +--- androidx.activity:activity:1.2.1 -> 1.7.2 (*)
+|    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-test:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-test-junit4:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-tooling:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    \--- androidx.compose.ui:ui-tooling-data:1.4.0 (c)
++--- androidx.core:core-ktx:1.9.0 (*)
++--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1
+|    +--- androidx.annotation:annotation:1.0.0 -> 1.5.0 (*)
+|    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (*)
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 (*)
+|    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (c)
+|    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (c)
+|    +--- androidx.lifecycle:lifecycle-common:2.6.1 (c)
+|    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1 (c)
+|    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1 (c)
+|    \--- androidx.lifecycle:lifecycle-livedata-core:2.6.1 (c)
++--- androidx.activity:activity-compose:1.7.2
+|    +--- androidx.activity:activity-ktx:1.7.2
+|    |    +--- androidx.activity:activity:1.7.2 (*)
+|    |    +--- androidx.core:core-ktx:1.1.0 -> 1.9.0 (*)
+|    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (*)
+|    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1
+|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 (*)
+|    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (c)
+|    |    |    \--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1 (c)
+|    |    +--- androidx.savedstate:savedstate-ktx:1.2.1
+|    |    |    +--- androidx.savedstate:savedstate:1.2.1 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    \--- androidx.savedstate:savedstate:1.2.1 (c)
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    +--- androidx.activity:activity:1.7.2 (c)
+|    |    \--- androidx.activity:activity-compose:1.7.2 (c)
+|    +--- androidx.compose.runtime:runtime:1.0.1 -> 1.4.0 (*)
+|    +--- androidx.compose.runtime:runtime-saveable:1.0.1 -> 1.4.0 (*)
+|    +--- androidx.compose.ui:ui:1.0.1 -> 1.4.0 (*)
+|    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (*)
+|    +--- androidx.activity:activity:1.7.2 (c)
+|    \--- androidx.activity:activity-ktx:1.7.2 (c)
++--- androidx.compose.ui:ui -> 1.4.0 (*)
++--- androidx.compose.ui:ui-graphics -> 1.4.0 (*)
++--- androidx.compose.ui:ui-tooling-preview -> 1.4.0 (*)
++--- androidx.compose.material3:material3 -> 1.0.0
+|    +--- androidx.compose.foundation:foundation:1.2.0 -> 1.4.0
+|    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    +--- androidx.compose.animation:animation:1.2.1 -> 1.4.0
+|    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    +--- androidx.compose.animation:animation-core:1.4.0
+|    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4 (*)
+|    |    |    |    \--- androidx.compose.animation:animation:1.4.0 (c)
+|    |    |    +--- androidx.compose.foundation:foundation-layout:1.2.1 -> 1.4.0
+|    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    +--- androidx.compose.ui:ui:1.2.1 -> 1.4.0 (*)
+|    |    |    |    +--- androidx.compose.ui:ui-unit:1.2.1 -> 1.4.0 (*)
+|    |    |    |    \--- androidx.compose.foundation:foundation:1.4.0 (c)
+|    |    |    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0 (*)
+|    |    |    +--- androidx.compose.ui:ui:1.2.1 -> 1.4.0 (*)
+|    |    |    +--- androidx.compose.ui:ui-geometry:1.2.1 -> 1.4.0 (*)
+|    |    |    \--- androidx.compose.animation:animation-core:1.4.0 (c)
+|    |    +--- androidx.compose.runtime:runtime:1.4.0 (*)
+|    |    +--- androidx.compose.ui:ui:1.4.0 (*)
+|    |    \--- androidx.compose.foundation:foundation-layout:1.4.0 (c)
+|    +--- androidx.compose.material:material-icons-core:1.0.2 -> 1.4.0
+|    |    +--- androidx.compose.ui:ui:1.2.1 -> 1.4.0 (*)
+|    |    \--- androidx.compose.material:material-ripple:1.4.0 (c)
+|    +--- androidx.compose.material:material-ripple:1.0.0 -> 1.4.0
+|    |    +--- androidx.compose.foundation:foundation:1.2.1 -> 1.4.0 (*)
+|    |    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0 (*)
+|    |    \--- androidx.compose.material:material-icons-core:1.4.0 (c)
+|    +--- androidx.compose.runtime:runtime:1.0.1 -> 1.4.0 (*)
+|    +--- androidx.compose.ui:ui:1.3.0 -> 1.4.0 (*)
+|    +--- androidx.compose.ui:ui-graphics:1.0.1 -> 1.4.0 (*)
+|    \--- androidx.compose.ui:ui-text:1.3.0 -> 1.4.0 (*)
++--- androidx.test.ext:junit:{strictly 1.1.5} -> 1.1.5 (c)
++--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:{strictly 1.8.10} -> 1.8.10 (c)
++--- androidx.core:core-ktx:{strictly 1.9.0} -> 1.9.0 (c)
++--- androidx.lifecycle:lifecycle-runtime-ktx:{strictly 2.6.1} -> 2.6.1 (c)
++--- androidx.test.espresso:espresso-core:{strictly 3.5.1} -> 3.5.1 (c)
++--- androidx.compose:compose-bom:{strictly 2023.03.00} -> 2023.03.00 (c)
++--- androidx.compose.ui:ui-test-junit4:{strictly 1.4.0} -> 1.4.0 (c)
++--- androidx.activity:activity-compose:{strictly 1.7.2} -> 1.7.2 (c)
++--- androidx.compose.ui:ui:{strictly 1.4.0} -> 1.4.0 (c)
++--- androidx.compose.ui:ui-graphics:{strictly 1.4.0} -> 1.4.0 (c)
++--- junit:junit:{strictly 4.13.2} -> 4.13.2 (c)
++--- androidx.test:core:{strictly 1.5.0} -> 1.5.0 (c)
++--- androidx.test:monitor:{strictly 1.6.1} -> 1.6.1 (c)
++--- androidx.annotation:annotation:{strictly 1.5.0} -> 1.5.0 (c)
++--- androidx.test:runner:{strictly 1.5.2} -> 1.5.2 (c)
++--- androidx.test.espresso:espresso-idling-resource:{strictly 3.5.1} -> 3.5.1 (c)
++--- com.squareup:javawriter:{strictly 2.1.1} -> 2.1.1 (c)
++--- javax.inject:javax.inject:{strictly 1} -> 1 (c)
++--- org.hamcrest:hamcrest-library:{strictly 1.3} -> 1.3 (c)
++--- org.hamcrest:hamcrest-integration:{strictly 1.3} -> 1.3 (c)
++--- com.google.code.findbugs:jsr305:{strictly 2.0.2} -> 2.0.2 (c)
++--- org.jetbrains.kotlin:kotlin-stdlib:{strictly 1.8.10} -> 1.8.10 (c)
++--- androidx.test:annotation:{strictly 1.0.1} -> 1.0.1 (c)
++--- androidx.activity:activity:{strictly 1.7.2} -> 1.7.2 (c)
++--- androidx.compose.ui:ui-test:{strictly 1.4.0} -> 1.4.0 (c)
++--- org.jetbrains.kotlin:kotlin-stdlib-common:{strictly 1.8.10} -> 1.8.10 (c)
++--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:{strictly 1.8.10} -> 1.8.10 (c)
++--- androidx.core:core:{strictly 1.9.0} -> 1.9.0 (c)
++--- androidx.lifecycle:lifecycle-runtime:{strictly 2.6.1} -> 2.6.1 (c)
++--- org.jetbrains.kotlinx:kotlinx-coroutines-android:{strictly 1.6.4} -> 1.6.4 (c)
++--- androidx.activity:activity-ktx:{strictly 1.7.2} -> 1.7.2 (c)
++--- androidx.compose.runtime:runtime:{strictly 1.4.0} -> 1.4.0 (c)
++--- androidx.compose.runtime:runtime-saveable:{strictly 1.4.0} -> 1.4.0 (c)
++--- androidx.lifecycle:lifecycle-viewmodel:{strictly 2.6.1} -> 2.6.1 (c)
++--- androidx.compose.ui:ui-geometry:{strictly 1.4.0} -> 1.4.0 (c)
++--- androidx.compose.ui:ui-text:{strictly 1.4.0} -> 1.4.0 (c)
++--- androidx.compose.ui:ui-unit:{strictly 1.4.0} -> 1.4.0 (c)
++--- org.hamcrest:hamcrest-core:{strictly 1.3} -> 1.3 (c)
++--- androidx.test.services:storage:{strictly 1.4.2} -> 1.4.2 (c)
++--- androidx.lifecycle:lifecycle-common:{strictly 2.6.1} -> 2.6.1 (c)
++--- androidx.tracing:tracing:{strictly 1.0.0} -> 1.0.0 (c)
++--- com.google.guava:listenablefuture:{strictly 1.0} -> 1.0 (c)
++--- androidx.concurrent:concurrent-futures:{strictly 1.1.0} -> 1.1.0 (c)
++--- org.jetbrains:annotations:{strictly 13.0} -> 13.0 (c)
++--- androidx.annotation:annotation-experimental:{strictly 1.3.0} -> 1.3.0 (c)
++--- org.jetbrains.kotlinx:kotlinx-coroutines-core:{strictly 1.6.4} -> 1.6.4 (c)
++--- org.jetbrains.kotlinx:kotlinx-coroutines-test:{strictly 1.6.4} -> 1.6.4 (c)
++--- androidx.lifecycle:lifecycle-viewmodel-savedstate:{strictly 2.6.1} -> 2.6.1 (c)
++--- androidx.savedstate:savedstate:{strictly 1.2.1} -> 1.2.1 (c)
++--- androidx.versionedparcelable:versionedparcelable:{strictly 1.1.1} -> 1.1.1 (c)
++--- androidx.arch.core:core-common:{strictly 2.2.0} -> 2.2.0 (c)
++--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:{strictly 1.6.4} -> 1.6.4 (c)
++--- androidx.lifecycle:lifecycle-viewmodel-ktx:{strictly 2.6.1} -> 2.6.1 (c)
++--- androidx.savedstate:savedstate-ktx:{strictly 1.2.1} -> 1.2.1 (c)
++--- org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:{strictly 1.6.4} -> 1.6.4 (c)
++--- org.jetbrains.kotlinx:kotlinx-coroutines-test-jvm:{strictly 1.6.4} -> 1.6.4 (c)
++--- androidx.lifecycle:lifecycle-livedata-core:{strictly 2.6.1} -> 2.6.1 (c)
+\--- androidx.collection:collection:{strictly 1.1.0} -> 1.1.0 (c)
+
+debugAndroidTestCompileOnly (n)
+No dependencies
+
+debugAndroidTestCompileOnlyDependenciesMetadata
+No dependencies
+
+debugAndroidTestImplementation (n)
+No dependencies
+
+debugAndroidTestImplementationDependenciesMetadata
+No dependencies
+
+debugAndroidTestIntransitiveDependenciesMetadata
+No dependencies
+
+debugAndroidTestRuntimeClasspath - Runtime classpath of compilation 'debugAndroidTest' (target  (androidJvm)).
++--- androidx.test.ext:junit:1.1.5
+|    +--- junit:junit:4.13.2
+|    |    \--- org.hamcrest:hamcrest-core:1.3
+|    +--- androidx.test:core:1.5.0
+|    |    +--- androidx.annotation:annotation:1.2.0 -> 1.5.0
+|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.7.10 -> 1.8.10
+|    |    |         +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.10
+|    |    |         \--- org.jetbrains:annotations:13.0
+|    |    +--- androidx.test:monitor:1.6.0 -> 1.6.1
+|    |    |    +--- androidx.annotation:annotation:1.2.0 -> 1.5.0 (*)
+|    |    |    +--- androidx.test:annotation:1.0.1
+|    |    |    |    +--- androidx.annotation:annotation:1.2.0 -> 1.5.0 (*)
+|    |    |    |    \--- androidx.annotation:annotation-experimental:1.1.0 -> 1.3.0
+|    |    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib:1.7.10 -> 1.8.10 (*)
+|    |    |    \--- androidx.tracing:tracing:1.0.0
+|    |    |         \--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    +--- androidx.test.services:storage:1.4.2
+|    |    |    +--- androidx.annotation:annotation:1.2.0 -> 1.5.0 (*)
+|    |    |    +--- androidx.test:monitor:1.6.0 -> 1.6.1 (*)
+|    |    |    +--- com.google.code.findbugs:jsr305:2.0.2
+|    |    |    \--- androidx.test:annotation:1.0.1 (*)
+|    |    +--- androidx.lifecycle:lifecycle-common:2.3.1 -> 2.6.1
+|    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4
+|    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4
+|    |    |    |    |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.6.4
+|    |    |    |    |         +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.6.4
+|    |    |    |    |         |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 (c)
+|    |    |    |    |         |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.6.4 (c)
+|    |    |    |    |         |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4 (c)
+|    |    |    |    |         |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-test-jvm:1.6.4 (c)
+|    |    |    |    |         |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.4 (c)
+|    |    |    |    |         +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.21 -> 1.8.10
+|    |    |    |    |         |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    |         |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.10
+|    |    |    |    |         |         \--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.6.21 -> 1.8.10
+|    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.6.4 (*)
+|    |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.21 -> 1.8.10 (*)
+|    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1 (c)
+|    |    |    \--- androidx.lifecycle:lifecycle-process:2.6.1 (c)
+|    |    +--- androidx.tracing:tracing:1.0.0 (*)
+|    |    +--- com.google.guava:listenablefuture:1.0
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.7.10 -> 1.8.10 (*)
+|    |    \--- androidx.concurrent:concurrent-futures:1.1.0
+|    |         +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |         \--- com.google.guava:listenablefuture:1.0
+|    +--- androidx.test:monitor:1.6.1 (*)
+|    \--- androidx.annotation:annotation:1.2.0 -> 1.5.0 (*)
++--- androidx.test.espresso:espresso-core:3.5.1
+|    +--- androidx.annotation:annotation:1.2.0 -> 1.5.0 (*)
+|    +--- androidx.test:core:1.5.0 (*)
+|    +--- androidx.test:runner:1.5.2
+|    |    +--- androidx.annotation:annotation:1.2.0 -> 1.5.0 (*)
+|    |    +--- androidx.test:annotation:1.0.1 (*)
+|    |    +--- androidx.test:monitor:1.6.1 (*)
+|    |    +--- androidx.test.services:storage:1.4.2 (*)
+|    |    +--- androidx.tracing:tracing:1.0.0 (*)
+|    |    \--- junit:junit:4.13.2 (*)
+|    +--- androidx.test.espresso:espresso-idling-resource:3.5.1
+|    +--- com.squareup:javawriter:2.1.1
+|    +--- javax.inject:javax.inject:1
+|    +--- org.hamcrest:hamcrest-library:1.3
+|    |    \--- org.hamcrest:hamcrest-core:1.3
+|    +--- org.hamcrest:hamcrest-integration:1.3
+|    |    \--- org.hamcrest:hamcrest-library:1.3 (*)
+|    +--- com.google.code.findbugs:jsr305:2.0.2
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.7.10 -> 1.8.10 (*)
+|    \--- androidx.test:annotation:1.0.1 (*)
++--- androidx.compose:compose-bom:2023.03.00
+|    +--- androidx.compose.ui:ui-test-junit4:1.4.0 (c)
+|    +--- androidx.compose.runtime:runtime-saveable:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-test:1.4.0 (c)
+|    +--- androidx.compose.runtime:runtime:1.4.0 (c)
+|    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-util:1.4.0 (c)
+|    \--- androidx.compose.ui:ui-geometry:1.4.0 (c)
++--- androidx.compose.ui:ui-test-junit4 -> 1.4.0
+|    +--- androidx.activity:activity:1.2.1 -> 1.7.2
+|    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    +--- androidx.collection:collection:1.0.0 -> 1.1.0
+|    |    |    \--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    +--- androidx.core:core:1.8.0 -> 1.9.0
+|    |    |    +--- androidx.annotation:annotation:1.2.0 -> 1.5.0 (*)
+|    |    |    +--- androidx.annotation:annotation-experimental:1.3.0 (*)
+|    |    |    +--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
+|    |    |    +--- androidx.concurrent:concurrent-futures:1.0.0 -> 1.1.0 (*)
+|    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.3.1 -> 2.6.1
+|    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    +--- androidx.arch.core:core-common:2.2.0
+|    |    |    |    |    \--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    +--- androidx.arch.core:core-runtime:2.2.0
+|    |    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    |    \--- androidx.arch.core:core-common:2.2.0 (*)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (*)
+|    |    |    |    +--- androidx.profileinstaller:profileinstaller:1.3.0
+|    |    |    |    |    +--- androidx.annotation:annotation:1.2.0 -> 1.5.0 (*)
+|    |    |    |    |    +--- androidx.concurrent:concurrent-futures:1.1.0 (*)
+|    |    |    |    |    +--- androidx.startup:startup-runtime:1.1.1
+|    |    |    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    |    |    \--- androidx.tracing:tracing:1.0.0 (*)
+|    |    |    |    |    \--- com.google.guava:listenablefuture:1.0
+|    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1 (c)
+|    |    |    |    \--- androidx.lifecycle:lifecycle-process:2.6.1 (c)
+|    |    |    +--- androidx.versionedparcelable:versionedparcelable:1.1.1
+|    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    \--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
+|    |    |    \--- androidx.core:core-ktx:1.9.0 (c)
+|    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (*)
+|    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1
+|    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1 (c)
+|    |    |    \--- androidx.lifecycle:lifecycle-process:2.6.1 (c)
+|    |    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1
+|    |    |    +--- androidx.annotation:annotation:1.0.0 -> 1.5.0 (*)
+|    |    |    +--- androidx.core:core-ktx:1.2.0 -> 1.9.0
+|    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    +--- androidx.core:core:1.9.0 (*)
+|    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.7.10 -> 1.8.10 (*)
+|    |    |    |    \--- androidx.core:core:1.9.0 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.6.1
+|    |    |    |    +--- androidx.arch.core:core-common:2.1.0 -> 2.2.0 (*)
+|    |    |    |    +--- androidx.arch.core:core-runtime:2.1.0 -> 2.2.0 (*)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (*)
+|    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-process:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1 (c)
+|    |    |    |    \--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (*)
+|    |    |    +--- androidx.savedstate:savedstate:1.2.1
+|    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    +--- androidx.arch.core:core-common:2.1.0 -> 2.2.0 (*)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (*)
+|    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    \--- androidx.savedstate:savedstate-ktx:1.2.1 (c)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 (*)
+|    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1 (c)
+|    |    |    \--- androidx.lifecycle:lifecycle-process:2.6.1 (c)
+|    |    +--- androidx.profileinstaller:profileinstaller:1.3.0 (*)
+|    |    +--- androidx.savedstate:savedstate:1.2.1 (*)
+|    |    +--- androidx.tracing:tracing:1.0.0 (*)
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    +--- androidx.activity:activity-compose:1.7.2 (c)
+|    |    \--- androidx.activity:activity-ktx:1.7.2 (c)
+|    +--- androidx.activity:activity-compose:1.3.0 -> 1.7.2
+|    |    +--- androidx.activity:activity-ktx:1.7.2
+|    |    |    +--- androidx.activity:activity:1.7.2 (*)
+|    |    |    +--- androidx.core:core-ktx:1.1.0 -> 1.9.0 (*)
+|    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1
+|    |    |    |    +--- androidx.annotation:annotation:1.0.0 -> 1.5.0 (*)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (*)
+|    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 (*)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-process:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1 (c)
+|    |    |    |    \--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1
+|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (*)
+|    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 (*)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-process:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (c)
+|    |    |    |    \--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1 (c)
+|    |    |    +--- androidx.savedstate:savedstate-ktx:1.2.1
+|    |    |    |    +--- androidx.savedstate:savedstate:1.2.1 (*)
+|    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    \--- androidx.savedstate:savedstate:1.2.1 (c)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    +--- androidx.activity:activity:1.7.2 (c)
+|    |    |    \--- androidx.activity:activity-compose:1.7.2 (c)
+|    |    +--- androidx.compose.runtime:runtime:1.0.1 -> 1.4.0
+|    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 (*)
+|    |    |    \--- androidx.compose.runtime:runtime-saveable:1.4.0 (c)
+|    |    +--- androidx.compose.runtime:runtime-saveable:1.0.1 -> 1.4.0
+|    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    +--- androidx.compose.runtime:runtime:1.4.0 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    \--- androidx.compose.runtime:runtime:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui:1.0.1 -> 1.4.0
+|    |    |    +--- androidx.activity:activity-ktx:1.7.0 -> 1.7.2 (*)
+|    |    |    +--- androidx.annotation:annotation:1.5.0 (*)
+|    |    |    +--- androidx.autofill:autofill:1.0.0
+|    |    |    |    \--- androidx.core:core:1.1.0 -> 1.9.0 (*)
+|    |    |    +--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
+|    |    |    +--- androidx.compose.runtime:runtime:1.4.0 (*)
+|    |    |    +--- androidx.compose.runtime:runtime-saveable:1.4.0 (*)
+|    |    |    +--- androidx.compose.ui:ui-geometry:1.4.0
+|    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0 (*)
+|    |    |    |    +--- androidx.compose.ui:ui-util:1.4.0
+|    |    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    |    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    |    |    |    |    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    |    |    |    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    |    |    |    |    +--- androidx.compose.ui:ui-test:1.4.0 (c)
+|    |    |    |    |    +--- androidx.compose.ui:ui-test-junit4:1.4.0 (c)
+|    |    |    |    |    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    |    |    |    |    \--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-test:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-test-junit4:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    |    |    |    \--- androidx.compose.ui:ui-util:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-graphics:1.4.0
+|    |    |    |    +--- androidx.annotation:annotation:1.2.0 -> 1.5.0 (*)
+|    |    |    |    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0 (*)
+|    |    |    |    +--- androidx.compose.ui:ui-unit:1.4.0
+|    |    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    |    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0 (*)
+|    |    |    |    |    +--- androidx.compose.ui:ui-geometry:1.4.0 (*)
+|    |    |    |    |    +--- androidx.compose.ui:ui-util:1.4.0 (*)
+|    |    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    |    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    |    |    |    |    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    |    |    |    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    |    |    |    |    +--- androidx.compose.ui:ui-test:1.4.0 (c)
+|    |    |    |    |    +--- androidx.compose.ui:ui-test-junit4:1.4.0 (c)
+|    |    |    |    |    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    |    |    |    |    \--- androidx.compose.ui:ui-util:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-util:1.4.0 (*)
+|    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.10
+|    |    |    |    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-test:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-test-junit4:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    |    |    |    \--- androidx.compose.ui:ui-util:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-text:1.4.0
+|    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    +--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
+|    |    |    |    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0 (*)
+|    |    |    |    +--- androidx.compose.runtime:runtime-saveable:1.2.1 -> 1.4.0 (*)
+|    |    |    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (*)
+|    |    |    |    +--- androidx.compose.ui:ui-unit:1.4.0 (*)
+|    |    |    |    +--- androidx.compose.ui:ui-util:1.4.0 (*)
+|    |    |    |    +--- androidx.core:core:1.7.0 -> 1.9.0 (*)
+|    |    |    |    +--- androidx.emoji2:emoji2:1.2.0 -> 1.3.0
+|    |    |    |    |    +--- androidx.annotation:annotation:1.2.0 -> 1.5.0 (*)
+|    |    |    |    |    +--- androidx.collection:collection:1.1.0 (*)
+|    |    |    |    |    +--- androidx.core:core:1.3.0 -> 1.9.0 (*)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-process:2.4.1 -> 2.6.1
+|    |    |    |    |    |    +--- androidx.annotation:annotation:1.2.0 -> 1.5.0 (*)
+|    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (*)
+|    |    |    |    |    |    +--- androidx.startup:startup-runtime:1.1.1 (*)
+|    |    |    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (c)
+|    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.6.1 (c)
+|    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (c)
+|    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (c)
+|    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (c)
+|    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1 (c)
+|    |    |    |    |    |    \--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1 (c)
+|    |    |    |    |    \--- androidx.startup:startup-runtime:1.0.0 -> 1.1.1 (*)
+|    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.10
+|    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4 (*)
+|    |    |    |    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-test:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-test-junit4:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    |    |    |    \--- androidx.compose.ui:ui-util:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-unit:1.4.0 (*)
+|    |    |    +--- androidx.compose.ui:ui-util:1.4.0 (*)
+|    |    |    +--- androidx.core:core:1.9.0 (*)
+|    |    |    +--- androidx.customview:customview-poolingcontainer:1.0.0
+|    |    |    |    +--- androidx.core:core-ktx:1.5.0 -> 1.9.0 (*)
+|    |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.6.21 -> 1.8.10 (*)
+|    |    |    +--- androidx.emoji2:emoji2:1.2.0 -> 1.3.0 (*)
+|    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (*)
+|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (*)
+|    |    |    +--- androidx.profileinstaller:profileinstaller:1.3.0 (*)
+|    |    |    +--- androidx.savedstate:savedstate-ktx:1.2.1 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.10
+|    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 (*)
+|    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4 (*)
+|    |    |    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-test:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-test-junit4:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    |    |    \--- androidx.compose.ui:ui-util:1.4.0 (c)
+|    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (*)
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    +--- androidx.activity:activity:1.7.2 (c)
+|    |    \--- androidx.activity:activity-ktx:1.7.2 (c)
+|    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    +--- androidx.compose.runtime:runtime-saveable:1.2.1 -> 1.4.0 (*)
+|    +--- androidx.compose.ui:ui-test:1.4.0
+|    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0 (*)
+|    |    +--- androidx.compose.ui:ui:1.4.0 (*)
+|    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (*)
+|    |    +--- androidx.compose.ui:ui-text:1.4.0 (*)
+|    |    +--- androidx.compose.ui:ui-unit:1.4.0 (*)
+|    |    +--- androidx.compose.ui:ui-util:1.4.0 (*)
+|    |    +--- androidx.core:core-ktx:1.1.0 -> 1.9.0 (*)
+|    |    +--- androidx.test:monitor:1.6.0 -> 1.6.1 (*)
+|    |    +--- androidx.test.espresso:espresso-core:3.5.0 -> 3.5.1 (*)
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.10
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4 (*)
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.4
+|    |    |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-test-jvm:1.6.4
+|    |    |         +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.6.4 (*)
+|    |    |         +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.21 -> 1.8.10 (*)
+|    |    |         +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4 (*)
+|    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.6.21 -> 1.8.10
+|    |    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-test-junit4:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-util:1.4.0 (c)
+|    |    \--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    +--- androidx.lifecycle:lifecycle-common:2.5.1 -> 2.6.1 (*)
+|    +--- androidx.lifecycle:lifecycle-runtime:2.5.1 -> 2.6.1 (*)
+|    +--- androidx.test:core:1.5.0 (*)
+|    +--- androidx.test:monitor:1.6.0 -> 1.6.1 (*)
+|    +--- androidx.test.espresso:espresso-core:3.5.0 -> 3.5.1 (*)
+|    +--- androidx.test.espresso:espresso-idling-resource:3.5.0 -> 3.5.1
+|    +--- androidx.test.ext:junit:1.1.5 (*)
+|    +--- junit:junit:4.13.2 (*)
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.10
+|    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4 (*)
+|    +--- org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.4 (*)
+|    +--- androidx.compose.ui:ui-test:1.4.0 (c)
+|    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-util:1.4.0 (c)
+|    \--- androidx.compose.ui:ui-geometry:1.4.0 (c)
++--- androidx.compose:compose-bom:{strictly 2023.03.00} -> 2023.03.00 (c)
++--- androidx.annotation:annotation:{strictly 1.5.0} -> 1.5.0 (c)
++--- org.jetbrains.kotlin:kotlin-stdlib:{strictly 1.8.10} -> 1.8.10 (c)
++--- androidx.activity:activity:{strictly 1.7.2} -> 1.7.2 (c)
++--- androidx.activity:activity-compose:{strictly 1.7.2} -> 1.7.2 (c)
++--- androidx.compose.runtime:runtime-saveable:{strictly 1.4.0} -> 1.4.0 (c)
++--- androidx.lifecycle:lifecycle-common:{strictly 2.6.1} -> 2.6.1 (c)
++--- androidx.lifecycle:lifecycle-runtime:{strictly 2.6.1} -> 2.6.1 (c)
++--- org.jetbrains.kotlin:kotlin-stdlib-common:{strictly 1.8.10} -> 1.8.10 (c)
++--- org.jetbrains.kotlinx:kotlinx-coroutines-core:{strictly 1.6.4} -> 1.6.4 (c)
++--- androidx.tracing:tracing:{strictly 1.0.0} -> 1.0.0 (c)
++--- androidx.concurrent:concurrent-futures:{strictly 1.1.0} -> 1.1.0 (c)
++--- androidx.annotation:annotation-experimental:{strictly 1.3.0} -> 1.3.0 (c)
++--- org.jetbrains:annotations:{strictly 13.0} -> 13.0 (c)
++--- androidx.compose.runtime:runtime:{strictly 1.4.0} -> 1.4.0 (c)
++--- androidx.compose.ui:ui:{strictly 1.4.0} -> 1.4.0 (c)
++--- androidx.compose.ui:ui-graphics:{strictly 1.4.0} -> 1.4.0 (c)
++--- androidx.compose.ui:ui-text:{strictly 1.4.0} -> 1.4.0 (c)
++--- androidx.compose.ui:ui-unit:{strictly 1.4.0} -> 1.4.0 (c)
++--- androidx.compose.ui:ui-util:{strictly 1.4.0} -> 1.4.0 (c)
++--- androidx.core:core-ktx:{strictly 1.9.0} -> 1.9.0 (c)
++--- androidx.collection:collection:{strictly 1.1.0} -> 1.1.0 (c)
++--- androidx.core:core:{strictly 1.9.0} -> 1.9.0 (c)
++--- androidx.lifecycle:lifecycle-viewmodel:{strictly 2.6.1} -> 2.6.1 (c)
++--- androidx.lifecycle:lifecycle-viewmodel-savedstate:{strictly 2.6.1} -> 2.6.1 (c)
++--- androidx.profileinstaller:profileinstaller:{strictly 1.3.0} -> 1.3.0 (c)
++--- androidx.savedstate:savedstate:{strictly 1.2.1} -> 1.2.1 (c)
++--- androidx.activity:activity-ktx:{strictly 1.7.2} -> 1.7.2 (c)
++--- org.jetbrains.kotlinx:kotlinx-coroutines-android:{strictly 1.6.4} -> 1.6.4 (c)
++--- androidx.arch.core:core-common:{strictly 2.2.0} -> 2.2.0 (c)
++--- androidx.arch.core:core-runtime:{strictly 2.2.0} -> 2.2.0 (c)
++--- org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:{strictly 1.6.4} -> 1.6.4 (c)
++--- androidx.autofill:autofill:{strictly 1.0.0} -> 1.0.0 (c)
++--- androidx.compose.ui:ui-geometry:{strictly 1.4.0} -> 1.4.0 (c)
++--- androidx.customview:customview-poolingcontainer:{strictly 1.0.0} -> 1.0.0 (c)
++--- androidx.emoji2:emoji2:{strictly 1.3.0} -> 1.3.0 (c)
++--- androidx.savedstate:savedstate-ktx:{strictly 1.2.1} -> 1.2.1 (c)
++--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:{strictly 1.6.4} -> 1.6.4 (c)
++--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:{strictly 1.8.10} -> 1.8.10 (c)
++--- androidx.versionedparcelable:versionedparcelable:{strictly 1.1.1} -> 1.1.1 (c)
++--- androidx.lifecycle:lifecycle-livedata-core:{strictly 2.6.1} -> 2.6.1 (c)
++--- androidx.startup:startup-runtime:{strictly 1.1.1} -> 1.1.1 (c)
++--- androidx.lifecycle:lifecycle-runtime-ktx:{strictly 2.6.1} -> 2.6.1 (c)
++--- androidx.lifecycle:lifecycle-viewmodel-ktx:{strictly 2.6.1} -> 2.6.1 (c)
++--- androidx.lifecycle:lifecycle-process:{strictly 2.6.1} -> 2.6.1 (c)
+\--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:{strictly 1.8.10} -> 1.8.10 (c)
+
+debugAndroidTestRuntimeOnly (n)
+No dependencies
+
+debugAndroidTestRuntimeOnlyDependenciesMetadata
+No dependencies
+
+debugAnnotationProcessor - Classpath for the annotation processor for 'debug'. (n)
+No dependencies
+
+debugAnnotationProcessorClasspath - Resolved configuration for annotation-processor for variant: debug
+No dependencies
+
+debugApi - API dependencies for 'debug' sources. (n)
+No dependencies
+
+debugApiDependenciesMetadata
+No dependencies
+
+debugApiElements - API elements for debug (n)
+No dependencies
+
+debugCompilationApi - API dependencies for compilation 'debug' (target  (androidJvm)). (n)
+No dependencies
+
+debugCompilationCompileOnly - Compile only dependencies for compilation 'debug' (target  (androidJvm)). (n)
+No dependencies
+
+debugCompilationImplementation - Implementation only dependencies for compilation 'debug' (target  (androidJvm)). (n)
+No dependencies
+
+debugCompilationRuntimeOnly - Runtime only dependencies for compilation 'debug' (target  (androidJvm)). (n)
+No dependencies
+
+debugCompileClasspath - Compile classpath for compilation 'debug' (target  (androidJvm)).
++--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.10
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.10
+|    |    \--- org.jetbrains:annotations:13.0
+|    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.10
+|         \--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
++--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:{strictly 1.8.10} -> 1.8.10 (c)
++--- androidx.compose.ui:ui-tooling -> 1.4.0
+|    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.7.10 -> 1.8.10 (*)
+|    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4
+|    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4
+|    |    |    |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.6.4
+|    |    |    |         +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.6.4
+|    |    |    |         |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 (c)
+|    |    |    |         |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.6.4 (c)
+|    |    |    |         |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4 (c)
+|    |    |    |         +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.21 -> 1.8.10 (*)
+|    |    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.6.21 -> 1.8.10
+|    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.6.4 (*)
+|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.21 -> 1.8.10 (*)
+|    |    \--- androidx.compose.runtime:runtime-saveable:1.4.0 (c)
+|    +--- androidx.compose.ui:ui:1.4.0
+|    |    +--- androidx.annotation:annotation:1.5.0 (*)
+|    |    +--- androidx.compose.runtime:runtime-saveable:1.4.0
+|    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    +--- androidx.compose.runtime:runtime:1.4.0 (*)
+|    |    |    \--- androidx.compose.runtime:runtime:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-geometry:1.4.0
+|    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-test-manifest:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-tooling:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-tooling-data:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    |    |    \--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-graphics:1.4.0
+|    |    |    +--- androidx.annotation:annotation:1.2.0 -> 1.5.0 (*)
+|    |    |    +--- androidx.compose.ui:ui-unit:1.4.0
+|    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    +--- androidx.compose.ui:ui-geometry:1.4.0 (*)
+|    |    |    |    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-test-manifest:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-tooling:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-tooling-data:1.4.0 (c)
+|    |    |    |    \--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-test-manifest:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-tooling:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-tooling-data:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    |    |    \--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-text:1.4.0
+|    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (*)
+|    |    |    +--- androidx.compose.ui:ui-unit:1.4.0 (*)
+|    |    |    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-test-manifest:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-tooling:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-tooling-data:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    |    |    \--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-unit:1.4.0 (*)
+|    |    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-test-manifest:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-tooling:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-tooling-data:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    |    \--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-tooling-data:1.4.0
+|    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0 (*)
+|    |    +--- androidx.compose.ui:ui:1.4.0 (*)
+|    |    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-test-manifest:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-tooling:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    |    \--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-tooling-preview:1.4.0
+|    |    +--- androidx.annotation:annotation:1.2.0 -> 1.5.0 (*)
+|    |    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0 (*)
+|    |    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-test-manifest:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-tooling:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-tooling-data:1.4.0 (c)
+|    |    \--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-test-manifest:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-tooling-data:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    \--- androidx.compose.ui:ui-unit:1.4.0 (c)
++--- androidx.compose.ui:ui-test-manifest -> 1.4.0
+|    +--- androidx.activity:activity:1.2.1 -> 1.7.2
+|    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    +--- androidx.core:core:1.8.0 -> 1.9.0
+|    |    |    +--- androidx.annotation:annotation:1.2.0 -> 1.5.0 (*)
+|    |    |    +--- androidx.annotation:annotation-experimental:1.3.0
+|    |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.7.10 -> 1.8.10 (*)
+|    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.3.1 -> 2.6.1
+|    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    +--- androidx.arch.core:core-common:2.2.0
+|    |    |    |    |    \--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1
+|    |    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 (*)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.6.1 (c)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (c)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (c)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (c)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1 (c)
+|    |    |    |    |    \--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1 (c)
+|    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1 (c)
+|    |    |    |    \--- androidx.lifecycle:lifecycle-livedata-core:2.6.1 (c)
+|    |    |    \--- androidx.versionedparcelable:versionedparcelable:1.1.1
+|    |    |         +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |         \--- androidx.collection:collection:1.0.0 -> 1.1.0
+|    |    |              \--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (*)
+|    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1
+|    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1 (c)
+|    |    |    \--- androidx.lifecycle:lifecycle-livedata-core:2.6.1 (c)
+|    |    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1
+|    |    |    +--- androidx.annotation:annotation:1.0.0 -> 1.5.0 (*)
+|    |    |    +--- androidx.core:core-ktx:1.2.0 -> 1.9.0
+|    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    +--- androidx.core:core:1.9.0 (*)
+|    |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.7.10 -> 1.8.10 (*)
+|    |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.6.1
+|    |    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (*)
+|    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1 (c)
+|    |    |    |    \--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (*)
+|    |    |    +--- androidx.savedstate:savedstate:1.2.1
+|    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    \--- androidx.savedstate:savedstate-ktx:1.2.1 (c)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 (*)
+|    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (c)
+|    |    |    \--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1 (c)
+|    |    +--- androidx.savedstate:savedstate:1.2.1 (*)
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    +--- androidx.activity:activity-compose:1.7.2 (c)
+|    |    \--- androidx.activity:activity-ktx:1.7.2 (c)
+|    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-tooling:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-tooling-data:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    \--- androidx.compose.ui:ui-unit:1.4.0 (c)
++--- androidx.core:core-ktx:1.9.0 (*)
++--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1
+|    +--- androidx.annotation:annotation:1.0.0 -> 1.5.0 (*)
+|    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (*)
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 (*)
+|    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (c)
+|    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (c)
+|    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1 (c)
+|    +--- androidx.lifecycle:lifecycle-common:2.6.1 (c)
+|    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1 (c)
+|    \--- androidx.lifecycle:lifecycle-livedata-core:2.6.1 (c)
++--- androidx.activity:activity-compose:1.7.2
+|    +--- androidx.activity:activity-ktx:1.7.2
+|    |    +--- androidx.activity:activity:1.7.2 (*)
+|    |    +--- androidx.core:core-ktx:1.1.0 -> 1.9.0 (*)
+|    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (*)
+|    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1
+|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 (*)
+|    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (c)
+|    |    |    \--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1 (c)
+|    |    +--- androidx.savedstate:savedstate-ktx:1.2.1
+|    |    |    +--- androidx.savedstate:savedstate:1.2.1 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    \--- androidx.savedstate:savedstate:1.2.1 (c)
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    +--- androidx.activity:activity:1.7.2 (c)
+|    |    \--- androidx.activity:activity-compose:1.7.2 (c)
+|    +--- androidx.compose.runtime:runtime:1.0.1 -> 1.4.0 (*)
+|    +--- androidx.compose.runtime:runtime-saveable:1.0.1 -> 1.4.0 (*)
+|    +--- androidx.compose.ui:ui:1.0.1 -> 1.4.0 (*)
+|    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (*)
+|    +--- androidx.activity:activity:1.7.2 (c)
+|    \--- androidx.activity:activity-ktx:1.7.2 (c)
++--- androidx.compose:compose-bom:2023.03.00
+|    +--- androidx.compose.material3:material3:1.0.0 (c)
+|    +--- androidx.compose.runtime:runtime:1.4.0 (c)
+|    +--- androidx.compose.runtime:runtime-saveable:1.4.0 (c)
+|    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-test-manifest:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-tooling:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-tooling-data:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    +--- androidx.compose.foundation:foundation:1.4.0 (c)
+|    +--- androidx.compose.material:material-icons-core:1.4.0 (c)
+|    +--- androidx.compose.material:material-ripple:1.4.0 (c)
+|    +--- androidx.compose.animation:animation:1.4.0 (c)
+|    +--- androidx.compose.animation:animation-core:1.4.0 (c)
+|    \--- androidx.compose.foundation:foundation-layout:1.4.0 (c)
++--- androidx.compose.ui:ui -> 1.4.0 (*)
++--- androidx.compose.ui:ui-graphics -> 1.4.0 (*)
++--- androidx.compose.ui:ui-tooling-preview -> 1.4.0 (*)
++--- androidx.compose.material3:material3 -> 1.0.0
+|    +--- androidx.compose.foundation:foundation:1.2.0 -> 1.4.0
+|    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    +--- androidx.compose.animation:animation:1.2.1 -> 1.4.0
+|    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    +--- androidx.compose.animation:animation-core:1.4.0
+|    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4 (*)
+|    |    |    |    \--- androidx.compose.animation:animation:1.4.0 (c)
+|    |    |    +--- androidx.compose.foundation:foundation-layout:1.2.1 -> 1.4.0
+|    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    +--- androidx.compose.ui:ui:1.2.1 -> 1.4.0 (*)
+|    |    |    |    +--- androidx.compose.ui:ui-unit:1.2.1 -> 1.4.0 (*)
+|    |    |    |    \--- androidx.compose.foundation:foundation:1.4.0 (c)
+|    |    |    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0 (*)
+|    |    |    +--- androidx.compose.ui:ui:1.2.1 -> 1.4.0 (*)
+|    |    |    +--- androidx.compose.ui:ui-geometry:1.2.1 -> 1.4.0 (*)
+|    |    |    \--- androidx.compose.animation:animation-core:1.4.0 (c)
+|    |    +--- androidx.compose.runtime:runtime:1.4.0 (*)
+|    |    +--- androidx.compose.ui:ui:1.4.0 (*)
+|    |    \--- androidx.compose.foundation:foundation-layout:1.4.0 (c)
+|    +--- androidx.compose.material:material-icons-core:1.0.2 -> 1.4.0
+|    |    +--- androidx.compose.ui:ui:1.2.1 -> 1.4.0 (*)
+|    |    \--- androidx.compose.material:material-ripple:1.4.0 (c)
+|    +--- androidx.compose.material:material-ripple:1.0.0 -> 1.4.0
+|    |    +--- androidx.compose.foundation:foundation:1.2.1 -> 1.4.0 (*)
+|    |    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0 (*)
+|    |    \--- androidx.compose.material:material-icons-core:1.4.0 (c)
+|    +--- androidx.compose.runtime:runtime:1.0.1 -> 1.4.0 (*)
+|    +--- androidx.compose.ui:ui:1.3.0 -> 1.4.0 (*)
+|    +--- androidx.compose.ui:ui-graphics:1.0.1 -> 1.4.0 (*)
+|    \--- androidx.compose.ui:ui-text:1.3.0 -> 1.4.0 (*)
++--- androidx.compose.ui:ui-tooling:{strictly 1.4.0} -> 1.4.0 (c)
++--- androidx.compose.ui:ui-test-manifest:{strictly 1.4.0} -> 1.4.0 (c)
++--- androidx.core:core-ktx:{strictly 1.9.0} -> 1.9.0 (c)
++--- androidx.lifecycle:lifecycle-runtime-ktx:{strictly 2.6.1} -> 2.6.1 (c)
++--- androidx.activity:activity-compose:{strictly 1.7.2} -> 1.7.2 (c)
++--- androidx.compose:compose-bom:{strictly 2023.03.00} -> 2023.03.00 (c)
++--- androidx.compose.ui:ui:{strictly 1.4.0} -> 1.4.0 (c)
++--- androidx.compose.ui:ui-graphics:{strictly 1.4.0} -> 1.4.0 (c)
++--- androidx.compose.ui:ui-tooling-preview:{strictly 1.4.0} -> 1.4.0 (c)
++--- androidx.compose.material3:material3:{strictly 1.0.0} -> 1.0.0 (c)
++--- org.jetbrains.kotlin:kotlin-stdlib:{strictly 1.8.10} -> 1.8.10 (c)
++--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:{strictly 1.8.10} -> 1.8.10 (c)
++--- androidx.annotation:annotation:{strictly 1.5.0} -> 1.5.0 (c)
++--- androidx.compose.runtime:runtime:{strictly 1.4.0} -> 1.4.0 (c)
++--- androidx.compose.ui:ui-tooling-data:{strictly 1.4.0} -> 1.4.0 (c)
++--- androidx.activity:activity:{strictly 1.7.2} -> 1.7.2 (c)
++--- androidx.core:core:{strictly 1.9.0} -> 1.9.0 (c)
++--- androidx.lifecycle:lifecycle-runtime:{strictly 2.6.1} -> 2.6.1 (c)
++--- org.jetbrains.kotlinx:kotlinx-coroutines-android:{strictly 1.6.4} -> 1.6.4 (c)
++--- androidx.activity:activity-ktx:{strictly 1.7.2} -> 1.7.2 (c)
++--- androidx.compose.runtime:runtime-saveable:{strictly 1.4.0} -> 1.4.0 (c)
++--- androidx.lifecycle:lifecycle-viewmodel:{strictly 2.6.1} -> 2.6.1 (c)
++--- androidx.compose.ui:ui-geometry:{strictly 1.4.0} -> 1.4.0 (c)
++--- androidx.compose.ui:ui-text:{strictly 1.4.0} -> 1.4.0 (c)
++--- androidx.compose.ui:ui-unit:{strictly 1.4.0} -> 1.4.0 (c)
++--- androidx.compose.foundation:foundation:{strictly 1.4.0} -> 1.4.0 (c)
++--- androidx.compose.material:material-icons-core:{strictly 1.4.0} -> 1.4.0 (c)
++--- androidx.compose.material:material-ripple:{strictly 1.4.0} -> 1.4.0 (c)
++--- org.jetbrains.kotlin:kotlin-stdlib-common:{strictly 1.8.10} -> 1.8.10 (c)
++--- org.jetbrains:annotations:{strictly 13.0} -> 13.0 (c)
++--- androidx.lifecycle:lifecycle-viewmodel-savedstate:{strictly 2.6.1} -> 2.6.1 (c)
++--- androidx.savedstate:savedstate:{strictly 1.2.1} -> 1.2.1 (c)
++--- androidx.annotation:annotation-experimental:{strictly 1.3.0} -> 1.3.0 (c)
++--- androidx.versionedparcelable:versionedparcelable:{strictly 1.1.1} -> 1.1.1 (c)
++--- androidx.arch.core:core-common:{strictly 2.2.0} -> 2.2.0 (c)
++--- androidx.lifecycle:lifecycle-common:{strictly 2.6.1} -> 2.6.1 (c)
++--- org.jetbrains.kotlinx:kotlinx-coroutines-core:{strictly 1.6.4} -> 1.6.4 (c)
++--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:{strictly 1.6.4} -> 1.6.4 (c)
++--- androidx.lifecycle:lifecycle-viewmodel-ktx:{strictly 2.6.1} -> 2.6.1 (c)
++--- androidx.savedstate:savedstate-ktx:{strictly 1.2.1} -> 1.2.1 (c)
++--- androidx.compose.animation:animation:{strictly 1.4.0} -> 1.4.0 (c)
++--- androidx.lifecycle:lifecycle-livedata-core:{strictly 2.6.1} -> 2.6.1 (c)
++--- androidx.collection:collection:{strictly 1.1.0} -> 1.1.0 (c)
++--- org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:{strictly 1.6.4} -> 1.6.4 (c)
++--- androidx.compose.animation:animation-core:{strictly 1.4.0} -> 1.4.0 (c)
+\--- androidx.compose.foundation:foundation-layout:{strictly 1.4.0} -> 1.4.0 (c)
+
+debugCompileOnly - Compile only dependencies for 'debug' sources. (n)
+No dependencies
+
+debugCompileOnlyDependenciesMetadata
+No dependencies
+
+debugImplementation - Implementation only dependencies for 'debug' sources. (n)
++--- androidx.compose.ui:ui-tooling (n)
+\--- androidx.compose.ui:ui-test-manifest (n)
+
+debugImplementationDependenciesMetadata
++--- androidx.compose.ui:ui-tooling FAILED
+\--- androidx.compose.ui:ui-test-manifest FAILED
+
+debugIntransitiveDependenciesMetadata
+No dependencies
+
+debugReverseMetadataValues - Metadata Values dependencies for the base Split
+No dependencies
+
+debugRuntimeClasspath - Runtime classpath of compilation 'debug' (target  (androidJvm)).
++--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.10
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.10
+|    |    \--- org.jetbrains:annotations:13.0
+|    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.10
+|         \--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
++--- androidx.compose.ui:ui-tooling -> 1.4.0
+|    +--- androidx.activity:activity-compose:1.7.0 -> 1.7.2
+|    |    +--- androidx.activity:activity-ktx:1.7.2
+|    |    |    +--- androidx.activity:activity:1.7.2
+|    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0
+|    |    |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.7.10 -> 1.8.10 (*)
+|    |    |    |    +--- androidx.collection:collection:1.0.0 -> 1.1.0
+|    |    |    |    |    \--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    +--- androidx.core:core:1.8.0 -> 1.9.0
+|    |    |    |    |    +--- androidx.annotation:annotation:1.2.0 -> 1.5.0 (*)
+|    |    |    |    |    +--- androidx.annotation:annotation-experimental:1.3.0
+|    |    |    |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.7.10 -> 1.8.10 (*)
+|    |    |    |    |    +--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
+|    |    |    |    |    +--- androidx.concurrent:concurrent-futures:1.0.0 -> 1.1.0
+|    |    |    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    |    |    \--- com.google.guava:listenablefuture:1.0
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.3.1 -> 2.6.1
+|    |    |    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    |    |    +--- androidx.arch.core:core-common:2.2.0
+|    |    |    |    |    |    |    \--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    |    |    +--- androidx.arch.core:core-runtime:2.2.0
+|    |    |    |    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    |    |    |    \--- androidx.arch.core:core-common:2.2.0 (*)
+|    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1
+|    |    |    |    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4
+|    |    |    |    |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4
+|    |    |    |    |    |    |    |    |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.6.4
+|    |    |    |    |    |    |    |    |         +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.6.4
+|    |    |    |    |    |    |    |    |         |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 (c)
+|    |    |    |    |    |    |    |    |         |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.6.4 (c)
+|    |    |    |    |    |    |    |    |         |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4 (c)
+|    |    |    |    |    |    |    |    |         +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.21 -> 1.8.10 (*)
+|    |    |    |    |    |    |    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.6.21 -> 1.8.10
+|    |    |    |    |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.6.4 (*)
+|    |    |    |    |    |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.21 -> 1.8.10 (*)
+|    |    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (c)
+|    |    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (c)
+|    |    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (c)
+|    |    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1 (c)
+|    |    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1 (c)
+|    |    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-process:2.6.1 (c)
+|    |    |    |    |    |    |    \--- androidx.lifecycle:lifecycle-livedata-core:2.6.1 (c)
+|    |    |    |    |    |    +--- androidx.profileinstaller:profileinstaller:1.3.0
+|    |    |    |    |    |    |    +--- androidx.annotation:annotation:1.2.0 -> 1.5.0 (*)
+|    |    |    |    |    |    |    +--- androidx.concurrent:concurrent-futures:1.1.0 (*)
+|    |    |    |    |    |    |    +--- androidx.startup:startup-runtime:1.1.1
+|    |    |    |    |    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    |    |    |    |    \--- androidx.tracing:tracing:1.0.0
+|    |    |    |    |    |    |    |         \--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    |    |    |    \--- com.google.guava:listenablefuture:1.0
+|    |    |    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (c)
+|    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (c)
+|    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (c)
+|    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1 (c)
+|    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1 (c)
+|    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-process:2.6.1 (c)
+|    |    |    |    |    |    \--- androidx.lifecycle:lifecycle-livedata-core:2.6.1 (c)
+|    |    |    |    |    +--- androidx.versionedparcelable:versionedparcelable:1.1.1
+|    |    |    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    |    |    \--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
+|    |    |    |    |    \--- androidx.core:core-ktx:1.9.0 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (*)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1
+|    |    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (c)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (c)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (c)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1 (c)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1 (c)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-process:2.6.1 (c)
+|    |    |    |    |    \--- androidx.lifecycle:lifecycle-livedata-core:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1
+|    |    |    |    |    +--- androidx.annotation:annotation:1.0.0 -> 1.5.0 (*)
+|    |    |    |    |    +--- androidx.core:core-ktx:1.2.0 -> 1.9.0
+|    |    |    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    |    |    +--- androidx.core:core:1.9.0 (*)
+|    |    |    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.7.10 -> 1.8.10 (*)
+|    |    |    |    |    |    \--- androidx.core:core:1.9.0 (c)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.6.1
+|    |    |    |    |    |    +--- androidx.arch.core:core-common:2.1.0 -> 2.2.0 (*)
+|    |    |    |    |    |    +--- androidx.arch.core:core-runtime:2.1.0 -> 2.2.0 (*)
+|    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (*)
+|    |    |    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (c)
+|    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-process:2.6.1 (c)
+|    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (c)
+|    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (c)
+|    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (c)
+|    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1 (c)
+|    |    |    |    |    |    \--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1 (c)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (*)
+|    |    |    |    |    +--- androidx.savedstate:savedstate:1.2.1
+|    |    |    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    |    |    +--- androidx.arch.core:core-common:2.1.0 -> 2.2.0 (*)
+|    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (*)
+|    |    |    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    |    |    \--- androidx.savedstate:savedstate-ktx:1.2.1 (c)
+|    |    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 (*)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (c)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.6.1 (c)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-process:2.6.1 (c)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (c)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (c)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (c)
+|    |    |    |    |    \--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1 (c)
+|    |    |    |    +--- androidx.profileinstaller:profileinstaller:1.3.0 (*)
+|    |    |    |    +--- androidx.savedstate:savedstate:1.2.1 (*)
+|    |    |    |    +--- androidx.tracing:tracing:1.0.0 (*)
+|    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    +--- androidx.activity:activity-compose:1.7.2 (c)
+|    |    |    |    \--- androidx.activity:activity-ktx:1.7.2 (c)
+|    |    |    +--- androidx.core:core-ktx:1.1.0 -> 1.9.0 (*)
+|    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1
+|    |    |    |    +--- androidx.annotation:annotation:1.0.0 -> 1.5.0 (*)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (*)
+|    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 (*)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-process:2.6.1 (c)
+|    |    |    |    \--- androidx.lifecycle:lifecycle-livedata-core:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1
+|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (*)
+|    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 (*)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-process:2.6.1 (c)
+|    |    |    |    \--- androidx.lifecycle:lifecycle-livedata-core:2.6.1 (c)
+|    |    |    +--- androidx.savedstate:savedstate-ktx:1.2.1
+|    |    |    |    +--- androidx.savedstate:savedstate:1.2.1 (*)
+|    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    \--- androidx.savedstate:savedstate:1.2.1 (c)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    +--- androidx.activity:activity:1.7.2 (c)
+|    |    |    \--- androidx.activity:activity-compose:1.7.2 (c)
+|    |    +--- androidx.compose.runtime:runtime:1.0.1 -> 1.4.0
+|    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 (*)
+|    |    |    \--- androidx.compose.runtime:runtime-saveable:1.4.0 (c)
+|    |    +--- androidx.compose.runtime:runtime-saveable:1.0.1 -> 1.4.0
+|    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    +--- androidx.compose.runtime:runtime:1.4.0 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    \--- androidx.compose.runtime:runtime:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui:1.0.1 -> 1.4.0
+|    |    |    +--- androidx.activity:activity-ktx:1.7.0 -> 1.7.2 (*)
+|    |    |    +--- androidx.annotation:annotation:1.5.0 (*)
+|    |    |    +--- androidx.autofill:autofill:1.0.0
+|    |    |    |    \--- androidx.core:core:1.1.0 -> 1.9.0 (*)
+|    |    |    +--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
+|    |    |    +--- androidx.compose.runtime:runtime:1.4.0 (*)
+|    |    |    +--- androidx.compose.runtime:runtime-saveable:1.4.0 (*)
+|    |    |    +--- androidx.compose.ui:ui-geometry:1.4.0
+|    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0 (*)
+|    |    |    |    +--- androidx.compose.ui:ui-util:1.4.0
+|    |    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    |    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    |    |    |    |    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    |    |    |    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    |    |    |    |    +--- androidx.compose.ui:ui-test-manifest:1.4.0 (c)
+|    |    |    |    |    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    |    |    |    |    +--- androidx.compose.ui:ui-tooling:1.4.0 (c)
+|    |    |    |    |    +--- androidx.compose.ui:ui-tooling-data:1.4.0 (c)
+|    |    |    |    |    +--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    |    |    |    |    \--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-test-manifest:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-tooling:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-tooling-data:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    |    |    |    \--- androidx.compose.ui:ui-util:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-graphics:1.4.0
+|    |    |    |    +--- androidx.annotation:annotation:1.2.0 -> 1.5.0 (*)
+|    |    |    |    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0 (*)
+|    |    |    |    +--- androidx.compose.ui:ui-unit:1.4.0
+|    |    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    |    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0 (*)
+|    |    |    |    |    +--- androidx.compose.ui:ui-geometry:1.4.0 (*)
+|    |    |    |    |    +--- androidx.compose.ui:ui-util:1.4.0 (*)
+|    |    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    |    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    |    |    |    |    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    |    |    |    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    |    |    |    |    +--- androidx.compose.ui:ui-test-manifest:1.4.0 (c)
+|    |    |    |    |    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    |    |    |    |    +--- androidx.compose.ui:ui-tooling:1.4.0 (c)
+|    |    |    |    |    +--- androidx.compose.ui:ui-tooling-data:1.4.0 (c)
+|    |    |    |    |    +--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    |    |    |    |    \--- androidx.compose.ui:ui-util:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-util:1.4.0 (*)
+|    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.10
+|    |    |    |    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-test-manifest:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-tooling:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-util:1.4.0 (c)
+|    |    |    |    \--- androidx.compose.ui:ui-tooling-data:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-text:1.4.0
+|    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    +--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
+|    |    |    |    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0 (*)
+|    |    |    |    +--- androidx.compose.runtime:runtime-saveable:1.2.1 -> 1.4.0 (*)
+|    |    |    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (*)
+|    |    |    |    +--- androidx.compose.ui:ui-unit:1.4.0 (*)
+|    |    |    |    +--- androidx.compose.ui:ui-util:1.4.0 (*)
+|    |    |    |    +--- androidx.core:core:1.7.0 -> 1.9.0 (*)
+|    |    |    |    +--- androidx.emoji2:emoji2:1.2.0 -> 1.3.0
+|    |    |    |    |    +--- androidx.annotation:annotation:1.2.0 -> 1.5.0 (*)
+|    |    |    |    |    +--- androidx.collection:collection:1.1.0 (*)
+|    |    |    |    |    +--- androidx.core:core:1.3.0 -> 1.9.0 (*)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-process:2.4.1 -> 2.6.1
+|    |    |    |    |    |    +--- androidx.annotation:annotation:1.2.0 -> 1.5.0 (*)
+|    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (*)
+|    |    |    |    |    |    +--- androidx.startup:startup-runtime:1.1.1 (*)
+|    |    |    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (c)
+|    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.6.1 (c)
+|    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (c)
+|    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (c)
+|    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (c)
+|    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1 (c)
+|    |    |    |    |    |    \--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1 (c)
+|    |    |    |    |    \--- androidx.startup:startup-runtime:1.0.0 -> 1.1.1 (*)
+|    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.10
+|    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4 (*)
+|    |    |    |    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-test-manifest:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-tooling:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-tooling-data:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    |    |    |    \--- androidx.compose.ui:ui-util:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-unit:1.4.0 (*)
+|    |    |    +--- androidx.compose.ui:ui-util:1.4.0 (*)
+|    |    |    +--- androidx.core:core:1.9.0 (*)
+|    |    |    +--- androidx.customview:customview-poolingcontainer:1.0.0
+|    |    |    |    +--- androidx.core:core-ktx:1.5.0 -> 1.9.0 (*)
+|    |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.6.21 -> 1.8.10 (*)
+|    |    |    +--- androidx.emoji2:emoji2:1.2.0 -> 1.3.0 (*)
+|    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (*)
+|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (*)
+|    |    |    +--- androidx.profileinstaller:profileinstaller:1.3.0 (*)
+|    |    |    +--- androidx.savedstate:savedstate-ktx:1.2.1 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.10
+|    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 (*)
+|    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4 (*)
+|    |    |    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-test-manifest:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-tooling:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-util:1.4.0 (c)
+|    |    |    +--- androidx.compose.foundation:foundation:1.4.0 (c)
+|    |    |    \--- androidx.compose.ui:ui-tooling-data:1.4.0 (c)
+|    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (*)
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    +--- androidx.activity:activity-ktx:1.7.2 (c)
+|    |    \--- androidx.activity:activity:1.7.2 (c)
+|    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    +--- androidx.compose.animation:animation:1.4.0
+|    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    +--- androidx.compose.animation:animation-core:1.4.0
+|    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0 (*)
+|    |    |    +--- androidx.compose.ui:ui:1.2.1 -> 1.4.0 (*)
+|    |    |    +--- androidx.compose.ui:ui-unit:1.2.1 -> 1.4.0 (*)
+|    |    |    +--- androidx.compose.ui:ui-util:1.2.1 -> 1.4.0 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4 (*)
+|    |    |    \--- androidx.compose.animation:animation:1.4.0 (c)
+|    |    +--- androidx.compose.foundation:foundation-layout:1.2.1 -> 1.4.0
+|    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    +--- androidx.compose.animation:animation-core:1.2.1 -> 1.4.0 (*)
+|    |    |    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0 (*)
+|    |    |    +--- androidx.compose.ui:ui:1.2.1 -> 1.4.0 (*)
+|    |    |    +--- androidx.compose.ui:ui-unit:1.2.1 -> 1.4.0 (*)
+|    |    |    +--- androidx.compose.ui:ui-util:1.2.1 -> 1.4.0 (*)
+|    |    |    +--- androidx.core:core:1.7.0 -> 1.9.0 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.10
+|    |    |    \--- androidx.compose.foundation:foundation:1.4.0 (c)
+|    |    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0 (*)
+|    |    +--- androidx.compose.ui:ui:1.2.1 -> 1.4.0 (*)
+|    |    +--- androidx.compose.ui:ui-geometry:1.2.1 -> 1.4.0 (*)
+|    |    +--- androidx.compose.ui:ui-util:1.2.1 -> 1.4.0 (*)
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.10
+|    |    \--- androidx.compose.animation:animation-core:1.4.0 (c)
+|    +--- androidx.compose.material:material:1.0.0 -> 1.4.0
+|    |    +--- androidx.compose.animation:animation:1.2.1 -> 1.4.0 (*)
+|    |    +--- androidx.compose.animation:animation-core:1.2.1 -> 1.4.0 (*)
+|    |    +--- androidx.compose.foundation:foundation:1.4.0
+|    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    +--- androidx.compose.animation:animation:1.2.1 -> 1.4.0 (*)
+|    |    |    +--- androidx.compose.foundation:foundation-layout:1.4.0 (*)
+|    |    |    +--- androidx.compose.runtime:runtime:1.4.0 (*)
+|    |    |    +--- androidx.compose.ui:ui:1.4.0 (*)
+|    |    |    +--- androidx.compose.ui:ui-graphics:1.2.1 -> 1.4.0 (*)
+|    |    |    +--- androidx.compose.ui:ui-text:1.2.1 -> 1.4.0 (*)
+|    |    |    +--- androidx.compose.ui:ui-util:1.2.1 -> 1.4.0 (*)
+|    |    |    +--- androidx.emoji2:emoji2:1.3.0 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.10
+|    |    |    \--- androidx.compose.foundation:foundation-layout:1.4.0 (c)
+|    |    +--- androidx.compose.foundation:foundation-layout:1.2.1 -> 1.4.0 (*)
+|    |    +--- androidx.compose.material:material-icons-core:1.4.0
+|    |    |    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0 (*)
+|    |    |    +--- androidx.compose.ui:ui:1.2.1 -> 1.4.0 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    +--- androidx.compose.material:material:1.4.0 (c)
+|    |    |    \--- androidx.compose.material:material-ripple:1.4.0 (c)
+|    |    +--- androidx.compose.material:material-ripple:1.4.0
+|    |    |    +--- androidx.compose.animation:animation:1.2.1 -> 1.4.0 (*)
+|    |    |    +--- androidx.compose.foundation:foundation:1.2.1 -> 1.4.0 (*)
+|    |    |    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0 (*)
+|    |    |    +--- androidx.compose.ui:ui-util:1.2.1 -> 1.4.0 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.10
+|    |    |    +--- androidx.compose.material:material:1.4.0 (c)
+|    |    |    \--- androidx.compose.material:material-icons-core:1.4.0 (c)
+|    |    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0 (*)
+|    |    +--- androidx.compose.ui:ui:1.2.1 -> 1.4.0 (*)
+|    |    +--- androidx.compose.ui:ui-text:1.2.1 -> 1.4.0 (*)
+|    |    +--- androidx.compose.ui:ui-util:1.2.1 -> 1.4.0 (*)
+|    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (*)
+|    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (*)
+|    |    +--- androidx.savedstate:savedstate:1.2.1 (*)
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.10
+|    |    +--- androidx.compose.material:material-icons-core:1.4.0 (c)
+|    |    \--- androidx.compose.material:material-ripple:1.4.0 (c)
+|    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0 (*)
+|    +--- androidx.compose.ui:ui:1.4.0 (*)
+|    +--- androidx.compose.ui:ui-tooling-data:1.4.0
+|    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0 (*)
+|    |    +--- androidx.compose.ui:ui:1.4.0 (*)
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-test-manifest:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-tooling:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    |    \--- androidx.compose.ui:ui-util:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-tooling-preview:1.4.0
+|    |    +--- androidx.annotation:annotation:1.2.0 -> 1.5.0 (*)
+|    |    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0 (*)
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-test-manifest:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-tooling:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-tooling-data:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    |    \--- androidx.compose.ui:ui-util:1.4.0 (c)
+|    +--- androidx.lifecycle:lifecycle-common:2.6.1 (*)
+|    +--- androidx.savedstate:savedstate-ktx:1.2.1 (*)
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-test-manifest:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-tooling-data:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    \--- androidx.compose.ui:ui-util:1.4.0 (c)
++--- androidx.compose.ui:ui-test-manifest -> 1.4.0
+|    +--- androidx.activity:activity:1.2.1 -> 1.7.2 (*)
+|    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-tooling:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-util:1.4.0 (c)
+|    \--- androidx.compose.ui:ui-tooling-data:1.4.0 (c)
++--- androidx.core:core-ktx:1.9.0 (*)
++--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (*)
++--- androidx.activity:activity-compose:1.7.2 (*)
++--- androidx.compose:compose-bom:2023.03.00
+|    +--- androidx.compose.material3:material3:1.0.0 (c)
+|    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-test-manifest:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-tooling:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    +--- androidx.compose.runtime:runtime:1.4.0 (c)
+|    +--- androidx.compose.runtime:runtime-saveable:1.4.0 (c)
+|    +--- androidx.compose.animation:animation-core:1.4.0 (c)
+|    +--- androidx.compose.foundation:foundation:1.4.0 (c)
+|    +--- androidx.compose.foundation:foundation-layout:1.4.0 (c)
+|    +--- androidx.compose.material:material-icons-core:1.4.0 (c)
+|    +--- androidx.compose.material:material-ripple:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-util:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    +--- androidx.compose.animation:animation:1.4.0 (c)
+|    +--- androidx.compose.material:material:1.4.0 (c)
+|    \--- androidx.compose.ui:ui-tooling-data:1.4.0 (c)
++--- androidx.compose.ui:ui -> 1.4.0 (*)
++--- androidx.compose.ui:ui-graphics -> 1.4.0 (*)
++--- androidx.compose.ui:ui-tooling-preview -> 1.4.0 (*)
+\--- androidx.compose.material3:material3 -> 1.0.0
+     +--- androidx.compose.animation:animation-core:1.1.1 -> 1.4.0 (*)
+     +--- androidx.compose.foundation:foundation:1.2.0 -> 1.4.0 (*)
+     +--- androidx.compose.foundation:foundation-layout:1.2.0 -> 1.4.0 (*)
+     +--- androidx.compose.material:material-icons-core:1.0.2 -> 1.4.0 (*)
+     +--- androidx.compose.material:material-ripple:1.0.0 -> 1.4.0 (*)
+     +--- androidx.compose.runtime:runtime:1.0.1 -> 1.4.0 (*)
+     +--- androidx.compose.ui:ui:1.3.0 -> 1.4.0 (*)
+     +--- androidx.compose.ui:ui-graphics:1.0.1 -> 1.4.0 (*)
+     +--- androidx.compose.ui:ui-text:1.3.0 -> 1.4.0 (*)
+     +--- androidx.compose.ui:ui-util:1.0.0 -> 1.4.0 (*)
+     +--- androidx.lifecycle:lifecycle-runtime:2.3.0 -> 2.6.1 (*)
+     +--- androidx.lifecycle:lifecycle-viewmodel:2.3.0 -> 2.6.1 (*)
+     +--- androidx.savedstate:savedstate-ktx:1.2.0 -> 1.2.1 (*)
+     \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.7.10 -> 1.8.10
+
+debugRuntimeElements - Runtime elements for debug (n)
+No dependencies
+
+debugRuntimeOnly - Runtime only dependencies for 'debug' sources. (n)
+No dependencies
+
+debugRuntimeOnlyDependenciesMetadata
+No dependencies
+
+debugUnitTestAnnotationProcessorClasspath - Resolved configuration for annotation-processor for variant: debugUnitTest
+No dependencies
+
+debugUnitTestApi (n)
+No dependencies
+
+debugUnitTestApiDependenciesMetadata
+No dependencies
+
+debugUnitTestCompilationApi - API dependencies for compilation 'debugUnitTest' (target  (androidJvm)). (n)
+No dependencies
+
+debugUnitTestCompilationCompileOnly - Compile only dependencies for compilation 'debugUnitTest' (target  (androidJvm)). (n)
+No dependencies
+
+debugUnitTestCompilationImplementation - Implementation only dependencies for compilation 'debugUnitTest' (target  (androidJvm)). (n)
+No dependencies
+
+debugUnitTestCompilationRuntimeOnly - Runtime only dependencies for compilation 'debugUnitTest' (target  (androidJvm)). (n)
+No dependencies
+
+debugUnitTestCompileClasspath - Compile classpath for compilation 'debugUnitTest' (target  (androidJvm)).
++--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.10
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.10
+|    |    \--- org.jetbrains:annotations:13.0
+|    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.10
+|         \--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
++--- androidx.compose.ui:ui-tooling -> 1.4.0
+|    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.7.10 -> 1.8.10 (*)
+|    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4
+|    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4
+|    |    |    |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.6.4
+|    |    |    |         +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.6.4
+|    |    |    |         |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 (c)
+|    |    |    |         |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.6.4 (c)
+|    |    |    |         |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4 (c)
+|    |    |    |         +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.21 -> 1.8.10 (*)
+|    |    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.6.21 -> 1.8.10
+|    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.6.4 (*)
+|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.21 -> 1.8.10 (*)
+|    |    \--- androidx.compose.runtime:runtime-saveable:1.4.0 (c)
+|    +--- androidx.compose.ui:ui:1.4.0
+|    |    +--- androidx.annotation:annotation:1.5.0 (*)
+|    |    +--- androidx.compose.runtime:runtime-saveable:1.4.0
+|    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    +--- androidx.compose.runtime:runtime:1.4.0 (*)
+|    |    |    \--- androidx.compose.runtime:runtime:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-geometry:1.4.0
+|    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-test-manifest:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-tooling:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-tooling-data:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    |    |    \--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-graphics:1.4.0
+|    |    |    +--- androidx.annotation:annotation:1.2.0 -> 1.5.0 (*)
+|    |    |    +--- androidx.compose.ui:ui-unit:1.4.0
+|    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    +--- androidx.compose.ui:ui-geometry:1.4.0 (*)
+|    |    |    |    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-test-manifest:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-tooling:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-tooling-data:1.4.0 (c)
+|    |    |    |    \--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-test-manifest:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-tooling:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-tooling-data:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    |    |    \--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-text:1.4.0
+|    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (*)
+|    |    |    +--- androidx.compose.ui:ui-unit:1.4.0 (*)
+|    |    |    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-test-manifest:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-tooling:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-tooling-data:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    |    |    \--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-unit:1.4.0 (*)
+|    |    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-test-manifest:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-tooling:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-tooling-data:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    |    \--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-tooling-data:1.4.0
+|    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0 (*)
+|    |    +--- androidx.compose.ui:ui:1.4.0 (*)
+|    |    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-test-manifest:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-tooling:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    |    \--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-tooling-preview:1.4.0
+|    |    +--- androidx.annotation:annotation:1.2.0 -> 1.5.0 (*)
+|    |    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0 (*)
+|    |    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-test-manifest:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-tooling:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-tooling-data:1.4.0 (c)
+|    |    \--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-test-manifest:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-tooling-data:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    \--- androidx.compose.ui:ui-unit:1.4.0 (c)
++--- androidx.compose.ui:ui-test-manifest -> 1.4.0
+|    +--- androidx.activity:activity:1.2.1 -> 1.7.2
+|    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    +--- androidx.core:core:1.8.0 -> 1.9.0
+|    |    |    +--- androidx.annotation:annotation:1.2.0 -> 1.5.0 (*)
+|    |    |    +--- androidx.annotation:annotation-experimental:1.3.0
+|    |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.7.10 -> 1.8.10 (*)
+|    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.3.1 -> 2.6.1
+|    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    +--- androidx.arch.core:core-common:2.2.0
+|    |    |    |    |    \--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1
+|    |    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 (*)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.6.1 (c)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (c)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (c)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (c)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1 (c)
+|    |    |    |    |    \--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1 (c)
+|    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1 (c)
+|    |    |    |    \--- androidx.lifecycle:lifecycle-livedata-core:2.6.1 (c)
+|    |    |    \--- androidx.versionedparcelable:versionedparcelable:1.1.1
+|    |    |         +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |         \--- androidx.collection:collection:1.0.0 -> 1.1.0
+|    |    |              \--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (*)
+|    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1
+|    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1 (c)
+|    |    |    \--- androidx.lifecycle:lifecycle-livedata-core:2.6.1 (c)
+|    |    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1
+|    |    |    +--- androidx.annotation:annotation:1.0.0 -> 1.5.0 (*)
+|    |    |    +--- androidx.core:core-ktx:1.2.0 -> 1.9.0
+|    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    +--- androidx.core:core:1.9.0 (*)
+|    |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.7.10 -> 1.8.10 (*)
+|    |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.6.1
+|    |    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (*)
+|    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1 (c)
+|    |    |    |    \--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (*)
+|    |    |    +--- androidx.savedstate:savedstate:1.2.1
+|    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    \--- androidx.savedstate:savedstate-ktx:1.2.1 (c)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 (*)
+|    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (c)
+|    |    |    \--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1 (c)
+|    |    +--- androidx.savedstate:savedstate:1.2.1 (*)
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    +--- androidx.activity:activity-compose:1.7.2 (c)
+|    |    \--- androidx.activity:activity-ktx:1.7.2 (c)
+|    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-tooling:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-tooling-data:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    \--- androidx.compose.ui:ui-unit:1.4.0 (c)
++--- project :app (*)
++--- androidx.core:core-ktx:1.9.0 (*)
++--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1
+|    +--- androidx.annotation:annotation:1.0.0 -> 1.5.0 (*)
+|    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (*)
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 (*)
+|    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (c)
+|    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (c)
+|    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1 (c)
+|    +--- androidx.lifecycle:lifecycle-common:2.6.1 (c)
+|    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1 (c)
+|    \--- androidx.lifecycle:lifecycle-livedata-core:2.6.1 (c)
++--- androidx.activity:activity-compose:1.7.2
+|    +--- androidx.activity:activity-ktx:1.7.2
+|    |    +--- androidx.activity:activity:1.7.2 (*)
+|    |    +--- androidx.core:core-ktx:1.1.0 -> 1.9.0 (*)
+|    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (*)
+|    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1
+|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 (*)
+|    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (c)
+|    |    |    \--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1 (c)
+|    |    +--- androidx.savedstate:savedstate-ktx:1.2.1
+|    |    |    +--- androidx.savedstate:savedstate:1.2.1 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    \--- androidx.savedstate:savedstate:1.2.1 (c)
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    +--- androidx.activity:activity:1.7.2 (c)
+|    |    \--- androidx.activity:activity-compose:1.7.2 (c)
+|    +--- androidx.compose.runtime:runtime:1.0.1 -> 1.4.0 (*)
+|    +--- androidx.compose.runtime:runtime-saveable:1.0.1 -> 1.4.0 (*)
+|    +--- androidx.compose.ui:ui:1.0.1 -> 1.4.0 (*)
+|    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (*)
+|    +--- androidx.activity:activity:1.7.2 (c)
+|    \--- androidx.activity:activity-ktx:1.7.2 (c)
++--- androidx.compose:compose-bom:2023.03.00
+|    +--- androidx.compose.material3:material3:1.0.0 (c)
+|    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-test-manifest:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-tooling:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    +--- androidx.compose.runtime:runtime:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-tooling-data:1.4.0 (c)
+|    +--- androidx.compose.runtime:runtime-saveable:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    +--- androidx.compose.foundation:foundation:1.4.0 (c)
+|    +--- androidx.compose.material:material-icons-core:1.4.0 (c)
+|    +--- androidx.compose.material:material-ripple:1.4.0 (c)
+|    +--- androidx.compose.animation:animation:1.4.0 (c)
+|    +--- androidx.compose.animation:animation-core:1.4.0 (c)
+|    \--- androidx.compose.foundation:foundation-layout:1.4.0 (c)
++--- androidx.compose.ui:ui -> 1.4.0 (*)
++--- androidx.compose.ui:ui-graphics -> 1.4.0 (*)
++--- androidx.compose.ui:ui-tooling-preview -> 1.4.0 (*)
++--- androidx.compose.material3:material3 -> 1.0.0
+|    +--- androidx.compose.foundation:foundation:1.2.0 -> 1.4.0
+|    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    +--- androidx.compose.animation:animation:1.2.1 -> 1.4.0
+|    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    +--- androidx.compose.animation:animation-core:1.4.0
+|    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4 (*)
+|    |    |    |    \--- androidx.compose.animation:animation:1.4.0 (c)
+|    |    |    +--- androidx.compose.foundation:foundation-layout:1.2.1 -> 1.4.0
+|    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    +--- androidx.compose.ui:ui:1.2.1 -> 1.4.0 (*)
+|    |    |    |    +--- androidx.compose.ui:ui-unit:1.2.1 -> 1.4.0 (*)
+|    |    |    |    \--- androidx.compose.foundation:foundation:1.4.0 (c)
+|    |    |    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0 (*)
+|    |    |    +--- androidx.compose.ui:ui:1.2.1 -> 1.4.0 (*)
+|    |    |    +--- androidx.compose.ui:ui-geometry:1.2.1 -> 1.4.0 (*)
+|    |    |    \--- androidx.compose.animation:animation-core:1.4.0 (c)
+|    |    +--- androidx.compose.runtime:runtime:1.4.0 (*)
+|    |    +--- androidx.compose.ui:ui:1.4.0 (*)
+|    |    \--- androidx.compose.foundation:foundation-layout:1.4.0 (c)
+|    +--- androidx.compose.material:material-icons-core:1.0.2 -> 1.4.0
+|    |    +--- androidx.compose.ui:ui:1.2.1 -> 1.4.0 (*)
+|    |    \--- androidx.compose.material:material-ripple:1.4.0 (c)
+|    +--- androidx.compose.material:material-ripple:1.0.0 -> 1.4.0
+|    |    +--- androidx.compose.foundation:foundation:1.2.1 -> 1.4.0 (*)
+|    |    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0 (*)
+|    |    \--- androidx.compose.material:material-icons-core:1.4.0 (c)
+|    +--- androidx.compose.runtime:runtime:1.0.1 -> 1.4.0 (*)
+|    +--- androidx.compose.ui:ui:1.3.0 -> 1.4.0 (*)
+|    +--- androidx.compose.ui:ui-graphics:1.0.1 -> 1.4.0 (*)
+|    \--- androidx.compose.ui:ui-text:1.3.0 -> 1.4.0 (*)
++--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:{strictly 1.8.10} -> 1.8.10 (c)
++--- androidx.compose.ui:ui-tooling:{strictly 1.4.0} -> 1.4.0 (c)
++--- androidx.activity:activity-compose:{strictly 1.7.2} -> 1.7.2 (c)
++--- androidx.lifecycle:lifecycle-runtime-ktx:{strictly 2.6.1} -> 2.6.1 (c)
++--- androidx.core:core-ktx:{strictly 1.9.0} -> 1.9.0 (c)
++--- androidx.compose.ui:ui:{strictly 1.4.0} -> 1.4.0 (c)
++--- androidx.compose.ui:ui-graphics:{strictly 1.4.0} -> 1.4.0 (c)
++--- androidx.compose.ui:ui-test-manifest:{strictly 1.4.0} -> 1.4.0 (c)
++--- androidx.compose.ui:ui-tooling-preview:{strictly 1.4.0} -> 1.4.0 (c)
++--- androidx.compose:compose-bom:{strictly 2023.03.00} -> 2023.03.00 (c)
++--- androidx.compose.material3:material3:{strictly 1.0.0} -> 1.0.0 (c)
++--- junit:junit:4.13.2
+|    \--- org.hamcrest:hamcrest-core:1.3
++--- junit:junit:{strictly 4.13.2} -> 4.13.2 (c)
++--- org.jetbrains.kotlin:kotlin-stdlib:{strictly 1.8.10} -> 1.8.10 (c)
++--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:{strictly 1.8.10} -> 1.8.10 (c)
++--- androidx.annotation:annotation:{strictly 1.5.0} -> 1.5.0 (c)
++--- androidx.compose.runtime:runtime:{strictly 1.4.0} -> 1.4.0 (c)
++--- androidx.compose.ui:ui-tooling-data:{strictly 1.4.0} -> 1.4.0 (c)
++--- androidx.activity:activity:{strictly 1.7.2} -> 1.7.2 (c)
++--- androidx.core:core:{strictly 1.9.0} -> 1.9.0 (c)
++--- androidx.lifecycle:lifecycle-runtime:{strictly 2.6.1} -> 2.6.1 (c)
++--- org.jetbrains.kotlinx:kotlinx-coroutines-android:{strictly 1.6.4} -> 1.6.4 (c)
++--- androidx.activity:activity-ktx:{strictly 1.7.2} -> 1.7.2 (c)
++--- androidx.compose.runtime:runtime-saveable:{strictly 1.4.0} -> 1.4.0 (c)
++--- androidx.lifecycle:lifecycle-viewmodel:{strictly 2.6.1} -> 2.6.1 (c)
++--- androidx.compose.ui:ui-geometry:{strictly 1.4.0} -> 1.4.0 (c)
++--- androidx.compose.ui:ui-text:{strictly 1.4.0} -> 1.4.0 (c)
++--- androidx.compose.ui:ui-unit:{strictly 1.4.0} -> 1.4.0 (c)
++--- androidx.compose.foundation:foundation:{strictly 1.4.0} -> 1.4.0 (c)
++--- androidx.compose.material:material-icons-core:{strictly 1.4.0} -> 1.4.0 (c)
++--- androidx.compose.material:material-ripple:{strictly 1.4.0} -> 1.4.0 (c)
++--- org.hamcrest:hamcrest-core:{strictly 1.3} -> 1.3 (c)
++--- org.jetbrains.kotlin:kotlin-stdlib-common:{strictly 1.8.10} -> 1.8.10 (c)
++--- org.jetbrains:annotations:{strictly 13.0} -> 13.0 (c)
++--- androidx.lifecycle:lifecycle-viewmodel-savedstate:{strictly 2.6.1} -> 2.6.1 (c)
++--- androidx.savedstate:savedstate:{strictly 1.2.1} -> 1.2.1 (c)
++--- androidx.annotation:annotation-experimental:{strictly 1.3.0} -> 1.3.0 (c)
++--- androidx.versionedparcelable:versionedparcelable:{strictly 1.1.1} -> 1.1.1 (c)
++--- androidx.arch.core:core-common:{strictly 2.2.0} -> 2.2.0 (c)
++--- androidx.lifecycle:lifecycle-common:{strictly 2.6.1} -> 2.6.1 (c)
++--- org.jetbrains.kotlinx:kotlinx-coroutines-core:{strictly 1.6.4} -> 1.6.4 (c)
++--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:{strictly 1.6.4} -> 1.6.4 (c)
++--- androidx.lifecycle:lifecycle-viewmodel-ktx:{strictly 2.6.1} -> 2.6.1 (c)
++--- androidx.savedstate:savedstate-ktx:{strictly 1.2.1} -> 1.2.1 (c)
++--- androidx.compose.animation:animation:{strictly 1.4.0} -> 1.4.0 (c)
++--- androidx.lifecycle:lifecycle-livedata-core:{strictly 2.6.1} -> 2.6.1 (c)
++--- androidx.collection:collection:{strictly 1.1.0} -> 1.1.0 (c)
++--- org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:{strictly 1.6.4} -> 1.6.4 (c)
++--- androidx.compose.animation:animation-core:{strictly 1.4.0} -> 1.4.0 (c)
+\--- androidx.compose.foundation:foundation-layout:{strictly 1.4.0} -> 1.4.0 (c)
+
+debugUnitTestCompileOnly (n)
+No dependencies
+
+debugUnitTestCompileOnlyDependenciesMetadata
+No dependencies
+
+debugUnitTestImplementation (n)
+No dependencies
+
+debugUnitTestImplementationDependenciesMetadata
+No dependencies
+
+debugUnitTestIntransitiveDependenciesMetadata
+No dependencies
+
+debugUnitTestRuntimeClasspath - Runtime classpath of compilation 'debugUnitTest' (target  (androidJvm)).
++--- project :app (*)
++--- junit:junit:4.13.2
+|    \--- org.hamcrest:hamcrest-core:1.3
++--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.10
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.10
+|    |    \--- org.jetbrains:annotations:13.0
+|    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.10
+|         \--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
++--- androidx.compose.ui:ui-tooling -> 1.4.0
+|    +--- androidx.activity:activity-compose:1.7.0 -> 1.7.2
+|    |    +--- androidx.activity:activity-ktx:1.7.2
+|    |    |    +--- androidx.activity:activity:1.7.2
+|    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0
+|    |    |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.7.10 -> 1.8.10 (*)
+|    |    |    |    +--- androidx.collection:collection:1.0.0 -> 1.1.0
+|    |    |    |    |    \--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    +--- androidx.core:core:1.8.0 -> 1.9.0
+|    |    |    |    |    +--- androidx.annotation:annotation:1.2.0 -> 1.5.0 (*)
+|    |    |    |    |    +--- androidx.annotation:annotation-experimental:1.3.0
+|    |    |    |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.7.10 -> 1.8.10 (*)
+|    |    |    |    |    +--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
+|    |    |    |    |    +--- androidx.concurrent:concurrent-futures:1.0.0 -> 1.1.0
+|    |    |    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    |    |    \--- com.google.guava:listenablefuture:1.0
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.3.1 -> 2.6.1
+|    |    |    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    |    |    +--- androidx.arch.core:core-common:2.2.0
+|    |    |    |    |    |    |    \--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    |    |    +--- androidx.arch.core:core-runtime:2.2.0
+|    |    |    |    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    |    |    |    \--- androidx.arch.core:core-common:2.2.0 (*)
+|    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1
+|    |    |    |    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4
+|    |    |    |    |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4
+|    |    |    |    |    |    |    |    |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.6.4
+|    |    |    |    |    |    |    |    |         +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.6.4
+|    |    |    |    |    |    |    |    |         |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 (c)
+|    |    |    |    |    |    |    |    |         |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.6.4 (c)
+|    |    |    |    |    |    |    |    |         |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4 (c)
+|    |    |    |    |    |    |    |    |         +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.21 -> 1.8.10 (*)
+|    |    |    |    |    |    |    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.6.21 -> 1.8.10
+|    |    |    |    |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.6.4 (*)
+|    |    |    |    |    |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.21 -> 1.8.10 (*)
+|    |    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (c)
+|    |    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (c)
+|    |    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (c)
+|    |    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1 (c)
+|    |    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1 (c)
+|    |    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-process:2.6.1 (c)
+|    |    |    |    |    |    |    \--- androidx.lifecycle:lifecycle-livedata-core:2.6.1 (c)
+|    |    |    |    |    |    +--- androidx.profileinstaller:profileinstaller:1.3.0
+|    |    |    |    |    |    |    +--- androidx.annotation:annotation:1.2.0 -> 1.5.0 (*)
+|    |    |    |    |    |    |    +--- androidx.concurrent:concurrent-futures:1.1.0 (*)
+|    |    |    |    |    |    |    +--- androidx.startup:startup-runtime:1.1.1
+|    |    |    |    |    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    |    |    |    |    \--- androidx.tracing:tracing:1.0.0
+|    |    |    |    |    |    |    |         \--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    |    |    |    \--- com.google.guava:listenablefuture:1.0
+|    |    |    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (c)
+|    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (c)
+|    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (c)
+|    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1 (c)
+|    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1 (c)
+|    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-process:2.6.1 (c)
+|    |    |    |    |    |    \--- androidx.lifecycle:lifecycle-livedata-core:2.6.1 (c)
+|    |    |    |    |    +--- androidx.versionedparcelable:versionedparcelable:1.1.1
+|    |    |    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    |    |    \--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
+|    |    |    |    |    \--- androidx.core:core-ktx:1.9.0 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (*)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1
+|    |    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (c)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (c)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (c)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1 (c)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1 (c)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-process:2.6.1 (c)
+|    |    |    |    |    \--- androidx.lifecycle:lifecycle-livedata-core:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1
+|    |    |    |    |    +--- androidx.annotation:annotation:1.0.0 -> 1.5.0 (*)
+|    |    |    |    |    +--- androidx.core:core-ktx:1.2.0 -> 1.9.0
+|    |    |    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    |    |    +--- androidx.core:core:1.9.0 (*)
+|    |    |    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.7.10 -> 1.8.10 (*)
+|    |    |    |    |    |    \--- androidx.core:core:1.9.0 (c)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.6.1
+|    |    |    |    |    |    +--- androidx.arch.core:core-common:2.1.0 -> 2.2.0 (*)
+|    |    |    |    |    |    +--- androidx.arch.core:core-runtime:2.1.0 -> 2.2.0 (*)
+|    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (*)
+|    |    |    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (c)
+|    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-process:2.6.1 (c)
+|    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (c)
+|    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (c)
+|    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (c)
+|    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1 (c)
+|    |    |    |    |    |    \--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1 (c)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (*)
+|    |    |    |    |    +--- androidx.savedstate:savedstate:1.2.1
+|    |    |    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    |    |    +--- androidx.arch.core:core-common:2.1.0 -> 2.2.0 (*)
+|    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (*)
+|    |    |    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    |    |    \--- androidx.savedstate:savedstate-ktx:1.2.1 (c)
+|    |    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 (*)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (c)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.6.1 (c)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-process:2.6.1 (c)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (c)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (c)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (c)
+|    |    |    |    |    \--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1 (c)
+|    |    |    |    +--- androidx.profileinstaller:profileinstaller:1.3.0 (*)
+|    |    |    |    +--- androidx.savedstate:savedstate:1.2.1 (*)
+|    |    |    |    +--- androidx.tracing:tracing:1.0.0 (*)
+|    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    +--- androidx.activity:activity-compose:1.7.2 (c)
+|    |    |    |    \--- androidx.activity:activity-ktx:1.7.2 (c)
+|    |    |    +--- androidx.core:core-ktx:1.1.0 -> 1.9.0 (*)
+|    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1
+|    |    |    |    +--- androidx.annotation:annotation:1.0.0 -> 1.5.0 (*)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (*)
+|    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 (*)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-process:2.6.1 (c)
+|    |    |    |    \--- androidx.lifecycle:lifecycle-livedata-core:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1
+|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (*)
+|    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 (*)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-process:2.6.1 (c)
+|    |    |    |    \--- androidx.lifecycle:lifecycle-livedata-core:2.6.1 (c)
+|    |    |    +--- androidx.savedstate:savedstate-ktx:1.2.1
+|    |    |    |    +--- androidx.savedstate:savedstate:1.2.1 (*)
+|    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    \--- androidx.savedstate:savedstate:1.2.1 (c)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    +--- androidx.activity:activity:1.7.2 (c)
+|    |    |    \--- androidx.activity:activity-compose:1.7.2 (c)
+|    |    +--- androidx.compose.runtime:runtime:1.0.1 -> 1.4.0
+|    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 (*)
+|    |    |    \--- androidx.compose.runtime:runtime-saveable:1.4.0 (c)
+|    |    +--- androidx.compose.runtime:runtime-saveable:1.0.1 -> 1.4.0
+|    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    +--- androidx.compose.runtime:runtime:1.4.0 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    \--- androidx.compose.runtime:runtime:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui:1.0.1 -> 1.4.0
+|    |    |    +--- androidx.activity:activity-ktx:1.7.0 -> 1.7.2 (*)
+|    |    |    +--- androidx.annotation:annotation:1.5.0 (*)
+|    |    |    +--- androidx.autofill:autofill:1.0.0
+|    |    |    |    \--- androidx.core:core:1.1.0 -> 1.9.0 (*)
+|    |    |    +--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
+|    |    |    +--- androidx.compose.runtime:runtime:1.4.0 (*)
+|    |    |    +--- androidx.compose.runtime:runtime-saveable:1.4.0 (*)
+|    |    |    +--- androidx.compose.ui:ui-geometry:1.4.0
+|    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0 (*)
+|    |    |    |    +--- androidx.compose.ui:ui-util:1.4.0
+|    |    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    |    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    |    |    |    |    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    |    |    |    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    |    |    |    |    +--- androidx.compose.ui:ui-test-manifest:1.4.0 (c)
+|    |    |    |    |    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    |    |    |    |    +--- androidx.compose.ui:ui-tooling:1.4.0 (c)
+|    |    |    |    |    +--- androidx.compose.ui:ui-tooling-data:1.4.0 (c)
+|    |    |    |    |    +--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    |    |    |    |    \--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-test-manifest:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-tooling:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-tooling-data:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    |    |    |    \--- androidx.compose.ui:ui-util:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-graphics:1.4.0
+|    |    |    |    +--- androidx.annotation:annotation:1.2.0 -> 1.5.0 (*)
+|    |    |    |    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0 (*)
+|    |    |    |    +--- androidx.compose.ui:ui-unit:1.4.0
+|    |    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    |    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0 (*)
+|    |    |    |    |    +--- androidx.compose.ui:ui-geometry:1.4.0 (*)
+|    |    |    |    |    +--- androidx.compose.ui:ui-util:1.4.0 (*)
+|    |    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    |    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    |    |    |    |    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    |    |    |    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    |    |    |    |    +--- androidx.compose.ui:ui-test-manifest:1.4.0 (c)
+|    |    |    |    |    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    |    |    |    |    +--- androidx.compose.ui:ui-tooling:1.4.0 (c)
+|    |    |    |    |    +--- androidx.compose.ui:ui-tooling-data:1.4.0 (c)
+|    |    |    |    |    +--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    |    |    |    |    \--- androidx.compose.ui:ui-util:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-util:1.4.0 (*)
+|    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.10
+|    |    |    |    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-test-manifest:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-tooling:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-util:1.4.0 (c)
+|    |    |    |    \--- androidx.compose.ui:ui-tooling-data:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-text:1.4.0
+|    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    +--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
+|    |    |    |    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0 (*)
+|    |    |    |    +--- androidx.compose.runtime:runtime-saveable:1.2.1 -> 1.4.0 (*)
+|    |    |    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (*)
+|    |    |    |    +--- androidx.compose.ui:ui-unit:1.4.0 (*)
+|    |    |    |    +--- androidx.compose.ui:ui-util:1.4.0 (*)
+|    |    |    |    +--- androidx.core:core:1.7.0 -> 1.9.0 (*)
+|    |    |    |    +--- androidx.emoji2:emoji2:1.2.0 -> 1.3.0
+|    |    |    |    |    +--- androidx.annotation:annotation:1.2.0 -> 1.5.0 (*)
+|    |    |    |    |    +--- androidx.collection:collection:1.1.0 (*)
+|    |    |    |    |    +--- androidx.core:core:1.3.0 -> 1.9.0 (*)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-process:2.4.1 -> 2.6.1
+|    |    |    |    |    |    +--- androidx.annotation:annotation:1.2.0 -> 1.5.0 (*)
+|    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (*)
+|    |    |    |    |    |    +--- androidx.startup:startup-runtime:1.1.1 (*)
+|    |    |    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (c)
+|    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.6.1 (c)
+|    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (c)
+|    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (c)
+|    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (c)
+|    |    |    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1 (c)
+|    |    |    |    |    |    \--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1 (c)
+|    |    |    |    |    \--- androidx.startup:startup-runtime:1.0.0 -> 1.1.1 (*)
+|    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.10
+|    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4 (*)
+|    |    |    |    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-test-manifest:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-tooling:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-tooling-data:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    |    |    |    \--- androidx.compose.ui:ui-util:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-unit:1.4.0 (*)
+|    |    |    +--- androidx.compose.ui:ui-util:1.4.0 (*)
+|    |    |    +--- androidx.core:core:1.9.0 (*)
+|    |    |    +--- androidx.customview:customview-poolingcontainer:1.0.0
+|    |    |    |    +--- androidx.core:core-ktx:1.5.0 -> 1.9.0 (*)
+|    |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.6.21 -> 1.8.10 (*)
+|    |    |    +--- androidx.emoji2:emoji2:1.2.0 -> 1.3.0 (*)
+|    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (*)
+|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (*)
+|    |    |    +--- androidx.profileinstaller:profileinstaller:1.3.0 (*)
+|    |    |    +--- androidx.savedstate:savedstate-ktx:1.2.1 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.10
+|    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 (*)
+|    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4 (*)
+|    |    |    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-test-manifest:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-tooling:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-util:1.4.0 (c)
+|    |    |    +--- androidx.compose.foundation:foundation:1.4.0 (c)
+|    |    |    \--- androidx.compose.ui:ui-tooling-data:1.4.0 (c)
+|    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (*)
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    +--- androidx.activity:activity-ktx:1.7.2 (c)
+|    |    \--- androidx.activity:activity:1.7.2 (c)
+|    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    +--- androidx.compose.animation:animation:1.4.0
+|    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    +--- androidx.compose.animation:animation-core:1.4.0
+|    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0 (*)
+|    |    |    +--- androidx.compose.ui:ui:1.2.1 -> 1.4.0 (*)
+|    |    |    +--- androidx.compose.ui:ui-unit:1.2.1 -> 1.4.0 (*)
+|    |    |    +--- androidx.compose.ui:ui-util:1.2.1 -> 1.4.0 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4 (*)
+|    |    |    \--- androidx.compose.animation:animation:1.4.0 (c)
+|    |    +--- androidx.compose.foundation:foundation-layout:1.2.1 -> 1.4.0
+|    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    +--- androidx.compose.animation:animation-core:1.2.1 -> 1.4.0 (*)
+|    |    |    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0 (*)
+|    |    |    +--- androidx.compose.ui:ui:1.2.1 -> 1.4.0 (*)
+|    |    |    +--- androidx.compose.ui:ui-unit:1.2.1 -> 1.4.0 (*)
+|    |    |    +--- androidx.compose.ui:ui-util:1.2.1 -> 1.4.0 (*)
+|    |    |    +--- androidx.core:core:1.7.0 -> 1.9.0 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.10
+|    |    |    \--- androidx.compose.foundation:foundation:1.4.0 (c)
+|    |    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0 (*)
+|    |    +--- androidx.compose.ui:ui:1.2.1 -> 1.4.0 (*)
+|    |    +--- androidx.compose.ui:ui-geometry:1.2.1 -> 1.4.0 (*)
+|    |    +--- androidx.compose.ui:ui-util:1.2.1 -> 1.4.0 (*)
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.10
+|    |    \--- androidx.compose.animation:animation-core:1.4.0 (c)
+|    +--- androidx.compose.material:material:1.0.0 -> 1.4.0
+|    |    +--- androidx.compose.animation:animation:1.2.1 -> 1.4.0 (*)
+|    |    +--- androidx.compose.animation:animation-core:1.2.1 -> 1.4.0 (*)
+|    |    +--- androidx.compose.foundation:foundation:1.4.0
+|    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    +--- androidx.compose.animation:animation:1.2.1 -> 1.4.0 (*)
+|    |    |    +--- androidx.compose.foundation:foundation-layout:1.4.0 (*)
+|    |    |    +--- androidx.compose.runtime:runtime:1.4.0 (*)
+|    |    |    +--- androidx.compose.ui:ui:1.4.0 (*)
+|    |    |    +--- androidx.compose.ui:ui-graphics:1.2.1 -> 1.4.0 (*)
+|    |    |    +--- androidx.compose.ui:ui-text:1.2.1 -> 1.4.0 (*)
+|    |    |    +--- androidx.compose.ui:ui-util:1.2.1 -> 1.4.0 (*)
+|    |    |    +--- androidx.emoji2:emoji2:1.3.0 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.10
+|    |    |    \--- androidx.compose.foundation:foundation-layout:1.4.0 (c)
+|    |    +--- androidx.compose.foundation:foundation-layout:1.2.1 -> 1.4.0 (*)
+|    |    +--- androidx.compose.material:material-icons-core:1.4.0
+|    |    |    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0 (*)
+|    |    |    +--- androidx.compose.ui:ui:1.2.1 -> 1.4.0 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    +--- androidx.compose.material:material:1.4.0 (c)
+|    |    |    \--- androidx.compose.material:material-ripple:1.4.0 (c)
+|    |    +--- androidx.compose.material:material-ripple:1.4.0
+|    |    |    +--- androidx.compose.animation:animation:1.2.1 -> 1.4.0 (*)
+|    |    |    +--- androidx.compose.foundation:foundation:1.2.1 -> 1.4.0 (*)
+|    |    |    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0 (*)
+|    |    |    +--- androidx.compose.ui:ui-util:1.2.1 -> 1.4.0 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.10
+|    |    |    +--- androidx.compose.material:material:1.4.0 (c)
+|    |    |    \--- androidx.compose.material:material-icons-core:1.4.0 (c)
+|    |    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0 (*)
+|    |    +--- androidx.compose.ui:ui:1.2.1 -> 1.4.0 (*)
+|    |    +--- androidx.compose.ui:ui-text:1.2.1 -> 1.4.0 (*)
+|    |    +--- androidx.compose.ui:ui-util:1.2.1 -> 1.4.0 (*)
+|    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (*)
+|    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (*)
+|    |    +--- androidx.savedstate:savedstate:1.2.1 (*)
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.10
+|    |    +--- androidx.compose.material:material-icons-core:1.4.0 (c)
+|    |    \--- androidx.compose.material:material-ripple:1.4.0 (c)
+|    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0 (*)
+|    +--- androidx.compose.ui:ui:1.4.0 (*)
+|    +--- androidx.compose.ui:ui-tooling-data:1.4.0
+|    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0 (*)
+|    |    +--- androidx.compose.ui:ui:1.4.0 (*)
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-test-manifest:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-tooling:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    |    \--- androidx.compose.ui:ui-util:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-tooling-preview:1.4.0
+|    |    +--- androidx.annotation:annotation:1.2.0 -> 1.5.0 (*)
+|    |    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0 (*)
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-test-manifest:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-tooling:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-tooling-data:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    |    \--- androidx.compose.ui:ui-util:1.4.0 (c)
+|    +--- androidx.lifecycle:lifecycle-common:2.6.1 (*)
+|    +--- androidx.savedstate:savedstate-ktx:1.2.1 (*)
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-test-manifest:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-tooling-data:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    \--- androidx.compose.ui:ui-util:1.4.0 (c)
++--- androidx.compose.ui:ui-test-manifest -> 1.4.0
+|    +--- androidx.activity:activity:1.2.1 -> 1.7.2 (*)
+|    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-tooling:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-util:1.4.0 (c)
+|    \--- androidx.compose.ui:ui-tooling-data:1.4.0 (c)
++--- androidx.core:core-ktx:1.9.0 (*)
++--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (*)
++--- androidx.activity:activity-compose:1.7.2 (*)
++--- androidx.compose:compose-bom:2023.03.00
+|    +--- androidx.compose.material3:material3:1.0.0 (c)
+|    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-test-manifest:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-tooling:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    +--- androidx.compose.runtime:runtime:1.4.0 (c)
+|    +--- androidx.compose.runtime:runtime-saveable:1.4.0 (c)
+|    +--- androidx.compose.animation:animation-core:1.4.0 (c)
+|    +--- androidx.compose.foundation:foundation:1.4.0 (c)
+|    +--- androidx.compose.foundation:foundation-layout:1.4.0 (c)
+|    +--- androidx.compose.material:material-icons-core:1.4.0 (c)
+|    +--- androidx.compose.material:material-ripple:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-util:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    +--- androidx.compose.animation:animation:1.4.0 (c)
+|    +--- androidx.compose.material:material:1.4.0 (c)
+|    \--- androidx.compose.ui:ui-tooling-data:1.4.0 (c)
++--- androidx.compose.ui:ui -> 1.4.0 (*)
++--- androidx.compose.ui:ui-graphics -> 1.4.0 (*)
++--- androidx.compose.ui:ui-tooling-preview -> 1.4.0 (*)
+\--- androidx.compose.material3:material3 -> 1.0.0
+     +--- androidx.compose.animation:animation-core:1.1.1 -> 1.4.0 (*)
+     +--- androidx.compose.foundation:foundation:1.2.0 -> 1.4.0 (*)
+     +--- androidx.compose.foundation:foundation-layout:1.2.0 -> 1.4.0 (*)
+     +--- androidx.compose.material:material-icons-core:1.0.2 -> 1.4.0 (*)
+     +--- androidx.compose.material:material-ripple:1.0.0 -> 1.4.0 (*)
+     +--- androidx.compose.runtime:runtime:1.0.1 -> 1.4.0 (*)
+     +--- androidx.compose.ui:ui:1.3.0 -> 1.4.0 (*)
+     +--- androidx.compose.ui:ui-graphics:1.0.1 -> 1.4.0 (*)
+     +--- androidx.compose.ui:ui-text:1.3.0 -> 1.4.0 (*)
+     +--- androidx.compose.ui:ui-util:1.0.0 -> 1.4.0 (*)
+     +--- androidx.lifecycle:lifecycle-runtime:2.3.0 -> 2.6.1 (*)
+     +--- androidx.lifecycle:lifecycle-viewmodel:2.3.0 -> 2.6.1 (*)
+     +--- androidx.savedstate:savedstate-ktx:1.2.0 -> 1.2.1 (*)
+     \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.7.10 -> 1.8.10
+
+debugUnitTestRuntimeOnly (n)
+No dependencies
+
+debugUnitTestRuntimeOnlyDependenciesMetadata
+No dependencies
+
+debugWearApp - Link to a wear app to embed for object 'debug'. (n)
+No dependencies
+
+debugWearBundling - Resolved Configuration for wear app bundling for variant: debug
+No dependencies
+
+implementation - Implementation only dependencies for 'main' sources. (n)
++--- androidx.core:core-ktx:1.9.0 (n)
++--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (n)
++--- androidx.activity:activity-compose:1.7.2 (n)
++--- androidx.compose:compose-bom:2023.03.00 (n)
++--- androidx.compose.ui:ui (n)
++--- androidx.compose.ui:ui-graphics (n)
++--- androidx.compose.ui:ui-tooling-preview (n)
+\--- androidx.compose.material3:material3 (n)
+
+implementationDependenciesMetadata
++--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.10
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.10
+|    |    \--- org.jetbrains:annotations:13.0
+|    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.10
+|         \--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
++--- androidx.core:core-ktx:1.9.0
+|    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.7.10 -> 1.8.10 (*)
+|    +--- androidx.core:core:1.9.0
+|    |    +--- androidx.annotation:annotation:1.2.0 -> 1.5.0 (*)
+|    |    +--- androidx.annotation:annotation-experimental:1.3.0
+|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.7.10 -> 1.8.10 (*)
+|    |    +--- androidx.lifecycle:lifecycle-runtime:2.3.1 -> 2.6.1
+|    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    +--- androidx.arch.core:core-common:2.2.0
+|    |    |    |    \--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1
+|    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4
+|    |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4
+|    |    |    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.6.21 -> 1.8.10
+|    |    |    |    |    |    \--- org.jetbrains.kotlinx:atomicfu:0.17.3
+|    |    |    |    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.6.20 -> 1.8.10
+|    |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.6.4
+|    |    |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 (c)
+|    |    |    |    |    |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4 (c)
+|    |    |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.21 -> 1.8.10 (*)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1 (c)
+|    |    |    |    \--- androidx.lifecycle:lifecycle-livedata-core:2.6.1 (c)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1 (c)
+|    |    |    \--- androidx.lifecycle:lifecycle-livedata-core:2.6.1 (c)
+|    |    \--- androidx.versionedparcelable:versionedparcelable:1.1.1
+|    |         +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |         \--- androidx.collection:collection:1.0.0
+|    |              \--- androidx.annotation:annotation:1.0.0 -> 1.5.0 (*)
+|    \--- org.jetbrains.kotlin:kotlin-stdlib:1.7.10 -> 1.8.10 (*)
++--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1
+|    +--- androidx.annotation:annotation:1.0.0 -> 1.5.0 (*)
+|    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (*)
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 (*)
+|    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (c)
+|    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (c)
+|    +--- androidx.lifecycle:lifecycle-common:2.6.1 (c)
+|    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1 (c)
+|    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1 (c)
+|    \--- androidx.lifecycle:lifecycle-livedata-core:2.6.1 (c)
++--- androidx.activity:activity-compose:1.7.2
+|    +--- androidx.activity:activity-ktx:1.7.2
+|    |    +--- androidx.activity:activity:1.7.2
+|    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    +--- androidx.core:core:1.8.0 -> 1.9.0 (*)
+|    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (*)
+|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1
+|    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1 (c)
+|    |    |    |    \--- androidx.lifecycle:lifecycle-livedata-core:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1
+|    |    |    |    +--- androidx.annotation:annotation:1.0.0 -> 1.5.0 (*)
+|    |    |    |    +--- androidx.core:core-ktx:1.2.0 -> 1.9.0 (*)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.6.1
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (*)
+|    |    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (c)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (c)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (c)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (c)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1 (c)
+|    |    |    |    |    \--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (*)
+|    |    |    |    +--- androidx.savedstate:savedstate:1.2.1
+|    |    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    |    \--- androidx.savedstate:savedstate-ktx:1.2.1 (c)
+|    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 (*)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (c)
+|    |    |    |    \--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1 (c)
+|    |    |    +--- androidx.savedstate:savedstate:1.2.1 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    +--- androidx.activity:activity-compose:1.7.2 (c)
+|    |    |    \--- androidx.activity:activity-ktx:1.7.2 (c)
+|    |    +--- androidx.core:core-ktx:1.1.0 -> 1.9.0 (*)
+|    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (*)
+|    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1
+|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 (*)
+|    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1 (c)
+|    |    |    \--- androidx.lifecycle:lifecycle-livedata-core:2.6.1 (c)
+|    |    +--- androidx.savedstate:savedstate-ktx:1.2.1
+|    |    |    +--- androidx.savedstate:savedstate:1.2.1 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    \--- androidx.savedstate:savedstate:1.2.1 (c)
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    +--- androidx.activity:activity:1.7.2 (c)
+|    |    \--- androidx.activity:activity-compose:1.7.2 (c)
+|    +--- androidx.compose.runtime:runtime:1.0.1 -> 1.4.0
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 (*)
+|    |    \--- androidx.compose.runtime:runtime-saveable:1.4.0 (c)
+|    +--- androidx.compose.runtime:runtime-saveable:1.0.1 -> 1.4.0
+|    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    +--- androidx.compose.runtime:runtime:1.4.0 (*)
+|    |    \--- androidx.compose.runtime:runtime:1.4.0 (c)
+|    +--- androidx.compose.ui:ui:1.0.1 -> 1.4.0
+|    |    +--- androidx.annotation:annotation:1.5.0 (*)
+|    |    +--- androidx.compose.runtime:runtime-saveable:1.4.0 (*)
+|    |    +--- androidx.compose.ui:ui-geometry:1.4.0
+|    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    |    |    \--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-graphics:1.4.0
+|    |    |    +--- androidx.annotation:annotation:1.2.0 -> 1.5.0 (*)
+|    |    |    +--- androidx.compose.ui:ui-unit:1.4.0
+|    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    +--- androidx.compose.ui:ui-geometry:1.4.0 (*)
+|    |    |    |    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    |    |    |    \--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    |    |    \--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-text:1.4.0
+|    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (*)
+|    |    |    +--- androidx.compose.ui:ui-unit:1.4.0 (*)
+|    |    |    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    |    |    \--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-unit:1.4.0 (*)
+|    |    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    |    \--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (*)
+|    +--- androidx.activity:activity-ktx:1.7.2 (c)
+|    \--- androidx.activity:activity:1.7.2 (c)
++--- androidx.compose:compose-bom:2023.03.00
+|    +--- androidx.compose.material3:material3:1.0.0 (c)
+|    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    +--- androidx.compose.runtime:runtime:1.4.0 (c)
+|    +--- androidx.compose.runtime:runtime-saveable:1.4.0 (c)
+|    +--- androidx.compose.foundation:foundation:1.4.0 (c)
+|    +--- androidx.compose.material:material-icons-core:1.4.0 (c)
+|    +--- androidx.compose.material:material-ripple:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    +--- androidx.compose.animation:animation:1.4.0 (c)
+|    +--- androidx.compose.animation:animation-core:1.4.0 (c)
+|    \--- androidx.compose.foundation:foundation-layout:1.4.0 (c)
++--- androidx.compose.ui:ui -> 1.4.0 (*)
++--- androidx.compose.ui:ui-graphics -> 1.4.0 (*)
++--- androidx.compose.ui:ui-tooling-preview -> 1.4.0
+|    +--- androidx.annotation:annotation:1.2.0 -> 1.5.0 (*)
+|    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0 (*)
+|    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    \--- androidx.compose.ui:ui-unit:1.4.0 (c)
+\--- androidx.compose.material3:material3 -> 1.0.0
+     +--- androidx.compose.foundation:foundation:1.2.0 -> 1.4.0
+     |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+     |    +--- androidx.compose.animation:animation:1.2.1 -> 1.4.0
+     |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+     |    |    +--- androidx.compose.animation:animation-core:1.4.0
+     |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+     |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4 (*)
+     |    |    |    \--- androidx.compose.animation:animation:1.4.0 (c)
+     |    |    +--- androidx.compose.foundation:foundation-layout:1.2.1 -> 1.4.0
+     |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+     |    |    |    +--- androidx.compose.ui:ui:1.2.1 -> 1.4.0 (*)
+     |    |    |    +--- androidx.compose.ui:ui-unit:1.2.1 -> 1.4.0 (*)
+     |    |    |    \--- androidx.compose.foundation:foundation:1.4.0 (c)
+     |    |    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0 (*)
+     |    |    +--- androidx.compose.ui:ui:1.2.1 -> 1.4.0 (*)
+     |    |    +--- androidx.compose.ui:ui-geometry:1.2.1 -> 1.4.0 (*)
+     |    |    \--- androidx.compose.animation:animation-core:1.4.0 (c)
+     |    +--- androidx.compose.runtime:runtime:1.4.0 (*)
+     |    +--- androidx.compose.ui:ui:1.4.0 (*)
+     |    \--- androidx.compose.foundation:foundation-layout:1.4.0 (c)
+     +--- androidx.compose.material:material-icons-core:1.0.2 -> 1.4.0
+     |    +--- androidx.compose.ui:ui:1.2.1 -> 1.4.0 (*)
+     |    \--- androidx.compose.material:material-ripple:1.4.0 (c)
+     +--- androidx.compose.material:material-ripple:1.0.0 -> 1.4.0
+     |    +--- androidx.compose.foundation:foundation:1.2.1 -> 1.4.0 (*)
+     |    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0 (*)
+     |    \--- androidx.compose.material:material-icons-core:1.4.0 (c)
+     +--- androidx.compose.runtime:runtime:1.0.1 -> 1.4.0 (*)
+     +--- androidx.compose.ui:ui:1.3.0 -> 1.4.0 (*)
+     +--- androidx.compose.ui:ui-graphics:1.0.1 -> 1.4.0 (*)
+     \--- androidx.compose.ui:ui-text:1.3.0 -> 1.4.0 (*)
+
+intransitiveDependenciesMetadata
+No dependencies
+
+kotlin-extension - Configuration for Compose related kotlin compiler extension
+\--- androidx.compose.compiler:compiler:1.4.3
+
+kotlinCompilerClasspath
+\--- org.jetbrains.kotlin:kotlin-compiler-embeddable:1.8.10
+     +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10
+     |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.10
+     |    \--- org.jetbrains:annotations:13.0
+     +--- org.jetbrains.kotlin:kotlin-script-runtime:1.8.10
+     +--- org.jetbrains.kotlin:kotlin-reflect:1.6.10
+     +--- org.jetbrains.kotlin:kotlin-daemon-embeddable:1.8.10
+     +--- org.jetbrains.intellij.deps:trove4j:1.0.20200330
+     \--- net.java.dev.jna:jna:5.6.0
+
+kotlinCompilerPluginClasspath
+No dependencies
+
+kotlinCompilerPluginClasspathDebug - Kotlin compiler plugins for compilation 'debug' (target  (androidJvm))
+No dependencies
+
+kotlinCompilerPluginClasspathDebugAndroidTest - Kotlin compiler plugins for compilation 'debugAndroidTest' (target  (androidJvm))
+No dependencies
+
+kotlinCompilerPluginClasspathDebugUnitTest - Kotlin compiler plugins for compilation 'debugUnitTest' (target  (androidJvm))
+No dependencies
+
+kotlinCompilerPluginClasspathRelease - Kotlin compiler plugins for compilation 'release' (target  (androidJvm))
+No dependencies
+
+kotlinCompilerPluginClasspathReleaseUnitTest - Kotlin compiler plugins for compilation 'releaseUnitTest' (target  (androidJvm))
+No dependencies
+
+kotlinKlibCommonizerClasspath
+\--- org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable:1.8.10
+     +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10
+     |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.10
+     |    \--- org.jetbrains:annotations:13.0
+     \--- org.jetbrains.kotlin:kotlin-compiler-embeddable:1.8.10
+          +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+          +--- org.jetbrains.kotlin:kotlin-script-runtime:1.8.10
+          +--- org.jetbrains.kotlin:kotlin-reflect:1.6.10
+          +--- org.jetbrains.kotlin:kotlin-daemon-embeddable:1.8.10
+          +--- org.jetbrains.intellij.deps:trove4j:1.0.20200330
+          \--- net.java.dev.jna:jna:5.6.0
+
+kotlinNativeCompilerPluginClasspath
+No dependencies
+
+lintChecks - Configuration to apply external lint check jar
+No dependencies
+
+lintPublish - Configuration to publish external lint check jar
+No dependencies
+
+releaseAnnotationProcessor - Classpath for the annotation processor for 'release'. (n)
+No dependencies
+
+releaseAnnotationProcessorClasspath - Resolved configuration for annotation-processor for variant: release
+No dependencies
+
+releaseApi - API dependencies for 'release' sources. (n)
+No dependencies
+
+releaseApiDependenciesMetadata
+No dependencies
+
+releaseApiElements - API elements for release (n)
+No dependencies
+
+releaseCompilationApi - API dependencies for compilation 'release' (target  (androidJvm)). (n)
+No dependencies
+
+releaseCompilationCompileOnly - Compile only dependencies for compilation 'release' (target  (androidJvm)). (n)
+No dependencies
+
+releaseCompilationImplementation - Implementation only dependencies for compilation 'release' (target  (androidJvm)). (n)
+No dependencies
+
+releaseCompilationRuntimeOnly - Runtime only dependencies for compilation 'release' (target  (androidJvm)). (n)
+No dependencies
+
+releaseCompileClasspath - Compile classpath for compilation 'release' (target  (androidJvm)).
++--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.10
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.10
+|    |    \--- org.jetbrains:annotations:13.0
+|    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.10
+|         \--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
++--- androidx.core:core-ktx:1.9.0
+|    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.7.10 -> 1.8.10 (*)
+|    +--- androidx.core:core:1.9.0
+|    |    +--- androidx.annotation:annotation:1.2.0 -> 1.5.0 (*)
+|    |    +--- androidx.annotation:annotation-experimental:1.3.0
+|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.7.10 -> 1.8.10 (*)
+|    |    +--- androidx.lifecycle:lifecycle-runtime:2.3.1 -> 2.6.1
+|    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    +--- androidx.arch.core:core-common:2.2.0
+|    |    |    |    \--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1
+|    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4
+|    |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4
+|    |    |    |    |    |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.6.4
+|    |    |    |    |    |         +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.6.4
+|    |    |    |    |    |         |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 (c)
+|    |    |    |    |    |         |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.6.4 (c)
+|    |    |    |    |    |         |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4 (c)
+|    |    |    |    |    |         +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.21 -> 1.8.10 (*)
+|    |    |    |    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.6.21 -> 1.8.10
+|    |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.6.4 (*)
+|    |    |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.21 -> 1.8.10 (*)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1 (c)
+|    |    |    |    \--- androidx.lifecycle:lifecycle-livedata-core:2.6.1 (c)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1 (c)
+|    |    |    \--- androidx.lifecycle:lifecycle-livedata-core:2.6.1 (c)
+|    |    \--- androidx.versionedparcelable:versionedparcelable:1.1.1
+|    |         +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |         \--- androidx.collection:collection:1.0.0 -> 1.1.0
+|    |              \--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    \--- org.jetbrains.kotlin:kotlin-stdlib:1.7.10 -> 1.8.10 (*)
++--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1
+|    +--- androidx.annotation:annotation:1.0.0 -> 1.5.0 (*)
+|    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (*)
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 (*)
+|    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (c)
+|    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (c)
+|    +--- androidx.lifecycle:lifecycle-common:2.6.1 (c)
+|    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1 (c)
+|    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1 (c)
+|    \--- androidx.lifecycle:lifecycle-livedata-core:2.6.1 (c)
++--- androidx.activity:activity-compose:1.7.2
+|    +--- androidx.activity:activity-ktx:1.7.2
+|    |    +--- androidx.activity:activity:1.7.2
+|    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    +--- androidx.core:core:1.8.0 -> 1.9.0 (*)
+|    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (*)
+|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1
+|    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1 (c)
+|    |    |    |    \--- androidx.lifecycle:lifecycle-livedata-core:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1
+|    |    |    |    +--- androidx.annotation:annotation:1.0.0 -> 1.5.0 (*)
+|    |    |    |    +--- androidx.core:core-ktx:1.2.0 -> 1.9.0 (*)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.6.1
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (*)
+|    |    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (c)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (c)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (c)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (c)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1 (c)
+|    |    |    |    |    \--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (*)
+|    |    |    |    +--- androidx.savedstate:savedstate:1.2.1
+|    |    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    |    \--- androidx.savedstate:savedstate-ktx:1.2.1 (c)
+|    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 (*)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (c)
+|    |    |    |    \--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1 (c)
+|    |    |    +--- androidx.savedstate:savedstate:1.2.1 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    +--- androidx.activity:activity-compose:1.7.2 (c)
+|    |    |    \--- androidx.activity:activity-ktx:1.7.2 (c)
+|    |    +--- androidx.core:core-ktx:1.1.0 -> 1.9.0 (*)
+|    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (*)
+|    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1
+|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 (*)
+|    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1 (c)
+|    |    |    \--- androidx.lifecycle:lifecycle-livedata-core:2.6.1 (c)
+|    |    +--- androidx.savedstate:savedstate-ktx:1.2.1
+|    |    |    +--- androidx.savedstate:savedstate:1.2.1 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    \--- androidx.savedstate:savedstate:1.2.1 (c)
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    +--- androidx.activity:activity:1.7.2 (c)
+|    |    \--- androidx.activity:activity-compose:1.7.2 (c)
+|    +--- androidx.compose.runtime:runtime:1.0.1 -> 1.4.0
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 (*)
+|    |    \--- androidx.compose.runtime:runtime-saveable:1.4.0 (c)
+|    +--- androidx.compose.runtime:runtime-saveable:1.0.1 -> 1.4.0
+|    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    +--- androidx.compose.runtime:runtime:1.4.0 (*)
+|    |    \--- androidx.compose.runtime:runtime:1.4.0 (c)
+|    +--- androidx.compose.ui:ui:1.0.1 -> 1.4.0
+|    |    +--- androidx.annotation:annotation:1.5.0 (*)
+|    |    +--- androidx.compose.runtime:runtime-saveable:1.4.0 (*)
+|    |    +--- androidx.compose.ui:ui-geometry:1.4.0
+|    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    |    |    \--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-graphics:1.4.0
+|    |    |    +--- androidx.annotation:annotation:1.2.0 -> 1.5.0 (*)
+|    |    |    +--- androidx.compose.ui:ui-unit:1.4.0
+|    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    +--- androidx.compose.ui:ui-geometry:1.4.0 (*)
+|    |    |    |    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    |    |    |    \--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    |    |    \--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-text:1.4.0
+|    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (*)
+|    |    |    +--- androidx.compose.ui:ui-unit:1.4.0 (*)
+|    |    |    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    |    |    \--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-unit:1.4.0 (*)
+|    |    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    |    \--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (*)
+|    +--- androidx.activity:activity-ktx:1.7.2 (c)
+|    \--- androidx.activity:activity:1.7.2 (c)
++--- androidx.compose:compose-bom:2023.03.00
+|    +--- androidx.compose.material3:material3:1.0.0 (c)
+|    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    +--- androidx.compose.runtime:runtime:1.4.0 (c)
+|    +--- androidx.compose.runtime:runtime-saveable:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    +--- androidx.compose.foundation:foundation:1.4.0 (c)
+|    +--- androidx.compose.material:material-icons-core:1.4.0 (c)
+|    +--- androidx.compose.material:material-ripple:1.4.0 (c)
+|    +--- androidx.compose.animation:animation:1.4.0 (c)
+|    +--- androidx.compose.animation:animation-core:1.4.0 (c)
+|    \--- androidx.compose.foundation:foundation-layout:1.4.0 (c)
++--- androidx.compose.ui:ui -> 1.4.0 (*)
++--- androidx.compose.ui:ui-graphics -> 1.4.0 (*)
++--- androidx.compose.ui:ui-tooling-preview -> 1.4.0
+|    +--- androidx.annotation:annotation:1.2.0 -> 1.5.0 (*)
+|    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0 (*)
+|    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    \--- androidx.compose.ui:ui-unit:1.4.0 (c)
++--- androidx.compose.material3:material3 -> 1.0.0
+|    +--- androidx.compose.foundation:foundation:1.2.0 -> 1.4.0
+|    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    +--- androidx.compose.animation:animation:1.2.1 -> 1.4.0
+|    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    +--- androidx.compose.animation:animation-core:1.4.0
+|    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4 (*)
+|    |    |    |    \--- androidx.compose.animation:animation:1.4.0 (c)
+|    |    |    +--- androidx.compose.foundation:foundation-layout:1.2.1 -> 1.4.0
+|    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    +--- androidx.compose.ui:ui:1.2.1 -> 1.4.0 (*)
+|    |    |    |    +--- androidx.compose.ui:ui-unit:1.2.1 -> 1.4.0 (*)
+|    |    |    |    \--- androidx.compose.foundation:foundation:1.4.0 (c)
+|    |    |    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0 (*)
+|    |    |    +--- androidx.compose.ui:ui:1.2.1 -> 1.4.0 (*)
+|    |    |    +--- androidx.compose.ui:ui-geometry:1.2.1 -> 1.4.0 (*)
+|    |    |    \--- androidx.compose.animation:animation-core:1.4.0 (c)
+|    |    +--- androidx.compose.runtime:runtime:1.4.0 (*)
+|    |    +--- androidx.compose.ui:ui:1.4.0 (*)
+|    |    \--- androidx.compose.foundation:foundation-layout:1.4.0 (c)
+|    +--- androidx.compose.material:material-icons-core:1.0.2 -> 1.4.0
+|    |    +--- androidx.compose.ui:ui:1.2.1 -> 1.4.0 (*)
+|    |    \--- androidx.compose.material:material-ripple:1.4.0 (c)
+|    +--- androidx.compose.material:material-ripple:1.0.0 -> 1.4.0
+|    |    +--- androidx.compose.foundation:foundation:1.2.1 -> 1.4.0 (*)
+|    |    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0 (*)
+|    |    \--- androidx.compose.material:material-icons-core:1.4.0 (c)
+|    +--- androidx.compose.runtime:runtime:1.0.1 -> 1.4.0 (*)
+|    +--- androidx.compose.ui:ui:1.3.0 -> 1.4.0 (*)
+|    +--- androidx.compose.ui:ui-graphics:1.0.1 -> 1.4.0 (*)
+|    \--- androidx.compose.ui:ui-text:1.3.0 -> 1.4.0 (*)
++--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:{strictly 1.8.10} -> 1.8.10 (c)
++--- androidx.core:core-ktx:{strictly 1.9.0} -> 1.9.0 (c)
++--- androidx.lifecycle:lifecycle-runtime-ktx:{strictly 2.6.1} -> 2.6.1 (c)
++--- androidx.activity:activity-compose:{strictly 1.7.2} -> 1.7.2 (c)
++--- androidx.compose.ui:ui:{strictly 1.4.0} -> 1.4.0 (c)
++--- androidx.compose.ui:ui-graphics:{strictly 1.4.0} -> 1.4.0 (c)
++--- androidx.compose.ui:ui-tooling-preview:{strictly 1.4.0} -> 1.4.0 (c)
++--- androidx.compose:compose-bom:{strictly 2023.03.00} -> 2023.03.00 (c)
++--- androidx.compose.material3:material3:{strictly 1.0.0} -> 1.0.0 (c)
++--- org.jetbrains.kotlin:kotlin-stdlib:{strictly 1.8.10} -> 1.8.10 (c)
++--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:{strictly 1.8.10} -> 1.8.10 (c)
++--- androidx.annotation:annotation:{strictly 1.5.0} -> 1.5.0 (c)
++--- androidx.core:core:{strictly 1.9.0} -> 1.9.0 (c)
++--- androidx.lifecycle:lifecycle-runtime:{strictly 2.6.1} -> 2.6.1 (c)
++--- org.jetbrains.kotlinx:kotlinx-coroutines-android:{strictly 1.6.4} -> 1.6.4 (c)
++--- androidx.activity:activity-ktx:{strictly 1.7.2} -> 1.7.2 (c)
++--- androidx.compose.runtime:runtime:{strictly 1.4.0} -> 1.4.0 (c)
++--- androidx.compose.runtime:runtime-saveable:{strictly 1.4.0} -> 1.4.0 (c)
++--- androidx.lifecycle:lifecycle-viewmodel:{strictly 2.6.1} -> 2.6.1 (c)
++--- androidx.compose.ui:ui-geometry:{strictly 1.4.0} -> 1.4.0 (c)
++--- androidx.compose.ui:ui-text:{strictly 1.4.0} -> 1.4.0 (c)
++--- androidx.compose.ui:ui-unit:{strictly 1.4.0} -> 1.4.0 (c)
++--- androidx.compose.foundation:foundation:{strictly 1.4.0} -> 1.4.0 (c)
++--- androidx.compose.material:material-icons-core:{strictly 1.4.0} -> 1.4.0 (c)
++--- androidx.compose.material:material-ripple:{strictly 1.4.0} -> 1.4.0 (c)
++--- org.jetbrains.kotlin:kotlin-stdlib-common:{strictly 1.8.10} -> 1.8.10 (c)
++--- org.jetbrains:annotations:{strictly 13.0} -> 13.0 (c)
++--- androidx.annotation:annotation-experimental:{strictly 1.3.0} -> 1.3.0 (c)
++--- androidx.versionedparcelable:versionedparcelable:{strictly 1.1.1} -> 1.1.1 (c)
++--- androidx.arch.core:core-common:{strictly 2.2.0} -> 2.2.0 (c)
++--- androidx.lifecycle:lifecycle-common:{strictly 2.6.1} -> 2.6.1 (c)
++--- org.jetbrains.kotlinx:kotlinx-coroutines-core:{strictly 1.6.4} -> 1.6.4 (c)
++--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:{strictly 1.6.4} -> 1.6.4 (c)
++--- androidx.activity:activity:{strictly 1.7.2} -> 1.7.2 (c)
++--- androidx.lifecycle:lifecycle-viewmodel-ktx:{strictly 2.6.1} -> 2.6.1 (c)
++--- androidx.savedstate:savedstate-ktx:{strictly 1.2.1} -> 1.2.1 (c)
++--- androidx.compose.animation:animation:{strictly 1.4.0} -> 1.4.0 (c)
++--- androidx.collection:collection:{strictly 1.1.0} -> 1.1.0 (c)
++--- org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:{strictly 1.6.4} -> 1.6.4 (c)
++--- androidx.lifecycle:lifecycle-viewmodel-savedstate:{strictly 2.6.1} -> 2.6.1 (c)
++--- androidx.savedstate:savedstate:{strictly 1.2.1} -> 1.2.1 (c)
++--- androidx.compose.animation:animation-core:{strictly 1.4.0} -> 1.4.0 (c)
++--- androidx.compose.foundation:foundation-layout:{strictly 1.4.0} -> 1.4.0 (c)
+\--- androidx.lifecycle:lifecycle-livedata-core:{strictly 2.6.1} -> 2.6.1 (c)
+
+releaseCompileOnly - Compile only dependencies for 'release' sources. (n)
+No dependencies
+
+releaseCompileOnlyDependenciesMetadata
+No dependencies
+
+releaseImplementation - Implementation only dependencies for 'release' sources. (n)
+No dependencies
+
+releaseImplementationDependenciesMetadata
+No dependencies
+
+releaseIntransitiveDependenciesMetadata
+No dependencies
+
+releaseReverseMetadataValues - Metadata Values dependencies for the base Split
+No dependencies
+
+releaseRuntimeClasspath - Runtime classpath of compilation 'release' (target  (androidJvm)).
++--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.10
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.10
+|    |    \--- org.jetbrains:annotations:13.0
+|    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.10
+|         \--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
++--- androidx.core:core-ktx:1.9.0
+|    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.7.10 -> 1.8.10 (*)
+|    +--- androidx.core:core:1.9.0
+|    |    +--- androidx.annotation:annotation:1.2.0 -> 1.5.0 (*)
+|    |    +--- androidx.annotation:annotation-experimental:1.3.0
+|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.7.10 -> 1.8.10 (*)
+|    |    +--- androidx.collection:collection:1.0.0 -> 1.1.0
+|    |    |    \--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    +--- androidx.concurrent:concurrent-futures:1.0.0 -> 1.1.0
+|    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    \--- com.google.guava:listenablefuture:1.0
+|    |    +--- androidx.lifecycle:lifecycle-runtime:2.3.1 -> 2.6.1
+|    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    +--- androidx.arch.core:core-common:2.2.0
+|    |    |    |    \--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    +--- androidx.arch.core:core-runtime:2.2.0
+|    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    \--- androidx.arch.core:core-common:2.2.0 (*)
+|    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1
+|    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4
+|    |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4
+|    |    |    |    |    |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.6.4
+|    |    |    |    |    |         +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.6.4
+|    |    |    |    |    |         |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 (c)
+|    |    |    |    |    |         |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.6.4 (c)
+|    |    |    |    |    |         |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4 (c)
+|    |    |    |    |    |         +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.21 -> 1.8.10 (*)
+|    |    |    |    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.6.21 -> 1.8.10
+|    |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.6.4 (*)
+|    |    |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.21 -> 1.8.10 (*)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-process:2.6.1 (c)
+|    |    |    |    \--- androidx.lifecycle:lifecycle-livedata-core:2.6.1 (c)
+|    |    |    +--- androidx.profileinstaller:profileinstaller:1.3.0
+|    |    |    |    +--- androidx.annotation:annotation:1.2.0 -> 1.5.0 (*)
+|    |    |    |    +--- androidx.concurrent:concurrent-futures:1.1.0 (*)
+|    |    |    |    +--- androidx.startup:startup-runtime:1.1.1
+|    |    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    |    \--- androidx.tracing:tracing:1.0.0
+|    |    |    |    |         \--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    \--- com.google.guava:listenablefuture:1.0
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-process:2.6.1 (c)
+|    |    |    \--- androidx.lifecycle:lifecycle-livedata-core:2.6.1 (c)
+|    |    +--- androidx.versionedparcelable:versionedparcelable:1.1.1
+|    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    \--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
+|    |    \--- androidx.core:core-ktx:1.9.0 (c)
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.7.10 -> 1.8.10 (*)
+|    \--- androidx.core:core:1.9.0 (c)
++--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1
+|    +--- androidx.annotation:annotation:1.0.0 -> 1.5.0 (*)
+|    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (*)
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 (*)
+|    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (c)
+|    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (c)
+|    +--- androidx.lifecycle:lifecycle-common:2.6.1 (c)
+|    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1 (c)
+|    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1 (c)
+|    +--- androidx.lifecycle:lifecycle-process:2.6.1 (c)
+|    \--- androidx.lifecycle:lifecycle-livedata-core:2.6.1 (c)
++--- androidx.activity:activity-compose:1.7.2
+|    +--- androidx.activity:activity-ktx:1.7.2
+|    |    +--- androidx.activity:activity:1.7.2
+|    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    +--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
+|    |    |    +--- androidx.core:core:1.8.0 -> 1.9.0 (*)
+|    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (*)
+|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1
+|    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-process:2.6.1 (c)
+|    |    |    |    \--- androidx.lifecycle:lifecycle-livedata-core:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1
+|    |    |    |    +--- androidx.annotation:annotation:1.0.0 -> 1.5.0 (*)
+|    |    |    |    +--- androidx.core:core-ktx:1.2.0 -> 1.9.0 (*)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.6.1
+|    |    |    |    |    +--- androidx.arch.core:core-common:2.1.0 -> 2.2.0 (*)
+|    |    |    |    |    +--- androidx.arch.core:core-runtime:2.1.0 -> 2.2.0 (*)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (*)
+|    |    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (c)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-process:2.6.1 (c)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (c)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (c)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (c)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1 (c)
+|    |    |    |    |    \--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (*)
+|    |    |    |    +--- androidx.savedstate:savedstate:1.2.1
+|    |    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    |    +--- androidx.arch.core:core-common:2.1.0 -> 2.2.0 (*)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (*)
+|    |    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    |    \--- androidx.savedstate:savedstate-ktx:1.2.1 (c)
+|    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 (*)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-process:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (c)
+|    |    |    |    \--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1 (c)
+|    |    |    +--- androidx.profileinstaller:profileinstaller:1.3.0 (*)
+|    |    |    +--- androidx.savedstate:savedstate:1.2.1 (*)
+|    |    |    +--- androidx.tracing:tracing:1.0.0 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    +--- androidx.activity:activity-compose:1.7.2 (c)
+|    |    |    \--- androidx.activity:activity-ktx:1.7.2 (c)
+|    |    +--- androidx.core:core-ktx:1.1.0 -> 1.9.0 (*)
+|    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (*)
+|    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1
+|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 (*)
+|    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-process:2.6.1 (c)
+|    |    |    \--- androidx.lifecycle:lifecycle-livedata-core:2.6.1 (c)
+|    |    +--- androidx.savedstate:savedstate-ktx:1.2.1
+|    |    |    +--- androidx.savedstate:savedstate:1.2.1 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    \--- androidx.savedstate:savedstate:1.2.1 (c)
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    +--- androidx.activity:activity:1.7.2 (c)
+|    |    \--- androidx.activity:activity-compose:1.7.2 (c)
+|    +--- androidx.compose.runtime:runtime:1.0.1 -> 1.4.0
+|    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 (*)
+|    |    \--- androidx.compose.runtime:runtime-saveable:1.4.0 (c)
+|    +--- androidx.compose.runtime:runtime-saveable:1.0.1 -> 1.4.0
+|    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    +--- androidx.compose.runtime:runtime:1.4.0 (*)
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    \--- androidx.compose.runtime:runtime:1.4.0 (c)
+|    +--- androidx.compose.ui:ui:1.0.1 -> 1.4.0
+|    |    +--- androidx.activity:activity-ktx:1.7.0 -> 1.7.2 (*)
+|    |    +--- androidx.annotation:annotation:1.5.0 (*)
+|    |    +--- androidx.autofill:autofill:1.0.0
+|    |    |    \--- androidx.core:core:1.1.0 -> 1.9.0 (*)
+|    |    +--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
+|    |    +--- androidx.compose.runtime:runtime:1.4.0 (*)
+|    |    +--- androidx.compose.runtime:runtime-saveable:1.4.0 (*)
+|    |    +--- androidx.compose.ui:ui-geometry:1.4.0
+|    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0 (*)
+|    |    |    +--- androidx.compose.ui:ui-util:1.4.0
+|    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    |    |    |    \--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    |    |    \--- androidx.compose.ui:ui-util:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-graphics:1.4.0
+|    |    |    +--- androidx.annotation:annotation:1.2.0 -> 1.5.0 (*)
+|    |    |    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0 (*)
+|    |    |    +--- androidx.compose.ui:ui-unit:1.4.0
+|    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0 (*)
+|    |    |    |    +--- androidx.compose.ui:ui-geometry:1.4.0 (*)
+|    |    |    |    +--- androidx.compose.ui:ui-util:1.4.0 (*)
+|    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    |    |    |    \--- androidx.compose.ui:ui-util:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-util:1.4.0 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.10
+|    |    |    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    |    |    \--- androidx.compose.ui:ui-util:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-text:1.4.0
+|    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    +--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
+|    |    |    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0 (*)
+|    |    |    +--- androidx.compose.runtime:runtime-saveable:1.2.1 -> 1.4.0 (*)
+|    |    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (*)
+|    |    |    +--- androidx.compose.ui:ui-unit:1.4.0 (*)
+|    |    |    +--- androidx.compose.ui:ui-util:1.4.0 (*)
+|    |    |    +--- androidx.core:core:1.7.0 -> 1.9.0 (*)
+|    |    |    +--- androidx.emoji2:emoji2:1.2.0 -> 1.3.0
+|    |    |    |    +--- androidx.annotation:annotation:1.2.0 -> 1.5.0 (*)
+|    |    |    |    +--- androidx.collection:collection:1.1.0 (*)
+|    |    |    |    +--- androidx.core:core:1.3.0 -> 1.9.0 (*)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-process:2.4.1 -> 2.6.1
+|    |    |    |    |    +--- androidx.annotation:annotation:1.2.0 -> 1.5.0 (*)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (*)
+|    |    |    |    |    +--- androidx.startup:startup-runtime:1.1.1 (*)
+|    |    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (c)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.6.1 (c)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (c)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (c)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (c)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1 (c)
+|    |    |    |    |    \--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1 (c)
+|    |    |    |    \--- androidx.startup:startup-runtime:1.0.0 -> 1.1.1 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.10
+|    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4 (*)
+|    |    |    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    |    |    \--- androidx.compose.ui:ui-util:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-unit:1.4.0 (*)
+|    |    +--- androidx.compose.ui:ui-util:1.4.0 (*)
+|    |    +--- androidx.core:core:1.9.0 (*)
+|    |    +--- androidx.customview:customview-poolingcontainer:1.0.0
+|    |    |    +--- androidx.core:core-ktx:1.5.0 -> 1.9.0 (*)
+|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.6.21 -> 1.8.10 (*)
+|    |    +--- androidx.emoji2:emoji2:1.2.0 -> 1.3.0 (*)
+|    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (*)
+|    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (*)
+|    |    +--- androidx.profileinstaller:profileinstaller:1.3.0 (*)
+|    |    +--- androidx.savedstate:savedstate-ktx:1.2.1 (*)
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.10
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 (*)
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4 (*)
+|    |    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-util:1.4.0 (c)
+|    |    \--- androidx.compose.foundation:foundation:1.4.0 (c)
+|    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (*)
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    +--- androidx.activity:activity-ktx:1.7.2 (c)
+|    \--- androidx.activity:activity:1.7.2 (c)
++--- androidx.compose:compose-bom:2023.03.00
+|    +--- androidx.compose.material3:material3:1.0.0 (c)
+|    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    +--- androidx.compose.runtime:runtime:1.4.0 (c)
+|    +--- androidx.compose.runtime:runtime-saveable:1.4.0 (c)
+|    +--- androidx.compose.animation:animation-core:1.4.0 (c)
+|    +--- androidx.compose.foundation:foundation:1.4.0 (c)
+|    +--- androidx.compose.foundation:foundation-layout:1.4.0 (c)
+|    +--- androidx.compose.material:material-icons-core:1.4.0 (c)
+|    +--- androidx.compose.material:material-ripple:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-util:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    \--- androidx.compose.animation:animation:1.4.0 (c)
++--- androidx.compose.ui:ui -> 1.4.0 (*)
++--- androidx.compose.ui:ui-graphics -> 1.4.0 (*)
++--- androidx.compose.ui:ui-tooling-preview -> 1.4.0
+|    +--- androidx.annotation:annotation:1.2.0 -> 1.5.0 (*)
+|    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0 (*)
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    \--- androidx.compose.ui:ui-util:1.4.0 (c)
+\--- androidx.compose.material3:material3 -> 1.0.0
+     +--- androidx.compose.animation:animation-core:1.1.1 -> 1.4.0
+     |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+     |    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0 (*)
+     |    +--- androidx.compose.ui:ui:1.2.1 -> 1.4.0 (*)
+     |    +--- androidx.compose.ui:ui-unit:1.2.1 -> 1.4.0 (*)
+     |    +--- androidx.compose.ui:ui-util:1.2.1 -> 1.4.0 (*)
+     |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+     |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4 (*)
+     |    \--- androidx.compose.animation:animation:1.4.0 (c)
+     +--- androidx.compose.foundation:foundation:1.2.0 -> 1.4.0
+     |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+     |    +--- androidx.compose.animation:animation:1.2.1 -> 1.4.0
+     |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+     |    |    +--- androidx.compose.animation:animation-core:1.4.0 (*)
+     |    |    +--- androidx.compose.foundation:foundation-layout:1.2.1 -> 1.4.0
+     |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+     |    |    |    +--- androidx.compose.animation:animation-core:1.2.1 -> 1.4.0 (*)
+     |    |    |    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0 (*)
+     |    |    |    +--- androidx.compose.ui:ui:1.2.1 -> 1.4.0 (*)
+     |    |    |    +--- androidx.compose.ui:ui-unit:1.2.1 -> 1.4.0 (*)
+     |    |    |    +--- androidx.compose.ui:ui-util:1.2.1 -> 1.4.0 (*)
+     |    |    |    +--- androidx.core:core:1.7.0 -> 1.9.0 (*)
+     |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.10
+     |    |    |    \--- androidx.compose.foundation:foundation:1.4.0 (c)
+     |    |    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0 (*)
+     |    |    +--- androidx.compose.ui:ui:1.2.1 -> 1.4.0 (*)
+     |    |    +--- androidx.compose.ui:ui-geometry:1.2.1 -> 1.4.0 (*)
+     |    |    +--- androidx.compose.ui:ui-util:1.2.1 -> 1.4.0 (*)
+     |    |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.10
+     |    |    \--- androidx.compose.animation:animation-core:1.4.0 (c)
+     |    +--- androidx.compose.foundation:foundation-layout:1.4.0 (*)
+     |    +--- androidx.compose.runtime:runtime:1.4.0 (*)
+     |    +--- androidx.compose.ui:ui:1.4.0 (*)
+     |    +--- androidx.compose.ui:ui-graphics:1.2.1 -> 1.4.0 (*)
+     |    +--- androidx.compose.ui:ui-text:1.2.1 -> 1.4.0 (*)
+     |    +--- androidx.compose.ui:ui-util:1.2.1 -> 1.4.0 (*)
+     |    +--- androidx.emoji2:emoji2:1.3.0 (*)
+     |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.10
+     |    \--- androidx.compose.foundation:foundation-layout:1.4.0 (c)
+     +--- androidx.compose.foundation:foundation-layout:1.2.0 -> 1.4.0 (*)
+     +--- androidx.compose.material:material-icons-core:1.0.2 -> 1.4.0
+     |    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0 (*)
+     |    +--- androidx.compose.ui:ui:1.2.1 -> 1.4.0 (*)
+     |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+     |    \--- androidx.compose.material:material-ripple:1.4.0 (c)
+     +--- androidx.compose.material:material-ripple:1.0.0 -> 1.4.0
+     |    +--- androidx.compose.animation:animation:1.2.1 -> 1.4.0 (*)
+     |    +--- androidx.compose.foundation:foundation:1.2.1 -> 1.4.0 (*)
+     |    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0 (*)
+     |    +--- androidx.compose.ui:ui-util:1.2.1 -> 1.4.0 (*)
+     |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.10
+     |    \--- androidx.compose.material:material-icons-core:1.4.0 (c)
+     +--- androidx.compose.runtime:runtime:1.0.1 -> 1.4.0 (*)
+     +--- androidx.compose.ui:ui:1.3.0 -> 1.4.0 (*)
+     +--- androidx.compose.ui:ui-graphics:1.0.1 -> 1.4.0 (*)
+     +--- androidx.compose.ui:ui-text:1.3.0 -> 1.4.0 (*)
+     +--- androidx.compose.ui:ui-util:1.0.0 -> 1.4.0 (*)
+     +--- androidx.lifecycle:lifecycle-runtime:2.3.0 -> 2.6.1 (*)
+     +--- androidx.lifecycle:lifecycle-viewmodel:2.3.0 -> 2.6.1 (*)
+     +--- androidx.savedstate:savedstate-ktx:1.2.0 -> 1.2.1 (*)
+     \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.7.10 -> 1.8.10
+
+releaseRuntimeElements - Runtime elements for release (n)
+No dependencies
+
+releaseRuntimeOnly - Runtime only dependencies for 'release' sources. (n)
+No dependencies
+
+releaseRuntimeOnlyDependenciesMetadata
+No dependencies
+
+releaseUnitTestAnnotationProcessorClasspath - Resolved configuration for annotation-processor for variant: releaseUnitTest
+No dependencies
+
+releaseUnitTestApi (n)
+No dependencies
+
+releaseUnitTestApiDependenciesMetadata
+No dependencies
+
+releaseUnitTestCompilationApi - API dependencies for compilation 'releaseUnitTest' (target  (androidJvm)). (n)
+No dependencies
+
+releaseUnitTestCompilationCompileOnly - Compile only dependencies for compilation 'releaseUnitTest' (target  (androidJvm)). (n)
+No dependencies
+
+releaseUnitTestCompilationImplementation - Implementation only dependencies for compilation 'releaseUnitTest' (target  (androidJvm)). (n)
+No dependencies
+
+releaseUnitTestCompilationRuntimeOnly - Runtime only dependencies for compilation 'releaseUnitTest' (target  (androidJvm)). (n)
+No dependencies
+
+releaseUnitTestCompileClasspath - Compile classpath for compilation 'releaseUnitTest' (target  (androidJvm)).
++--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.10
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.10
+|    |    \--- org.jetbrains:annotations:13.0
+|    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.10
+|         \--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
++--- androidx.core:core-ktx:1.9.0
+|    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.7.10 -> 1.8.10 (*)
+|    +--- androidx.core:core:1.9.0
+|    |    +--- androidx.annotation:annotation:1.2.0 -> 1.5.0 (*)
+|    |    +--- androidx.annotation:annotation-experimental:1.3.0
+|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.7.10 -> 1.8.10 (*)
+|    |    +--- androidx.lifecycle:lifecycle-runtime:2.3.1 -> 2.6.1
+|    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    +--- androidx.arch.core:core-common:2.2.0
+|    |    |    |    \--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1
+|    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4
+|    |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4
+|    |    |    |    |    |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.6.4
+|    |    |    |    |    |         +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.6.4
+|    |    |    |    |    |         |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 (c)
+|    |    |    |    |    |         |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.6.4 (c)
+|    |    |    |    |    |         |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4 (c)
+|    |    |    |    |    |         +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.21 -> 1.8.10 (*)
+|    |    |    |    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.6.21 -> 1.8.10
+|    |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.6.4 (*)
+|    |    |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.21 -> 1.8.10 (*)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1 (c)
+|    |    |    |    \--- androidx.lifecycle:lifecycle-livedata-core:2.6.1 (c)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1 (c)
+|    |    |    \--- androidx.lifecycle:lifecycle-livedata-core:2.6.1 (c)
+|    |    \--- androidx.versionedparcelable:versionedparcelable:1.1.1
+|    |         +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |         \--- androidx.collection:collection:1.0.0 -> 1.1.0
+|    |              \--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    \--- org.jetbrains.kotlin:kotlin-stdlib:1.7.10 -> 1.8.10 (*)
++--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1
+|    +--- androidx.annotation:annotation:1.0.0 -> 1.5.0 (*)
+|    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (*)
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 (*)
+|    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (c)
+|    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (c)
+|    +--- androidx.lifecycle:lifecycle-common:2.6.1 (c)
+|    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1 (c)
+|    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1 (c)
+|    \--- androidx.lifecycle:lifecycle-livedata-core:2.6.1 (c)
++--- androidx.activity:activity-compose:1.7.2
+|    +--- androidx.activity:activity-ktx:1.7.2
+|    |    +--- androidx.activity:activity:1.7.2
+|    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    +--- androidx.core:core:1.8.0 -> 1.9.0 (*)
+|    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (*)
+|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1
+|    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1 (c)
+|    |    |    |    \--- androidx.lifecycle:lifecycle-livedata-core:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1
+|    |    |    |    +--- androidx.annotation:annotation:1.0.0 -> 1.5.0 (*)
+|    |    |    |    +--- androidx.core:core-ktx:1.2.0 -> 1.9.0 (*)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.6.1
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (*)
+|    |    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (c)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (c)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (c)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (c)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1 (c)
+|    |    |    |    |    \--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (*)
+|    |    |    |    +--- androidx.savedstate:savedstate:1.2.1
+|    |    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    |    \--- androidx.savedstate:savedstate-ktx:1.2.1 (c)
+|    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 (*)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (c)
+|    |    |    |    \--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1 (c)
+|    |    |    +--- androidx.savedstate:savedstate:1.2.1 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    +--- androidx.activity:activity-compose:1.7.2 (c)
+|    |    |    \--- androidx.activity:activity-ktx:1.7.2 (c)
+|    |    +--- androidx.core:core-ktx:1.1.0 -> 1.9.0 (*)
+|    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (*)
+|    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1
+|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 (*)
+|    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1 (c)
+|    |    |    \--- androidx.lifecycle:lifecycle-livedata-core:2.6.1 (c)
+|    |    +--- androidx.savedstate:savedstate-ktx:1.2.1
+|    |    |    +--- androidx.savedstate:savedstate:1.2.1 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    \--- androidx.savedstate:savedstate:1.2.1 (c)
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    +--- androidx.activity:activity:1.7.2 (c)
+|    |    \--- androidx.activity:activity-compose:1.7.2 (c)
+|    +--- androidx.compose.runtime:runtime:1.0.1 -> 1.4.0
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 (*)
+|    |    \--- androidx.compose.runtime:runtime-saveable:1.4.0 (c)
+|    +--- androidx.compose.runtime:runtime-saveable:1.0.1 -> 1.4.0
+|    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    +--- androidx.compose.runtime:runtime:1.4.0 (*)
+|    |    \--- androidx.compose.runtime:runtime:1.4.0 (c)
+|    +--- androidx.compose.ui:ui:1.0.1 -> 1.4.0
+|    |    +--- androidx.annotation:annotation:1.5.0 (*)
+|    |    +--- androidx.compose.runtime:runtime-saveable:1.4.0 (*)
+|    |    +--- androidx.compose.ui:ui-geometry:1.4.0
+|    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    |    |    \--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-graphics:1.4.0
+|    |    |    +--- androidx.annotation:annotation:1.2.0 -> 1.5.0 (*)
+|    |    |    +--- androidx.compose.ui:ui-unit:1.4.0
+|    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    +--- androidx.compose.ui:ui-geometry:1.4.0 (*)
+|    |    |    |    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    |    |    |    \--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    |    |    \--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-text:1.4.0
+|    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (*)
+|    |    |    +--- androidx.compose.ui:ui-unit:1.4.0 (*)
+|    |    |    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    |    |    \--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-unit:1.4.0 (*)
+|    |    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    |    \--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (*)
+|    +--- androidx.activity:activity-ktx:1.7.2 (c)
+|    \--- androidx.activity:activity:1.7.2 (c)
++--- androidx.compose:compose-bom:2023.03.00
+|    +--- androidx.compose.material3:material3:1.0.0 (c)
+|    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    +--- androidx.compose.runtime:runtime:1.4.0 (c)
+|    +--- androidx.compose.runtime:runtime-saveable:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    +--- androidx.compose.foundation:foundation:1.4.0 (c)
+|    +--- androidx.compose.material:material-icons-core:1.4.0 (c)
+|    +--- androidx.compose.material:material-ripple:1.4.0 (c)
+|    +--- androidx.compose.animation:animation:1.4.0 (c)
+|    +--- androidx.compose.animation:animation-core:1.4.0 (c)
+|    \--- androidx.compose.foundation:foundation-layout:1.4.0 (c)
++--- androidx.compose.ui:ui -> 1.4.0 (*)
++--- androidx.compose.ui:ui-graphics -> 1.4.0 (*)
++--- androidx.compose.ui:ui-tooling-preview -> 1.4.0
+|    +--- androidx.annotation:annotation:1.2.0 -> 1.5.0 (*)
+|    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0 (*)
+|    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    \--- androidx.compose.ui:ui-unit:1.4.0 (c)
++--- androidx.compose.material3:material3 -> 1.0.0
+|    +--- androidx.compose.foundation:foundation:1.2.0 -> 1.4.0
+|    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    +--- androidx.compose.animation:animation:1.2.1 -> 1.4.0
+|    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    +--- androidx.compose.animation:animation-core:1.4.0
+|    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4 (*)
+|    |    |    |    \--- androidx.compose.animation:animation:1.4.0 (c)
+|    |    |    +--- androidx.compose.foundation:foundation-layout:1.2.1 -> 1.4.0
+|    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    +--- androidx.compose.ui:ui:1.2.1 -> 1.4.0 (*)
+|    |    |    |    +--- androidx.compose.ui:ui-unit:1.2.1 -> 1.4.0 (*)
+|    |    |    |    \--- androidx.compose.foundation:foundation:1.4.0 (c)
+|    |    |    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0 (*)
+|    |    |    +--- androidx.compose.ui:ui:1.2.1 -> 1.4.0 (*)
+|    |    |    +--- androidx.compose.ui:ui-geometry:1.2.1 -> 1.4.0 (*)
+|    |    |    \--- androidx.compose.animation:animation-core:1.4.0 (c)
+|    |    +--- androidx.compose.runtime:runtime:1.4.0 (*)
+|    |    +--- androidx.compose.ui:ui:1.4.0 (*)
+|    |    \--- androidx.compose.foundation:foundation-layout:1.4.0 (c)
+|    +--- androidx.compose.material:material-icons-core:1.0.2 -> 1.4.0
+|    |    +--- androidx.compose.ui:ui:1.2.1 -> 1.4.0 (*)
+|    |    \--- androidx.compose.material:material-ripple:1.4.0 (c)
+|    +--- androidx.compose.material:material-ripple:1.0.0 -> 1.4.0
+|    |    +--- androidx.compose.foundation:foundation:1.2.1 -> 1.4.0 (*)
+|    |    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0 (*)
+|    |    \--- androidx.compose.material:material-icons-core:1.4.0 (c)
+|    +--- androidx.compose.runtime:runtime:1.0.1 -> 1.4.0 (*)
+|    +--- androidx.compose.ui:ui:1.3.0 -> 1.4.0 (*)
+|    +--- androidx.compose.ui:ui-graphics:1.0.1 -> 1.4.0 (*)
+|    \--- androidx.compose.ui:ui-text:1.3.0 -> 1.4.0 (*)
++--- project :app (*)
++--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:{strictly 1.8.10} -> 1.8.10 (c)
++--- androidx.core:core-ktx:{strictly 1.9.0} -> 1.9.0 (c)
++--- androidx.lifecycle:lifecycle-runtime-ktx:{strictly 2.6.1} -> 2.6.1 (c)
++--- androidx.activity:activity-compose:{strictly 1.7.2} -> 1.7.2 (c)
++--- androidx.compose.ui:ui:{strictly 1.4.0} -> 1.4.0 (c)
++--- androidx.compose.ui:ui-graphics:{strictly 1.4.0} -> 1.4.0 (c)
++--- androidx.compose.ui:ui-tooling-preview:{strictly 1.4.0} -> 1.4.0 (c)
++--- androidx.compose:compose-bom:{strictly 2023.03.00} -> 2023.03.00 (c)
++--- androidx.compose.material3:material3:{strictly 1.0.0} -> 1.0.0 (c)
++--- junit:junit:4.13.2
+|    \--- org.hamcrest:hamcrest-core:1.3
++--- junit:junit:{strictly 4.13.2} -> 4.13.2 (c)
++--- org.jetbrains.kotlin:kotlin-stdlib:{strictly 1.8.10} -> 1.8.10 (c)
++--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:{strictly 1.8.10} -> 1.8.10 (c)
++--- androidx.annotation:annotation:{strictly 1.5.0} -> 1.5.0 (c)
++--- androidx.core:core:{strictly 1.9.0} -> 1.9.0 (c)
++--- androidx.lifecycle:lifecycle-runtime:{strictly 2.6.1} -> 2.6.1 (c)
++--- org.jetbrains.kotlinx:kotlinx-coroutines-android:{strictly 1.6.4} -> 1.6.4 (c)
++--- androidx.activity:activity-ktx:{strictly 1.7.2} -> 1.7.2 (c)
++--- androidx.compose.runtime:runtime:{strictly 1.4.0} -> 1.4.0 (c)
++--- androidx.compose.runtime:runtime-saveable:{strictly 1.4.0} -> 1.4.0 (c)
++--- androidx.lifecycle:lifecycle-viewmodel:{strictly 2.6.1} -> 2.6.1 (c)
++--- androidx.compose.ui:ui-geometry:{strictly 1.4.0} -> 1.4.0 (c)
++--- androidx.compose.ui:ui-text:{strictly 1.4.0} -> 1.4.0 (c)
++--- androidx.compose.ui:ui-unit:{strictly 1.4.0} -> 1.4.0 (c)
++--- androidx.compose.foundation:foundation:{strictly 1.4.0} -> 1.4.0 (c)
++--- androidx.compose.material:material-icons-core:{strictly 1.4.0} -> 1.4.0 (c)
++--- androidx.compose.material:material-ripple:{strictly 1.4.0} -> 1.4.0 (c)
++--- org.hamcrest:hamcrest-core:{strictly 1.3} -> 1.3 (c)
++--- org.jetbrains.kotlin:kotlin-stdlib-common:{strictly 1.8.10} -> 1.8.10 (c)
++--- org.jetbrains:annotations:{strictly 13.0} -> 13.0 (c)
++--- androidx.annotation:annotation-experimental:{strictly 1.3.0} -> 1.3.0 (c)
++--- androidx.versionedparcelable:versionedparcelable:{strictly 1.1.1} -> 1.1.1 (c)
++--- androidx.arch.core:core-common:{strictly 2.2.0} -> 2.2.0 (c)
++--- androidx.lifecycle:lifecycle-common:{strictly 2.6.1} -> 2.6.1 (c)
++--- org.jetbrains.kotlinx:kotlinx-coroutines-core:{strictly 1.6.4} -> 1.6.4 (c)
++--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:{strictly 1.6.4} -> 1.6.4 (c)
++--- androidx.activity:activity:{strictly 1.7.2} -> 1.7.2 (c)
++--- androidx.lifecycle:lifecycle-viewmodel-ktx:{strictly 2.6.1} -> 2.6.1 (c)
++--- androidx.savedstate:savedstate-ktx:{strictly 1.2.1} -> 1.2.1 (c)
++--- androidx.compose.animation:animation:{strictly 1.4.0} -> 1.4.0 (c)
++--- androidx.collection:collection:{strictly 1.1.0} -> 1.1.0 (c)
++--- org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:{strictly 1.6.4} -> 1.6.4 (c)
++--- androidx.lifecycle:lifecycle-viewmodel-savedstate:{strictly 2.6.1} -> 2.6.1 (c)
++--- androidx.savedstate:savedstate:{strictly 1.2.1} -> 1.2.1 (c)
++--- androidx.compose.animation:animation-core:{strictly 1.4.0} -> 1.4.0 (c)
++--- androidx.compose.foundation:foundation-layout:{strictly 1.4.0} -> 1.4.0 (c)
+\--- androidx.lifecycle:lifecycle-livedata-core:{strictly 2.6.1} -> 2.6.1 (c)
+
+releaseUnitTestCompileOnly (n)
+No dependencies
+
+releaseUnitTestCompileOnlyDependenciesMetadata
+No dependencies
+
+releaseUnitTestImplementation (n)
+No dependencies
+
+releaseUnitTestImplementationDependenciesMetadata
+No dependencies
+
+releaseUnitTestIntransitiveDependenciesMetadata
+No dependencies
+
+releaseUnitTestRuntimeClasspath - Runtime classpath of compilation 'releaseUnitTest' (target  (androidJvm)).
++--- project :app (*)
++--- junit:junit:4.13.2
+|    \--- org.hamcrest:hamcrest-core:1.3
++--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.10
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.10
+|    |    \--- org.jetbrains:annotations:13.0
+|    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.10
+|         \--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
++--- androidx.core:core-ktx:1.9.0
+|    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.7.10 -> 1.8.10 (*)
+|    +--- androidx.core:core:1.9.0
+|    |    +--- androidx.annotation:annotation:1.2.0 -> 1.5.0 (*)
+|    |    +--- androidx.annotation:annotation-experimental:1.3.0
+|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.7.10 -> 1.8.10 (*)
+|    |    +--- androidx.collection:collection:1.0.0 -> 1.1.0
+|    |    |    \--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    +--- androidx.concurrent:concurrent-futures:1.0.0 -> 1.1.0
+|    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    \--- com.google.guava:listenablefuture:1.0
+|    |    +--- androidx.lifecycle:lifecycle-runtime:2.3.1 -> 2.6.1
+|    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    +--- androidx.arch.core:core-common:2.2.0
+|    |    |    |    \--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    +--- androidx.arch.core:core-runtime:2.2.0
+|    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    \--- androidx.arch.core:core-common:2.2.0 (*)
+|    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1
+|    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4
+|    |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4
+|    |    |    |    |    |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.6.4
+|    |    |    |    |    |         +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.6.4
+|    |    |    |    |    |         |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 (c)
+|    |    |    |    |    |         |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.6.4 (c)
+|    |    |    |    |    |         |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4 (c)
+|    |    |    |    |    |         +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.21 -> 1.8.10 (*)
+|    |    |    |    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.6.21 -> 1.8.10
+|    |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.6.4 (*)
+|    |    |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.21 -> 1.8.10 (*)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-process:2.6.1 (c)
+|    |    |    |    \--- androidx.lifecycle:lifecycle-livedata-core:2.6.1 (c)
+|    |    |    +--- androidx.profileinstaller:profileinstaller:1.3.0
+|    |    |    |    +--- androidx.annotation:annotation:1.2.0 -> 1.5.0 (*)
+|    |    |    |    +--- androidx.concurrent:concurrent-futures:1.1.0 (*)
+|    |    |    |    +--- androidx.startup:startup-runtime:1.1.1
+|    |    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    |    \--- androidx.tracing:tracing:1.0.0
+|    |    |    |    |         \--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    \--- com.google.guava:listenablefuture:1.0
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-process:2.6.1 (c)
+|    |    |    \--- androidx.lifecycle:lifecycle-livedata-core:2.6.1 (c)
+|    |    +--- androidx.versionedparcelable:versionedparcelable:1.1.1
+|    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    \--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
+|    |    \--- androidx.core:core-ktx:1.9.0 (c)
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.7.10 -> 1.8.10 (*)
+|    \--- androidx.core:core:1.9.0 (c)
++--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1
+|    +--- androidx.annotation:annotation:1.0.0 -> 1.5.0 (*)
+|    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (*)
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 (*)
+|    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (c)
+|    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (c)
+|    +--- androidx.lifecycle:lifecycle-common:2.6.1 (c)
+|    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1 (c)
+|    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1 (c)
+|    +--- androidx.lifecycle:lifecycle-process:2.6.1 (c)
+|    \--- androidx.lifecycle:lifecycle-livedata-core:2.6.1 (c)
++--- androidx.activity:activity-compose:1.7.2
+|    +--- androidx.activity:activity-ktx:1.7.2
+|    |    +--- androidx.activity:activity:1.7.2
+|    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    +--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
+|    |    |    +--- androidx.core:core:1.8.0 -> 1.9.0 (*)
+|    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (*)
+|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1
+|    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-process:2.6.1 (c)
+|    |    |    |    \--- androidx.lifecycle:lifecycle-livedata-core:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1
+|    |    |    |    +--- androidx.annotation:annotation:1.0.0 -> 1.5.0 (*)
+|    |    |    |    +--- androidx.core:core-ktx:1.2.0 -> 1.9.0 (*)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.6.1
+|    |    |    |    |    +--- androidx.arch.core:core-common:2.1.0 -> 2.2.0 (*)
+|    |    |    |    |    +--- androidx.arch.core:core-runtime:2.1.0 -> 2.2.0 (*)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (*)
+|    |    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (c)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-process:2.6.1 (c)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (c)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (c)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (c)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1 (c)
+|    |    |    |    |    \--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (*)
+|    |    |    |    +--- androidx.savedstate:savedstate:1.2.1
+|    |    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    |    +--- androidx.arch.core:core-common:2.1.0 -> 2.2.0 (*)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (*)
+|    |    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    |    \--- androidx.savedstate:savedstate-ktx:1.2.1 (c)
+|    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 (*)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-process:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (c)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (c)
+|    |    |    |    \--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1 (c)
+|    |    |    +--- androidx.profileinstaller:profileinstaller:1.3.0 (*)
+|    |    |    +--- androidx.savedstate:savedstate:1.2.1 (*)
+|    |    |    +--- androidx.tracing:tracing:1.0.0 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    +--- androidx.activity:activity-compose:1.7.2 (c)
+|    |    |    \--- androidx.activity:activity-ktx:1.7.2 (c)
+|    |    +--- androidx.core:core-ktx:1.1.0 -> 1.9.0 (*)
+|    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (*)
+|    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1
+|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 (*)
+|    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1 (c)
+|    |    |    +--- androidx.lifecycle:lifecycle-process:2.6.1 (c)
+|    |    |    \--- androidx.lifecycle:lifecycle-livedata-core:2.6.1 (c)
+|    |    +--- androidx.savedstate:savedstate-ktx:1.2.1
+|    |    |    +--- androidx.savedstate:savedstate:1.2.1 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    \--- androidx.savedstate:savedstate:1.2.1 (c)
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    +--- androidx.activity:activity:1.7.2 (c)
+|    |    \--- androidx.activity:activity-compose:1.7.2 (c)
+|    +--- androidx.compose.runtime:runtime:1.0.1 -> 1.4.0
+|    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 (*)
+|    |    \--- androidx.compose.runtime:runtime-saveable:1.4.0 (c)
+|    +--- androidx.compose.runtime:runtime-saveable:1.0.1 -> 1.4.0
+|    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    +--- androidx.compose.runtime:runtime:1.4.0 (*)
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    \--- androidx.compose.runtime:runtime:1.4.0 (c)
+|    +--- androidx.compose.ui:ui:1.0.1 -> 1.4.0
+|    |    +--- androidx.activity:activity-ktx:1.7.0 -> 1.7.2 (*)
+|    |    +--- androidx.annotation:annotation:1.5.0 (*)
+|    |    +--- androidx.autofill:autofill:1.0.0
+|    |    |    \--- androidx.core:core:1.1.0 -> 1.9.0 (*)
+|    |    +--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
+|    |    +--- androidx.compose.runtime:runtime:1.4.0 (*)
+|    |    +--- androidx.compose.runtime:runtime-saveable:1.4.0 (*)
+|    |    +--- androidx.compose.ui:ui-geometry:1.4.0
+|    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0 (*)
+|    |    |    +--- androidx.compose.ui:ui-util:1.4.0
+|    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    |    |    |    \--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    |    |    \--- androidx.compose.ui:ui-util:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-graphics:1.4.0
+|    |    |    +--- androidx.annotation:annotation:1.2.0 -> 1.5.0 (*)
+|    |    |    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0 (*)
+|    |    |    +--- androidx.compose.ui:ui-unit:1.4.0
+|    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    |    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0 (*)
+|    |    |    |    +--- androidx.compose.ui:ui-geometry:1.4.0 (*)
+|    |    |    |    +--- androidx.compose.ui:ui-util:1.4.0 (*)
+|    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    |    |    |    +--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    |    |    |    \--- androidx.compose.ui:ui-util:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-util:1.4.0 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.10
+|    |    |    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    |    |    \--- androidx.compose.ui:ui-util:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-text:1.4.0
+|    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+|    |    |    +--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
+|    |    |    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0 (*)
+|    |    |    +--- androidx.compose.runtime:runtime-saveable:1.2.1 -> 1.4.0 (*)
+|    |    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (*)
+|    |    |    +--- androidx.compose.ui:ui-unit:1.4.0 (*)
+|    |    |    +--- androidx.compose.ui:ui-util:1.4.0 (*)
+|    |    |    +--- androidx.core:core:1.7.0 -> 1.9.0 (*)
+|    |    |    +--- androidx.emoji2:emoji2:1.2.0 -> 1.3.0
+|    |    |    |    +--- androidx.annotation:annotation:1.2.0 -> 1.5.0 (*)
+|    |    |    |    +--- androidx.collection:collection:1.1.0 (*)
+|    |    |    |    +--- androidx.core:core:1.3.0 -> 1.9.0 (*)
+|    |    |    |    +--- androidx.lifecycle:lifecycle-process:2.4.1 -> 2.6.1
+|    |    |    |    |    +--- androidx.annotation:annotation:1.2.0 -> 1.5.0 (*)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (*)
+|    |    |    |    |    +--- androidx.startup:startup-runtime:1.1.1 (*)
+|    |    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 (c)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.6.1 (c)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (c)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.6.1 (c)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (c)
+|    |    |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1 (c)
+|    |    |    |    |    \--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1 (c)
+|    |    |    |    \--- androidx.startup:startup-runtime:1.0.0 -> 1.1.1 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.10
+|    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4 (*)
+|    |    |    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    |    |    +--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    |    |    \--- androidx.compose.ui:ui-util:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-unit:1.4.0 (*)
+|    |    +--- androidx.compose.ui:ui-util:1.4.0 (*)
+|    |    +--- androidx.core:core:1.9.0 (*)
+|    |    +--- androidx.customview:customview-poolingcontainer:1.0.0
+|    |    |    +--- androidx.core:core-ktx:1.5.0 -> 1.9.0 (*)
+|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.6.21 -> 1.8.10 (*)
+|    |    +--- androidx.emoji2:emoji2:1.2.0 -> 1.3.0 (*)
+|    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.1 (*)
+|    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (*)
+|    |    +--- androidx.profileinstaller:profileinstaller:1.3.0 (*)
+|    |    +--- androidx.savedstate:savedstate-ktx:1.2.1 (*)
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.10
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 (*)
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4 (*)
+|    |    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    |    +--- androidx.compose.ui:ui-util:1.4.0 (c)
+|    |    \--- androidx.compose.foundation:foundation:1.4.0 (c)
+|    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.1 (*)
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    +--- androidx.activity:activity-ktx:1.7.2 (c)
+|    \--- androidx.activity:activity:1.7.2 (c)
++--- androidx.compose:compose-bom:2023.03.00
+|    +--- androidx.compose.material3:material3:1.0.0 (c)
+|    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-tooling-preview:1.4.0 (c)
+|    +--- androidx.compose.runtime:runtime:1.4.0 (c)
+|    +--- androidx.compose.runtime:runtime-saveable:1.4.0 (c)
+|    +--- androidx.compose.animation:animation-core:1.4.0 (c)
+|    +--- androidx.compose.foundation:foundation:1.4.0 (c)
+|    +--- androidx.compose.foundation:foundation-layout:1.4.0 (c)
+|    +--- androidx.compose.material:material-icons-core:1.4.0 (c)
+|    +--- androidx.compose.material:material-ripple:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-util:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    \--- androidx.compose.animation:animation:1.4.0 (c)
++--- androidx.compose.ui:ui -> 1.4.0 (*)
++--- androidx.compose.ui:ui-graphics -> 1.4.0 (*)
++--- androidx.compose.ui:ui-tooling-preview -> 1.4.0
+|    +--- androidx.annotation:annotation:1.2.0 -> 1.5.0 (*)
+|    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0 (*)
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+|    +--- androidx.compose.ui:ui:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-geometry:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-graphics:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-text:1.4.0 (c)
+|    +--- androidx.compose.ui:ui-unit:1.4.0 (c)
+|    \--- androidx.compose.ui:ui-util:1.4.0 (c)
+\--- androidx.compose.material3:material3 -> 1.0.0
+     +--- androidx.compose.animation:animation-core:1.1.1 -> 1.4.0
+     |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+     |    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0 (*)
+     |    +--- androidx.compose.ui:ui:1.2.1 -> 1.4.0 (*)
+     |    +--- androidx.compose.ui:ui-unit:1.2.1 -> 1.4.0 (*)
+     |    +--- androidx.compose.ui:ui-util:1.2.1 -> 1.4.0 (*)
+     |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+     |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4 (*)
+     |    \--- androidx.compose.animation:animation:1.4.0 (c)
+     +--- androidx.compose.foundation:foundation:1.2.0 -> 1.4.0
+     |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+     |    +--- androidx.compose.animation:animation:1.2.1 -> 1.4.0
+     |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+     |    |    +--- androidx.compose.animation:animation-core:1.4.0 (*)
+     |    |    +--- androidx.compose.foundation:foundation-layout:1.2.1 -> 1.4.0
+     |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.5.0 (*)
+     |    |    |    +--- androidx.compose.animation:animation-core:1.2.1 -> 1.4.0 (*)
+     |    |    |    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0 (*)
+     |    |    |    +--- androidx.compose.ui:ui:1.2.1 -> 1.4.0 (*)
+     |    |    |    +--- androidx.compose.ui:ui-unit:1.2.1 -> 1.4.0 (*)
+     |    |    |    +--- androidx.compose.ui:ui-util:1.2.1 -> 1.4.0 (*)
+     |    |    |    +--- androidx.core:core:1.7.0 -> 1.9.0 (*)
+     |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.10
+     |    |    |    \--- androidx.compose.foundation:foundation:1.4.0 (c)
+     |    |    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0 (*)
+     |    |    +--- androidx.compose.ui:ui:1.2.1 -> 1.4.0 (*)
+     |    |    +--- androidx.compose.ui:ui-geometry:1.2.1 -> 1.4.0 (*)
+     |    |    +--- androidx.compose.ui:ui-util:1.2.1 -> 1.4.0 (*)
+     |    |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.10
+     |    |    \--- androidx.compose.animation:animation-core:1.4.0 (c)
+     |    +--- androidx.compose.foundation:foundation-layout:1.4.0 (*)
+     |    +--- androidx.compose.runtime:runtime:1.4.0 (*)
+     |    +--- androidx.compose.ui:ui:1.4.0 (*)
+     |    +--- androidx.compose.ui:ui-graphics:1.2.1 -> 1.4.0 (*)
+     |    +--- androidx.compose.ui:ui-text:1.2.1 -> 1.4.0 (*)
+     |    +--- androidx.compose.ui:ui-util:1.2.1 -> 1.4.0 (*)
+     |    +--- androidx.emoji2:emoji2:1.3.0 (*)
+     |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.10
+     |    \--- androidx.compose.foundation:foundation-layout:1.4.0 (c)
+     +--- androidx.compose.foundation:foundation-layout:1.2.0 -> 1.4.0 (*)
+     +--- androidx.compose.material:material-icons-core:1.0.2 -> 1.4.0
+     |    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0 (*)
+     |    +--- androidx.compose.ui:ui:1.2.1 -> 1.4.0 (*)
+     |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+     |    \--- androidx.compose.material:material-ripple:1.4.0 (c)
+     +--- androidx.compose.material:material-ripple:1.0.0 -> 1.4.0
+     |    +--- androidx.compose.animation:animation:1.2.1 -> 1.4.0 (*)
+     |    +--- androidx.compose.foundation:foundation:1.2.1 -> 1.4.0 (*)
+     |    +--- androidx.compose.runtime:runtime:1.2.1 -> 1.4.0 (*)
+     |    +--- androidx.compose.ui:ui-util:1.2.1 -> 1.4.0 (*)
+     |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.10
+     |    \--- androidx.compose.material:material-icons-core:1.4.0 (c)
+     +--- androidx.compose.runtime:runtime:1.0.1 -> 1.4.0 (*)
+     +--- androidx.compose.ui:ui:1.3.0 -> 1.4.0 (*)
+     +--- androidx.compose.ui:ui-graphics:1.0.1 -> 1.4.0 (*)
+     +--- androidx.compose.ui:ui-text:1.3.0 -> 1.4.0 (*)
+     +--- androidx.compose.ui:ui-util:1.0.0 -> 1.4.0 (*)
+     +--- androidx.lifecycle:lifecycle-runtime:2.3.0 -> 2.6.1 (*)
+     +--- androidx.lifecycle:lifecycle-viewmodel:2.3.0 -> 2.6.1 (*)
+     +--- androidx.savedstate:savedstate-ktx:1.2.0 -> 1.2.1 (*)
+     \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.7.10 -> 1.8.10
+
+releaseUnitTestRuntimeOnly (n)
+No dependencies
+
+releaseUnitTestRuntimeOnlyDependenciesMetadata
+No dependencies
+
+releaseWearApp - Link to a wear app to embed for object 'release'. (n)
+No dependencies
+
+releaseWearBundling - Resolved Configuration for wear app bundling for variant: release
+No dependencies
+
+runtimeOnly - Runtime only dependencies for 'main' sources. (n)
+No dependencies
+
+runtimeOnlyDependenciesMetadata
+No dependencies
+
+testAnnotationProcessor - Classpath for the annotation processor for 'test'. (n)
+No dependencies
+
+testApi (n)
+No dependencies
+
+testApiDependenciesMetadata
+No dependencies
+
+testCompileOnly - Compile only dependencies for 'test' sources. (n)
+No dependencies
+
+testCompileOnlyDependenciesMetadata
+No dependencies
+
+testDebugAnnotationProcessor - Classpath for the annotation processor for 'testDebug'. (n)
+No dependencies
+
+testDebugApi (n)
+No dependencies
+
+testDebugApiDependenciesMetadata
+No dependencies
+
+testDebugCompileOnly - Compile only dependencies for 'testDebug' sources. (n)
+No dependencies
+
+testDebugCompileOnlyDependenciesMetadata
+No dependencies
+
+testDebugImplementation - Implementation only dependencies for 'testDebug' sources. (n)
+No dependencies
+
+testDebugImplementationDependenciesMetadata
+No dependencies
+
+testDebugIntransitiveDependenciesMetadata
+No dependencies
+
+testDebugRuntimeOnly - Runtime only dependencies for 'testDebug' sources. (n)
+No dependencies
+
+testDebugRuntimeOnlyDependenciesMetadata
+No dependencies
+
+testDebugWearApp - Link to a wear app to embed for object 'testDebug'. (n)
+No dependencies
+
+testFixturesAnnotationProcessor - Classpath for the annotation processor for 'testFixtures'. (n)
+No dependencies
+
+testFixturesApi - API dependencies for 'testFixtures' sources. (n)
+No dependencies
+
+testFixturesApiDependenciesMetadata
+No dependencies
+
+testFixturesCompileOnly - Compile only dependencies for 'testFixtures' sources. (n)
+No dependencies
+
+testFixturesCompileOnlyDependenciesMetadata
+No dependencies
+
+testFixturesDebugAnnotationProcessor - Classpath for the annotation processor for 'testFixturesDebug'. (n)
+No dependencies
+
+testFixturesDebugApi - API dependencies for 'testFixturesDebug' sources. (n)
+No dependencies
+
+testFixturesDebugApiDependenciesMetadata
+No dependencies
+
+testFixturesDebugCompileOnly - Compile only dependencies for 'testFixturesDebug' sources. (n)
+No dependencies
+
+testFixturesDebugCompileOnlyDependenciesMetadata
+No dependencies
+
+testFixturesDebugImplementation - Implementation only dependencies for 'testFixturesDebug' sources. (n)
+No dependencies
+
+testFixturesDebugImplementationDependenciesMetadata
+No dependencies
+
+testFixturesDebugIntransitiveDependenciesMetadata
+No dependencies
+
+testFixturesDebugRuntimeOnly - Runtime only dependencies for 'testFixturesDebug' sources. (n)
+No dependencies
+
+testFixturesDebugRuntimeOnlyDependenciesMetadata
+No dependencies
+
+testFixturesDebugWearApp - Link to a wear app to embed for object 'testFixturesDebug'. (n)
+No dependencies
+
+testFixturesImplementation - Implementation only dependencies for 'testFixtures' sources. (n)
+No dependencies
+
+testFixturesImplementationDependenciesMetadata
+No dependencies
+
+testFixturesIntransitiveDependenciesMetadata
+No dependencies
+
+testFixturesReleaseAnnotationProcessor - Classpath for the annotation processor for 'testFixturesRelease'. (n)
+No dependencies
+
+testFixturesReleaseApi - API dependencies for 'testFixturesRelease' sources. (n)
+No dependencies
+
+testFixturesReleaseApiDependenciesMetadata
+No dependencies
+
+testFixturesReleaseCompileOnly - Compile only dependencies for 'testFixturesRelease' sources. (n)
+No dependencies
+
+testFixturesReleaseCompileOnlyDependenciesMetadata
+No dependencies
+
+testFixturesReleaseImplementation - Implementation only dependencies for 'testFixturesRelease' sources. (n)
+No dependencies
+
+testFixturesReleaseImplementationDependenciesMetadata
+No dependencies
+
+testFixturesReleaseIntransitiveDependenciesMetadata
+No dependencies
+
+testFixturesReleaseRuntimeOnly - Runtime only dependencies for 'testFixturesRelease' sources. (n)
+No dependencies
+
+testFixturesReleaseRuntimeOnlyDependenciesMetadata
+No dependencies
+
+testFixturesReleaseWearApp - Link to a wear app to embed for object 'testFixturesRelease'. (n)
+No dependencies
+
+testFixturesRuntimeOnly - Runtime only dependencies for 'testFixtures' sources. (n)
+No dependencies
+
+testFixturesRuntimeOnlyDependenciesMetadata
+No dependencies
+
+testFixturesWearApp - Link to a wear app to embed for object 'testFixtures'. (n)
+No dependencies
+
+testImplementation - Implementation only dependencies for 'test' sources. (n)
+\--- junit:junit:4.13.2 (n)
+
+testImplementationDependenciesMetadata
+\--- junit:junit:4.13.2
+     \--- org.hamcrest:hamcrest-core:1.3
+
+testIntransitiveDependenciesMetadata
+No dependencies
+
+testReleaseAnnotationProcessor - Classpath for the annotation processor for 'testRelease'. (n)
+No dependencies
+
+testReleaseApi (n)
+No dependencies
+
+testReleaseApiDependenciesMetadata
+No dependencies
+
+testReleaseCompileOnly - Compile only dependencies for 'testRelease' sources. (n)
+No dependencies
+
+testReleaseCompileOnlyDependenciesMetadata
+No dependencies
+
+testReleaseImplementation - Implementation only dependencies for 'testRelease' sources. (n)
+No dependencies
+
+testReleaseImplementationDependenciesMetadata
+No dependencies
+
+testReleaseIntransitiveDependenciesMetadata
+No dependencies
+
+testReleaseRuntimeOnly - Runtime only dependencies for 'testRelease' sources. (n)
+No dependencies
+
+testReleaseRuntimeOnlyDependenciesMetadata
+No dependencies
+
+testReleaseWearApp - Link to a wear app to embed for object 'testRelease'. (n)
+No dependencies
+
+testRuntimeOnly - Runtime only dependencies for 'test' sources. (n)
+No dependencies
+
+testRuntimeOnlyDependenciesMetadata
+No dependencies
+
+testWearApp - Link to a wear app to embed for object 'test'. (n)
+No dependencies
+
+wearApp - Link to a wear app to embed for object 'main'. (n)
+No dependencies
+
+(c) - A dependency constraint, not a dependency. The dependency affected by the constraint occurs elsewhere in the tree.
+(*) - Indicates repeated occurrences of a transitive dependency subtree. Gradle expands transitive dependency subtrees only once per project; repeat occurrences only display the root of the subtree, followed by this annotation.
+
+(n) - A dependency or dependency configuration that cannot be resolved.
+
+A web-based, searchable dependency report is available by adding the --scan option.

--- a/test/data/gradle-properties-android.txt
+++ b/test/data/gradle-properties-android.txt
@@ -1,0 +1,96 @@
+
+------------------------------------------------------------
+Root project 'CdxgenAndroidTest'
+------------------------------------------------------------
+
+AGP_INTERNAL__MIN_PLUGIN_VERSION_CHECK_STARTED: true
+allprojects: [root project 'CdxgenAndroidTest', project ':app', project ':data']
+android.nonTransitiveRClass: true
+android.useAndroidX: true
+ant: org.gradle.api.internal.project.DefaultAntBuilder@3286478f
+antBuilderFactory: org.gradle.api.internal.project.DefaultAntBuilderFactory@2d411aea
+artifacts: org.gradle.api.internal.artifacts.dsl.DefaultArtifactHandler_Decorated@101b4ea4
+asDynamicObject: DynamicObject for root project 'CdxgenAndroidTest'
+baseClassLoaderScope: org.gradle.api.internal.initialization.DefaultClassLoaderScope@5fd337d3
+buildDir: /mnt/work/sandbox/cdxgenMultiModuleSample/build
+buildFile: /mnt/work/sandbox/cdxgenMultiModuleSample/build.gradle.kts
+buildPath: :
+buildScriptSource: org.gradle.groovy.scripts.TextResourceScriptSource@5f69a999
+buildscript: org.gradle.api.internal.initialization.DefaultScriptHandler@7ada6ed4
+childProjects: {app=project ':app', data=project ':data'}
+childProjectsUnchecked: {app=project ':app', data=project ':data'}
+class: class org.gradle.api.internal.project.DefaultProject_Decorated
+classLoaderScope: org.gradle.api.internal.initialization.DefaultClassLoaderScope@5ea408b9
+components: SoftwareComponentInternal set
+configurationActions: org.gradle.configuration.project.DefaultProjectConfigurationActionContainer@30fe7145
+configurationTargetIdentifier: org.gradle.configuration.ConfigurationTargetIdentifier$1@76d5a526
+configurations: configuration container
+convention: org.gradle.internal.extensibility.DefaultConvention@6462ff04
+crossProjectModelAccess: org.gradle.api.internal.project.DefaultCrossProjectModelAccess@4de79192
+defaultTasks: []
+deferredProjectConfiguration: org.gradle.api.internal.project.DeferredProjectConfiguration@ed0b532
+dependencies: org.gradle.api.internal.artifacts.dsl.dependencies.DefaultDependencyHandler_Decorated@5577dd5b
+dependencyFactory: org.gradle.api.internal.artifacts.DefaultDependencyFactory@269e922e
+dependencyLocking: org.gradle.internal.locking.DefaultDependencyLockingHandler_Decorated@5784fc6e
+dependencyMetaDataProvider: org.gradle.internal.service.scopes.ProjectScopeServices$ProjectBackedModuleMetaDataProvider@5c76aa89
+depth: 0
+description: null
+detachedState: false
+displayName: root project 'CdxgenAndroidTest'
+ext: org.gradle.internal.extensibility.DefaultExtraPropertiesExtension@37002959
+extensions: org.gradle.internal.extensibility.DefaultConvention@6462ff04
+fileOperations: org.gradle.api.internal.file.DefaultFileOperations@65ddc275
+fileResolver: org.gradle.api.internal.file.BaseDirFileResolver@15ca352c
+gradle: build 'CdxgenAndroidTest'
+group: 
+identityPath: :
+inheritedScope: org.gradle.internal.extensibility.ExtensibleDynamicObject$InheritedDynamicObject@7c81e7fe
+internalStatus: property(java.lang.Object, fixed(class java.lang.String, release))
+kotlin.code.style: official
+kotlin.plugin.loaded.in.projects.1.8.10: :app
+kotlin.properties.provider: org.jetbrains.kotlin.gradle.plugin.PropertiesProvider@4afd53d6
+layout: org.gradle.api.internal.file.DefaultProjectLayout@4138ee96
+listenerBuildOperationDecorator: org.gradle.configuration.internal.DefaultListenerBuildOperationDecorator@59fc0c8
+logger: org.gradle.internal.logging.slf4j.OutputEventListenerBackedLogger@1c9c30d5
+logging: org.gradle.internal.logging.services.DefaultLoggingManager@76d26992
+model: root project 'CdxgenAndroidTest'
+modelIdentityDisplayName: null
+modelRegistry: org.gradle.model.internal.registry.DefaultModelRegistry@5691f77d
+name: CdxgenAndroidTest
+normalization: org.gradle.normalization.internal.DefaultInputNormalizationHandler_Decorated@50dbff67
+objects: org.gradle.api.internal.model.DefaultObjectFactory@2bb9fc34
+org.gradle.jvmargs: -Xmx2048m -Dfile.encoding=UTF-8
+owner: root project 'CdxgenAndroidTest'
+parent: null
+parentIdentifier: null
+path: :
+pluginContext: false
+pluginManager: org.gradle.api.internal.plugins.DefaultPluginManager_Decorated@4e429e28
+plugins: [org.gradle.api.plugins.HelpTasksPlugin$Inject@32eaf833, org.gradle.buildinit.plugins.BuildInitPlugin$Inject@1c312a56, org.gradle.buildinit.plugins.WrapperPlugin$Inject@2f83378, org.gradle.kotlin.dsl.provider.plugins.KotlinScriptRootPlugin$Inject@49ee21ac, org.gradle.kotlin.dsl.provider.plugins.KotlinScriptBasePlugin$Inject@2583d184]
+processOperations: org.gradle.process.internal.DefaultExecActionFactory$DecoratingExecActionFactory@1731a282
+project: root project 'CdxgenAndroidTest'
+projectConfigurator: org.gradle.api.internal.project.BuildOperationCrossProjectConfigurator@181e47c4
+projectDir: /mnt/work/sandbox/cdxgenMultiModuleSample
+projectEvaluationBroadcaster: ProjectEvaluationListener broadcast
+projectEvaluator: org.gradle.configuration.project.LifecycleProjectEvaluator@7ca240af
+projectPath: :
+properties: {...}
+providers: org.gradle.api.internal.provider.DefaultProviderFactory_Decorated@264b32cd
+repositories: repository container
+resources: org.gradle.api.internal.resources.DefaultResourceHandler@3cf4b134
+rootDir: /mnt/work/sandbox/cdxgenMultiModuleSample
+rootProject: root project 'CdxgenAndroidTest'
+rootScript: false
+script: false
+scriptHandlerFactory: org.gradle.api.internal.initialization.DefaultScriptHandlerFactory@563ef109
+scriptPluginFactory: org.gradle.configuration.ScriptPluginFactorySelector@38777459
+serviceRegistryFactory: org.gradle.internal.service.scopes.BuildScopeServiceRegistryFactory@4755f4c0
+services: ProjectScopeServices
+standardOutputCapture: org.gradle.internal.logging.services.DefaultLoggingManager@76d26992
+state: project state 'EXECUTED'
+status: release
+subprojects: [project ':app', project ':data']
+taskDependencyFactory: org.gradle.api.internal.tasks.DefaultTaskDependencyFactory@5eb1800f
+taskThatOwnsThisObject: null
+tasks: task set
+version: unspecified

--- a/utils.js
+++ b/utils.js
@@ -1676,7 +1676,8 @@ export const parseGradleProjects = function (rawOutput) {
           const projName = tmpB[1].split(" ")[0].replace(/'/g, "");
           // Include all projects including test projects
           if (projName.startsWith(":")) {
-            projects.add(projName);
+            // Handle the case where the project name could have a space. Eg: +--- project :app (*)
+            projects.add(projName.split(" ")[0]);
           }
         }
       } else if (l.includes("--- project ")) {
@@ -1684,7 +1685,7 @@ export const parseGradleProjects = function (rawOutput) {
         if (tmpB && tmpB.length > 1) {
           const projName = tmpB[1];
           if (projName.startsWith(":")) {
-            projects.add(projName);
+            projects.add(projName.split(" ")[0]);
           }
         }
       }
@@ -1726,7 +1727,7 @@ export const parseGradleProperties = function (rawOutput) {
           const spStrs = tmpB[1].replace(/[[\]']/g, "").split(", ");
           const tmpprojects = spStrs
             .flatMap((s) => s.replace("project ", ""))
-            .filter((s) => ![":app", ""].includes(s.trim()));
+            .filter((s) => ![""].includes(s.trim()));
           tmpprojects.forEach(projects.add, projects);
         }
       }

--- a/utils.test.js
+++ b/utils.test.js
@@ -295,6 +295,10 @@ test("parse gradle dependencies", () => {
   );
   expect(parsedList.pkgList.length).toEqual(152);
   expect(parsedList.dependenciesList.length).toEqual(153);
+  parsedList = parseGradleDep(
+    readFileSync("./test/data/gradle-android-app.dep", { encoding: "utf-8" })
+  );
+  expect(parsedList.pkgList.length).toEqual(101);
 });
 
 test("parse gradle projects", () => {
@@ -317,6 +321,11 @@ test("parse gradle projects", () => {
   );
   expect(retMap.rootProject).toEqual("fineract");
   expect(retMap.projects.length).toEqual(22);
+  retMap = parseGradleProjects(
+    readFileSync("./test/data/gradle-android-app.dep", { encoding: "utf-8" })
+  );
+  expect(retMap.rootProject).toEqual("root");
+  expect(retMap.projects).toEqual([":app"]);
 });
 
 test("parse gradle properties", () => {
@@ -366,7 +375,7 @@ test("parse gradle properties", () => {
   );
   expect(retMap).toEqual({
     rootProject: "java-test",
-    projects: [],
+    projects: [":app"],
     metadata: {
       group: "com.ajmalab.demo",
       version: "latest",
@@ -411,6 +420,13 @@ test("parse gradle properties", () => {
   );
   expect(retMap.rootProject).toEqual("elasticsearch");
   expect(retMap.projects.length).toEqual(409);
+  retMap = parseGradleProperties(
+    readFileSync("./test/data/gradle-properties-android.txt", {
+      encoding: "utf-8"
+    })
+  );
+  expect(retMap.rootProject).toEqual("CdxgenAndroidTest");
+  expect(retMap.projects.length).toEqual(2);
 });
 
 test("parse maven tree", () => {


### PR DESCRIPTION
Fixes #448 
Handles root project with unknown version (Eg: :app (*))

@ptrkaz Could you kindly test this PR?
@ajmalab We added filtering of root projects named `app` for one of your test cases called java-test. Any idea what the original issue was? Could you check this branch against other gradle projects?