### PR TITLE
Fixes #464: Updated the regex to support 'relocation' of a complete component

### DIFF
--- a/test/data/gradle-android-jetify.dep
+++ b/test/data/gradle-android-jetify.dep
@@ -1,0 +1,2 @@
+\--- com.android.support:appcompat-v7:26.1.0 -> androidx.appcompat:appcompat:1.2.0 (*)
+

--- a/utils.js
+++ b/utils.js
@@ -1449,7 +1449,7 @@ export const parseGradleDep = function (
     }
     let stack = [last_purl];
     const depRegex =
-      /^.*?--- +(?<group>[^\s:]+):(?<name>[^\s:]+)(?::(?:{strictly [[]?)?(?<versionspecified>[^,\s:}]+))?(?:})?(?:[^->]* +-> +(?<versionoverride>[^\s:]+))?/gm;
+      /^.*?--- +(?<groupspecified>[^\s:]+):(?<namespecified>[^\s:]+)(?::(?:{strictly [[]?)?(?<versionspecified>[^,\s:}]+))?(?:})?(?:[^->]* +-> +(?:(?<groupoverride>[^\s:]+):(?<nameoverride>[^\s:]+):)?(?<versionoverride>[^\s:]+))?/gm;
     for (const rline of rawOutput.split("\n")) {
       if (!rline) {
         continue;
@@ -1489,9 +1489,11 @@ export const parseGradleDep = function (
         }
       }
       while ((match = depRegex.exec(rline))) {
-        const [line, group, name, versionspecified, versionoverride] = match;
+        const [line, groupspecified, namespecified, versionspecified, groupoverride, nameoverride, versionoverride] = match;
+        const group = groupoverride || groupspecified;
+        const name = nameoverride || namespecified;
         const version = versionoverride || versionspecified;
-        const level = line.split(group)[0].length / 5;
+        const level = line.split(groupspecified)[0].length / 5;
         if (version !== undefined) {
           let purlString = new PackageURL(
             "maven",

--- a/utils.test.js
+++ b/utils.test.js
@@ -299,6 +299,18 @@ test("parse gradle dependencies", () => {
     readFileSync("./test/data/gradle-android-app.dep", { encoding: "utf-8" })
   );
   expect(parsedList.pkgList.length).toEqual(101);
+  parsedList = parseGradleDep(
+    readFileSync("./test/data/gradle-android-jetify.dep", { encoding: "utf-8" })
+  );
+  expect(parsedList.pkgList.length).toEqual(1);
+  expect(parsedList.pkgList).toEqual([
+    {
+      group: "androidx.appcompat",
+      name: "appcompat",
+      version: "1.2.0",
+      qualifiers: { type: "jar" }
+    }
+  ]);
 });
 
 test("parse gradle projects", () => {


### PR DESCRIPTION
Fixes #464: Updated the regex to support 'relocation' of a complete component, not just the version.