### PR TITLE
Adds jws verification example to the readme. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,9 +381,32 @@ cdxgen can sign the generated SBoM json file to increase authenticity and non-re
 - SBOM_SIGN_PRIVATE_KEY: Location to the RSA private key
 - SBOM_SIGN_PUBLIC_KEY: Optional. Location to the RSA public key
 
-To generate test public/private key pairs, you can run cdxgen by passing the argument `--generate-key-and-sign`. The generated json file would have an attribute called `signature` which could be used for validation. [jwt.io](jwt.io) is a known site that could be used for such signature validation.
+To generate test public/private key pairs, you can run cdxgen by passing the argument `--generate-key-and-sign`. The generated json file would have an attribute called `signature` which could be used for validation. [jwt.io](https://jwt.io) is a known site that could be used for such signature validation.
 
 ![SBoM signing](sbom-sign.jpg)
+
+### Verifying the signature (Node.js example)
+
+There are many [libraries](https://jwt.io/#libraries-io) available to validate JSON Web Tokens. Below is a javascript example.
+
+```js
+# npm install jws
+const jws = require("jws");
+const fs = require("fs");
+// Location of the SBoM json file
+const bomJsonFile = "bom.json";
+// Location of the public key
+const publicKeyFile = "public.key";
+const bomJson = JSON.parse(fs.readFileSync(bomJsonFile, "utf8"));
+// Retrieve the signature
+const bomSignature = bomJson.signature.value;
+const validationResult = jws.verify(bomSignature, bomJson.signature.algorithm, fs.readFileSync(publicKeyFile, "utf8"));
+if (validationResult) {
+  console.log("Signature is valid!");
+} else {
+  console.log("SBoM signature is invalid :(");
+}
+```
 
 ## Automatic services detection
 

--- a/bin/cdxgen.js
+++ b/bin/cdxgen.js
@@ -266,9 +266,10 @@ const checkPermissions = (filePath) => {
           }
           let privateKeyToUse = undefined;
           let jwkPublicKey = undefined;
+          let publicKeyFile = undefined;
           if (args.generateKeyAndSign) {
             const jdirName = dirname(jsonFile);
-            const publicKeyFile = join(jdirName, "public.key");
+            publicKeyFile = join(jdirName, "public.key");
             const privateKeyFile = join(jdirName, "private.key");
             const { privateKey, publicKey } = crypto.generateKeyPairSync(
               "rsa",
@@ -331,6 +332,26 @@ const checkPermissions = (filePath) => {
                 jsonFile,
                 JSON.stringify(bomJsonUnsignedObj, null, 2)
               );
+              if (publicKeyFile) {
+                // Verifying this signature
+                const signatureVerification = jws.verify(
+                  signature,
+                  alg,
+                  fs.readFileSync(publicKeyFile, "utf8")
+                );
+                if (signatureVerification) {
+                  console.log(
+                    "SBoM signature is verifiable with the public key and the algorithm",
+                    publicKeyFile,
+                    alg
+                  );
+                } else {
+                  console.log("SBoM signature verification was unsuccessful");
+                  console.log(
+                    "Check if the public key was exported in PEM format"
+                  );
+                }
+              }
             }
           } catch (ex) {
             console.log("SBoM signing was unsuccessful", ex);


### PR DESCRIPTION
Enabled self-verification if the public key file is present

Fixes #440 

@troy256 could you let me know if you require samples in any other language?