### PR TITLE
Handle Gradle sub-projects correctly

### DIFF
--- a/index.js
+++ b/index.js
@@ -1448,6 +1448,11 @@ export const createJavaBom = async (path, options) => {
         }
       } // for
       if (pkgList.length) {
+        if (parentComponent.components && parentComponent.components.length) {
+          for (const subProj of parentComponent.components) {
+            pkgList = pkgList.filter(pkg => !(pkg.group === subProj.group && pkg.name === subProj.name && pkg.version === subProj.version))
+          }
+        }
         console.log(
           "Obtained",
           pkgList.length,

--- a/index.js
+++ b/index.js
@@ -1450,7 +1450,7 @@ export const createJavaBom = async (path, options) => {
       if (pkgList.length) {
         if (parentComponent.components && parentComponent.components.length) {
           for (const subProj of parentComponent.components) {
-            pkgList = pkgList.filter(pkg => !(pkg.group === subProj.group && pkg.name === subProj.name && pkg.version === subProj.version))
+            pkgList = pkgList.filter(pkg => pkg["bom-ref"] !== subProj["bom-ref"]);
           }
         }
         console.log(

--- a/utils.js
+++ b/utils.js
@@ -1516,6 +1516,8 @@ export const parseGradleDep = function (
               version: version !== undefined ? version : rootProjectVersion,
               qualifiers: { type: "jar" }
             };
+            adep["purl"] = purlString;
+            adep["bom-ref"] = purlString;
             if (scope) {
               adep["scope"] = scope;
             }

--- a/utils.js
+++ b/utils.js
@@ -1450,7 +1450,7 @@ export const parseGradleDep = function (
     }
     let stack = [last_purl];
     const depRegex =
-      /^.*?--- +(?<groupspecified>[^\s:]+):(?<namespecified>[^\s:]+)(?::(?:{strictly [[]?)?(?<versionspecified>[^,\s:}]+))?(?:})?(?:[^->]* +-> +(?:(?<groupoverride>[^\s:]+):(?<nameoverride>[^\s:]+):)?(?<versionoverride>[^\s:]+))?/gm;
+      /^.*?--- +(?<groupspecified>[^\s:]+) ?:(?<namespecified>[^\s:]+)(?::(?:{strictly [[]?)?(?<versionspecified>[^,\s:}]+))?(?:})?(?:[^->]* +-> +(?:(?<groupoverride>[^\s:]+):(?<nameoverride>[^\s:]+):)?(?<versionoverride>[^\s:]+))?/gm;
     for (const rline of rawOutput.split("\n")) {
       if (!rline) {
         continue;
@@ -1468,16 +1468,9 @@ export const parseGradleDep = function (
         rline.startsWith("\\--- ")
       ) {
         last_level = 1;
-        if (rline.startsWith("+--- project :")) {
-          const tmpProj = rline.split("+--- project :");
-          last_project_purl = `pkg:maven/${tmpProj[1].trim()}@${rootProjectVersion}?type=jar`;
-          stack = [last_project_purl];
-          last_purl = last_project_purl;
-        } else {
-          last_project_purl = first_purl;
-          last_purl = last_project_purl;
-          stack = [first_purl];
-        }
+        last_project_purl = first_purl;
+        last_purl = last_project_purl;
+        stack = [first_purl];
       }
       if (rline.includes(" - ")) {
         profileName = rline.split(" - ")[0];
@@ -1503,73 +1496,71 @@ export const parseGradleDep = function (
         const name = nameoverride || namespecified;
         const version = versionoverride || versionspecified;
         const level = line.split(groupspecified)[0].length / 5;
-        if (version !== undefined) {
+        if (version !== undefined || group === "project") {
           let purlString = new PackageURL(
             "maven",
-            group,
+            group !== "project" ? group : rootProjectGroup,
             name,
-            version,
+            version !== undefined ? version : rootProjectVersion,
             { type: "jar" },
             null
           ).toString();
           purlString = decodeURIComponent(purlString);
           keys_cache[purlString + "_" + last_purl] = true;
-          if (group !== "project") {
-            // Filter duplicates
-            if (!deps_keys_cache[purlString]) {
-              deps_keys_cache[purlString] = true;
-              const adep = {
-                group,
-                name: name,
-                version: version,
-                qualifiers: { type: "jar" }
-              };
-              if (scope) {
-                adep["scope"] = scope;
-              }
-              if (profileName) {
-                adep.properties = [
-                  {
-                    name: "GradleProfileName",
-                    value: profileName
-                  }
-                ];
-              }
-              deps.push(adep);
+          // Filter duplicates
+          if (!deps_keys_cache[purlString]) {
+            deps_keys_cache[purlString] = true;
+            const adep = {
+              group: group !== "project" ? group : rootProjectGroup,
+              name: name,
+              version: version !== undefined ? version : rootProjectVersion,
+              qualifiers: { type: "jar" }
+            };
+            if (scope) {
+              adep["scope"] = scope;
             }
-            if (!level_trees[purlString]) {
-              level_trees[purlString] = [];
+            if (profileName) {
+              adep.properties = [
+                {
+                  name: "GradleProfileName",
+                  value: profileName
+                }
+              ];
             }
-            if (level == 0) {
-              stack = [first_purl];
-              stack.push(purlString);
-            } else if (last_purl === "") {
-              stack.push(purlString);
-            } else if (level > last_level) {
-              const cnodes = level_trees[last_purl] || [];
-              if (!cnodes.includes(purlString)) {
-                cnodes.push(purlString);
-              }
-              level_trees[last_purl] = cnodes;
-              if (stack[stack.length - 1] !== purlString) {
-                stack.push(purlString);
-              }
-            } else {
-              for (let i = level; i <= last_level; i++) {
-                stack.pop();
-              }
-              const last_stack =
-                stack.length > 0 ? stack[stack.length - 1] : last_project_purl;
-              const cnodes = level_trees[last_stack] || [];
-              if (!cnodes.includes(purlString)) {
-                cnodes.push(purlString);
-              }
-              level_trees[last_stack] = cnodes;
-              stack.push(purlString);
-            }
-            last_level = level;
-            last_purl = purlString;
+            deps.push(adep);
           }
+          if (!level_trees[purlString]) {
+            level_trees[purlString] = [];
+          }
+          if (level == 0) {
+            stack = [first_purl];
+            stack.push(purlString);
+          } else if (last_purl === "") {
+            stack.push(purlString);
+          } else if (level > last_level) {
+            const cnodes = level_trees[last_purl] || [];
+            if (!cnodes.includes(purlString)) {
+              cnodes.push(purlString);
+            }
+            level_trees[last_purl] = cnodes;
+            if (stack[stack.length - 1] !== purlString) {
+              stack.push(purlString);
+            }
+          } else {
+            for (let i = level; i <= last_level; i++) {
+              stack.pop();
+            }
+            const last_stack =
+              stack.length > 0 ? stack[stack.length - 1] : last_project_purl;
+            const cnodes = level_trees[last_stack] || [];
+            if (!cnodes.includes(purlString)) {
+              cnodes.push(purlString);
+            }
+            level_trees[last_stack] = cnodes;
+            stack.push(purlString);
+          }
+          last_level = level;
+          last_purl = purlString;
         }
       }
     }

--- a/utils.test.js
+++ b/utils.test.js
@@ -273,17 +273,17 @@ test("parse gradle dependencies", () => {
   parsedList = parseGradleDep(
     readFileSync("./test/data/gradle-out-249.dep", { encoding: "utf-8" })
   );
-  expect(parsedList.pkgList.length).toEqual(20);
+  expect(parsedList.pkgList.length).toEqual(21);
   expect(parsedList.dependenciesList.length).toEqual(22);
   parsedList = parseGradleDep(
     readFileSync("./test/data/gradle-service.out", { encoding: "utf-8" })
   );
-  expect(parsedList.pkgList.length).toEqual(34);
+  expect(parsedList.pkgList.length).toEqual(35);
   expect(parsedList.dependenciesList.length).toEqual(36);
   parsedList = parseGradleDep(
     readFileSync("./test/data/gradle-s.out", { encoding: "utf-8" })
   );
-  expect(parsedList.pkgList.length).toEqual(27);
+  expect(parsedList.pkgList.length).toEqual(28);
   expect(parsedList.dependenciesList.length).toEqual(29);
   parsedList = parseGradleDep(
     readFileSync("./test/data/gradle-core.out", { encoding: "utf-8" })
@@ -298,7 +298,7 @@ test("parse gradle dependencies", () => {
   parsedList = parseGradleDep(
     readFileSync("./test/data/gradle-android-app.dep", { encoding: "utf-8" })
   );
-  expect(parsedList.pkgList.length).toEqual(101);
+  expect(parsedList.pkgList.length).toEqual(102);
   parsedList = parseGradleDep(
     readFileSync("./test/data/gradle-android-jetify.dep", { encoding: "utf-8" })
   );

--- a/utils.test.js
+++ b/utils.test.js
@@ -157,7 +157,9 @@ test("parse gradle dependencies", () => {
     qualifiers: {
       type: "jar"
     },
-    version: "0.4.25"
+    version: "0.4.25",
+    "bom-ref": "pkg:maven/org.ethereum/solcJ-all@0.4.25?type=jar",
+    purl: "pkg:maven/org.ethereum/solcJ-all@0.4.25?type=jar"
   });
 
   parsedList = parseGradleDep(
@@ -178,7 +180,9 @@ test("parse gradle dependencies", () => {
         name: "GradleProfileName",
         value: "androidTestImplementation"
       }
-    ]
+    ],
+    "bom-ref": "pkg:maven/com.android.support.test/runner@1.0.2?type=jar",
+    purl: "pkg:maven/com.android.support.test/runner@1.0.2?type=jar"
   });
   expect(parsedList.pkgList[103]).toEqual({
     group: "androidx.core",
@@ -193,7 +197,9 @@ test("parse gradle dependencies", () => {
         name: "GradleProfileName",
         value: "releaseUnitTestRuntimeClasspath"
       }
-    ]
+    ],
+    "bom-ref": "pkg:maven/androidx.core/core@1.7.0?type=jar",
+    purl: "pkg:maven/androidx.core/core@1.7.0?type=jar"
   });
   parsedList = parseGradleDep(
     readFileSync("./test/data/gradle-out1.dep", { encoding: "utf-8" })
@@ -210,7 +216,9 @@ test("parse gradle dependencies", () => {
         name: "GradleProfileName",
         value: "compileClasspath"
       }
-    ]
+    ],
+    "bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-web@2.2.0.RELEASE?type=jar",
+    purl: "pkg:maven/org.springframework.boot/spring-boot-starter-web@2.2.0.RELEASE?type=jar"
   });
 
   parsedList = parseGradleDep(
@@ -221,7 +229,9 @@ test("parse gradle dependencies", () => {
     group: "ch.qos.logback",
     name: "logback-core",
     qualifiers: { type: "jar" },
-    version: "1.4.5"
+    version: "1.4.5",
+    "bom-ref": "pkg:maven/ch.qos.logback/logback-core@1.4.5?type=jar",
+    purl: "pkg:maven/ch.qos.logback/logback-core@1.4.5?type=jar"
   });
   parsedList = parseGradleDep(
     readFileSync("./test/data/gradle-rich2.dep", { encoding: "utf-8" })
@@ -232,13 +242,17 @@ test("parse gradle dependencies", () => {
       group: "io.appium",
       name: "java-client",
       qualifiers: { type: "jar" },
-      version: "8.1.1"
+      version: "8.1.1",
+      "bom-ref": "pkg:maven/io.appium/java-client@8.1.1?type=jar",
+      purl: "pkg:maven/io.appium/java-client@8.1.1?type=jar"
     },
     {
       group: "org.seleniumhq.selenium",
       name: "selenium-support",
       qualifiers: { type: "jar" },
-      version: "4.5.0"
+      version: "4.5.0",
+      "bom-ref": "pkg:maven/org.seleniumhq.selenium/selenium-support@4.5.0?type=jar",
+      purl: "pkg:maven/org.seleniumhq.selenium/selenium-support@4.5.0?type=jar"
     }
   ]);
   parsedList = parseGradleDep(
@@ -250,7 +264,9 @@ test("parse gradle dependencies", () => {
       group: "org.seleniumhq.selenium",
       name: "selenium-remote-driver",
       version: "4.5.0",
-      qualifiers: { type: "jar" }
+      qualifiers: { type: "jar" },
+      "bom-ref": "pkg:maven/org.seleniumhq.selenium/selenium-remote-driver@4.5.0?type=jar",
+      purl: "pkg:maven/org.seleniumhq.selenium/selenium-remote-driver@4.5.0?type=jar"
     }
   ]);
   parsedList = parseGradleDep(
@@ -262,7 +278,9 @@ test("parse gradle dependencies", () => {
       group: "org.seleniumhq.selenium",
       name: "selenium-api",
       version: "4.5.0",
-      qualifiers: { type: "jar" }
+      qualifiers: { type: "jar" },
+      "bom-ref": "pkg:maven/org.seleniumhq.selenium/selenium-api@4.5.0?type=jar",
+      purl: "pkg:maven/org.seleniumhq.selenium/selenium-api@4.5.0?type=jar"
     }
   ]);
   parsedList = parseGradleDep(
@@ -308,7 +326,9 @@ test("parse gradle dependencies", () => {
       group: "androidx.appcompat",
       name: "appcompat",
       version: "1.2.0",
-      qualifiers: { type: "jar" }
+      qualifiers: { type: "jar" },
+      "bom-ref": "pkg:maven/androidx.appcompat/appcompat@1.2.0?type=jar",
+      purl: "pkg:maven/androidx.appcompat/appcompat@1.2.0?type=jar"
     }
   ]);
 });


### PR DESCRIPTION
This PR corrects the way Gradle sub-projects are handled:
1) it uses the correct `group` -- there was a mismatch between the objects, so the dependency-tree was incorrect
2) if the scan is started on a sub-project instead of on the root, any references to other projects would not be visible as these projects were not included in the list of components/dependencies

Now, sub-projects are simply handled as if they were normal components/dependencies and in the case of scanning from the root of a multi-project, the duplicate components are removed.

Seeing how testing would need a combination of methods from `index.js` and `utils.js`, I wasn't sure how to go about this.