### PR TITLE
Evinse for js - part 2 - callstack, vue and svelte

### DIFF
--- a/.github/workflows/repotests.yml
+++ b/.github/workflows/repotests.yml
@@ -112,6 +112,10 @@ jobs:
         with:
           repository: 'zoom/meetingsdk-vuejs-sample'
           path: 'repotests/meetingsdk-vuejs-sample'
+      - uses: actions/checkout@v3
+        with:
+          repository: 'sveltejs/examples'
+          path: 'repotests/sveltejs-examples'          
       - name: repotests
         run: |
           bin/cdxgen.js -p -r -t java repotests/shiftleft-java-example -o bomresults/bom-java.json --generate-key-and-sign
@@ -121,6 +125,8 @@ jobs:
           node bin/evinse.js -i bomresults/bom-ts.json -o bomresults/bom-ts.evinse.json -l javascript --with-data-flow -p repotests/shiftleft-ts-example
           FETCH_LICENSE=false bin/cdxgen.js -p -t js repotests/meetingsdk-vuejs-sample -o bomresults/bom-vue.json
           node bin/evinse.js -i bomresults/bom-vue.json -o bomresults/bom-vue.evinse.json -l javascript --with-data-flow -p repotests/meetingsdk-vuejs-sample
+          ASTGEN_IGNORE_DIRS="" FETCH_LICENSE=false bin/cdxgen.js -p -t js repotests/sveltejs-examples -o bomresults/bom-svelte.json
+          ASTGEN_IGNORE_DIRS="" node bin/evinse.js -i bomresults/bom-svelte.json -o bomresults/bom-svelte.evinse.json -l javascript --with-data-flow -p repotests/sveltejs-examples          
           FETCH_LICENSE=1 bin/cdxgen.js -p -t js repotests/shiftleft-ts-example --required-only -o bomresults/bom-ts.json --validate
           FETCH_LICENSE=false bin/cdxgen.js -p -r -t go repotests/shiftleft-go-example -o bomresults/bom-go.json --validate
           FETCH_LICENSE=true bin/cdxgen.js -p -r -t csharp repotests/vulnerable_net_core -o bomresults/bom-csharp2.json --validate

--- a/.github/workflows/repotests.yml
+++ b/.github/workflows/repotests.yml
@@ -126,7 +126,7 @@ jobs:
           FETCH_LICENSE=false bin/cdxgen.js -p -t js repotests/meetingsdk-vuejs-sample -o bomresults/bom-vue.json
           node bin/evinse.js -i bomresults/bom-vue.json -o bomresults/bom-vue.evinse.json -l javascript --with-data-flow -p repotests/meetingsdk-vuejs-sample
           ASTGEN_IGNORE_DIRS="" FETCH_LICENSE=false bin/cdxgen.js -p -t js repotests/sveltejs-examples -o bomresults/bom-svelte.json
-          ASTGEN_IGNORE_DIRS="" node bin/evinse.js -i bomresults/bom-svelte.json -o bomresults/bom-svelte.evinse.json -l javascript --with-data-flow -p repotests/sveltejs-examples          
+          ASTGEN_IGNORE_DIRS="" node bin/evinse.js -i bomresults/bom-svelte.json -o bomresults/bom-svelte.evinse.json -l javascript --with-data-flow -p repotests/sveltejs-examples
           FETCH_LICENSE=1 bin/cdxgen.js -p -t js repotests/shiftleft-ts-example --required-only -o bomresults/bom-ts.json --validate
           FETCH_LICENSE=false bin/cdxgen.js -p -r -t go repotests/shiftleft-go-example -o bomresults/bom-go.json --validate
           FETCH_LICENSE=true bin/cdxgen.js -p -r -t csharp repotests/vulnerable_net_core -o bomresults/bom-csharp2.json --validate

--- a/.github/workflows/repotests.yml
+++ b/.github/workflows/repotests.yml
@@ -108,11 +108,19 @@ jobs:
         with:
           repository: 'GoogleCloudPlatform/microservices-demo'
           path: 'repotests/microservices-demo'
+      - uses: actions/checkout@v3
+        with:
+          repository: 'zoom/meetingsdk-vuejs-sample'
+          path: 'repotests/meetingsdk-vuejs-sample'
       - name: repotests
         run: |
           bin/cdxgen.js -p -r -t java repotests/shiftleft-java-example -o bomresults/bom-java.json --generate-key-and-sign
+          node bin/evinse.js -i bomresults/bom-java.json -o bomresults/bom-java.evinse.json -l java --with-data-flow -p repotests/shiftleft-java-example
           SBOM_SIGN_ALGORITHM=RS512 SBOM_SIGN_PRIVATE_KEY=bomresults/private.key SBOM_SIGN_PUBLIC_KEY=bomresults/public.key bin/cdxgen.js -p -r -t github repotests/shiftleft-java-example -o bomresults/bom-github.json
           FETCH_LICENSE=false bin/cdxgen.js -p -t js repotests/shiftleft-ts-example -o bomresults/bom-ts.json --validate
+          node bin/evinse.js -i bomresults/bom-ts.json -o bomresults/bom-ts.evinse.json -l javascript --with-data-flow -p repotests/shiftleft-ts-example
+          FETCH_LICENSE=false bin/cdxgen.js -p -t js repotests/meetingsdk-vuejs-sample -o bomresults/bom-vue.json
+          node bin/evinse.js -i bomresults/bom-vue.json -o bomresults/bom-vue.evinse.json -l javascript --with-data-flow -p repotests/meetingsdk-vuejs-sample
           FETCH_LICENSE=1 bin/cdxgen.js -p -t js repotests/shiftleft-ts-example --required-only -o bomresults/bom-ts.json --validate
           FETCH_LICENSE=false bin/cdxgen.js -p -r -t go repotests/shiftleft-go-example -o bomresults/bom-go.json --validate
           FETCH_LICENSE=true bin/cdxgen.js -p -r -t csharp repotests/vulnerable_net_core -o bomresults/bom-csharp2.json --validate

--- a/README.md
+++ b/README.md
@@ -286,35 +286,37 @@ cdxgen can retain the dependency tree under the `dependencies` attribute for a s
 
 ## Environment variables
 
-| Variable                     | Description                                                                                                                 |
-| ---------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| CDXGEN_DEBUG_MODE            | Set to `debug` to enable debug messages                                                                                     |
-| GITHUB_TOKEN                 | Specify GitHub token to prevent traffic shaping while querying license and repo information                                 |
-| MVN_CMD                      | Set to override maven command                                                                                               |
-| MVN_ARGS                     | Set to pass additional arguments such as profile or settings to maven                                                       |
-| MAVEN_HOME                   | Specify maven home                                                                                                          |
-| GRADLE_CACHE_DIR             | Specify gradle cache directory. Useful for class name resolving                                                             |
-| GRADLE_MULTI_PROJECT_MODE    | Unused. Automatically handled                                                                                               |
-| GRADLE_ARGS                  | Set to pass additional arguments such as profile or settings to gradle (all tasks). Eg: --configuration runtimeClassPath    |
-| GRADLE_ARGS_PROPERTIES       | Set to pass additional arguments only to the `gradle properties` task, used for collecting metadata about the project       |
-| GRADLE_ARGS_DEPENDENCIES     | Set to pass additional arguments only to the `gradle dependencies` task, used for listing actual project dependencies       |
-| GRADLE_HOME                  | Specify gradle home                                                                                                         |
-| GRADLE_CMD                   | Set to override gradle command                                                                                              |
-| GRADLE_DEPENDENCY_TASK       | By default cdxgen use the task "dependencies" to collect packages. Set to override the task name.                           |
-| SBT_CACHE_DIR                | Specify sbt cache directory. Useful for class name resolving                                                                |
-| FETCH_LICENSE                | Set this variable to `true` or `1` to fetch license information from the registry. npm and golang                           |
-| USE_GOSUM                    | Set to `true` or `1` to generate BOMs for golang projects using go.sum as the dependency source of truth, instead of go.mod |
-| CDXGEN_TIMEOUT_MS            | Default timeout for known execution involving maven, gradle or sbt                                                          |
-| CDXGEN_SERVER_TIMEOUT_MS     | Default timeout in server mode                                                                                              |
-| BAZEL_TARGET                 | Bazel target to build. Default :all (Eg: //java-maven)                                                                      |
-| CLJ_CMD                      | Set to override the clojure cli command                                                                                     |
-| LEIN_CMD                     | Set to override the leiningen command                                                                                       |
-| SBOM_SIGN_ALGORITHM          | Signature algorithm. Some valid values are RS256, RS384, RS512, PS256, PS384, PS512, ES256 etc                              |
-| SBOM_SIGN_PRIVATE_KEY        | Private key to use for signing                                                                                              |
-| SBOM_SIGN_PUBLIC_KEY         | Optional. Public key to include in the SBoM signature                                                                       |
-| CDX_MAVEN_PLUGIN             | CycloneDX Maven plugin to use. Default "org.cyclonedx:cyclonedx-maven-plugin:2.7.8"                                         |
-| CDX_MAVEN_GOAL               | CycloneDX Maven plugin goal to use. Default makeAggregateBom. Other options: makeBom, makePackageBom                        |
-| CDX_MAVEN_INCLUDE_TEST_SCOPE | Whether test scoped dependencies should be included from Maven projects, Default: true                                      |
+| Variable                     | Description                                                                                                                          |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| CDXGEN_DEBUG_MODE            | Set to `debug` to enable debug messages                                                                                              |
+| GITHUB_TOKEN                 | Specify GitHub token to prevent traffic shaping while querying license and repo information                                          |
+| MVN_CMD                      | Set to override maven command                                                                                                        |
+| MVN_ARGS                     | Set to pass additional arguments such as profile or settings to maven                                                                |
+| MAVEN_HOME                   | Specify maven home                                                                                                                   |
+| GRADLE_CACHE_DIR             | Specify gradle cache directory. Useful for class name resolving                                                                      |
+| GRADLE_MULTI_PROJECT_MODE    | Unused. Automatically handled                                                                                                        |
+| GRADLE_ARGS                  | Set to pass additional arguments such as profile or settings to gradle (all tasks). Eg: --configuration runtimeClassPath             |
+| GRADLE_ARGS_PROPERTIES       | Set to pass additional arguments only to the `gradle properties` task, used for collecting metadata about the project                |
+| GRADLE_ARGS_DEPENDENCIES     | Set to pass additional arguments only to the `gradle dependencies` task, used for listing actual project dependencies                |
+| GRADLE_HOME                  | Specify gradle home                                                                                                                  |
+| GRADLE_CMD                   | Set to override gradle command                                                                                                       |
+| GRADLE_DEPENDENCY_TASK       | By default cdxgen use the task "dependencies" to collect packages. Set to override the task name.                                    |
+| SBT_CACHE_DIR                | Specify sbt cache directory. Useful for class name resolving                                                                         |
+| FETCH_LICENSE                | Set this variable to `true` or `1` to fetch license information from the registry. npm and golang                                    |
+| USE_GOSUM                    | Set to `true` or `1` to generate BOMs for golang projects using go.sum as the dependency source of truth, instead of go.mod          |
+| CDXGEN_TIMEOUT_MS            | Default timeout for known execution involving maven, gradle or sbt                                                                   |
+| CDXGEN_SERVER_TIMEOUT_MS     | Default timeout in server mode                                                                                                       |
+| BAZEL_TARGET                 | Bazel target to build. Default :all (Eg: //java-maven)                                                                               |
+| CLJ_CMD                      | Set to override the clojure cli command                                                                                              |
+| LEIN_CMD                     | Set to override the leiningen command                                                                                                |
+| SBOM_SIGN_ALGORITHM          | Signature algorithm. Some valid values are RS256, RS384, RS512, PS256, PS384, PS512, ES256 etc                                       |
+| SBOM_SIGN_PRIVATE_KEY        | Private key to use for signing                                                                                                       |
+| SBOM_SIGN_PUBLIC_KEY         | Optional. Public key to include in the SBoM signature                                                                                |
+| CDX_MAVEN_PLUGIN             | CycloneDX Maven plugin to use. Default "org.cyclonedx:cyclonedx-maven-plugin:2.7.8"                                                  |
+| CDX_MAVEN_GOAL               | CycloneDX Maven plugin goal to use. Default makeAggregateBom. Other options: makeBom, makePackageBom                                 |
+| CDX_MAVEN_INCLUDE_TEST_SCOPE | Whether test scoped dependencies should be included from Maven projects, Default: true                                               |
+| ASTGEN_IGNORE_DIRS           | Comma separated list of directories to ignore while analyzing using babel. The environment variable is also used by atom and astgen. |
+| ASTGEN_IGNORE_FILE_PATTERN   | Ignore regex to use                                                                                                                  |
 
 ## Plugins
 

--- a/analyzer.js
+++ b/analyzer.js
@@ -20,6 +20,11 @@ const IGNORE_DIRS = [
   "types",
   "mock",
   "mocks",
+  "jest-cache",
+  "eslint-rules",
+  "codemods",
+  "flow-typed",
+  "i18n",
   "__tests__"
 ];
 
@@ -34,7 +39,7 @@ const getAllFiles = (dir, extn, files, result, regex) => {
   regex = regex || new RegExp(`\\${extn}$`);
 
   for (let i = 0; i < files.length; i++) {
-    if (IGNORE_FILE_PATTERN.test(files[i])) {
+    if (IGNORE_FILE_PATTERN.test(files[i]) || files[i].startsWith(".")) {
       continue;
     }
     const file = join(dir, files[i]);
@@ -88,7 +93,7 @@ const babelParserOptions = {
  * Filter only references to (t|jsx?) or (less|scss) files for now.
  * Opt to use our relative paths.
  */
-const setFileRef = (allImports, src, file, pathnode) => {
+const setFileRef = (allImports, src, file, pathnode, specifiers = []) => {
   const pathway = pathnode.value || pathnode.name;
   const sourceLoc = pathnode.loc?.start;
   if (!pathway) {
@@ -99,8 +104,12 @@ const setFileRef = (allImports, src, file, pathnode) => {
   if (/\.(svg|png|jpg|d\.ts)/.test(pathway)) {
     return;
   }
+  const importedModules = specifiers
+    .map((s) => s.imported?.name)
+    .filter((v) => v !== undefined);
   const occurrence = {
     importedAs: pathway,
+    importedModules,
     isExternal: true,
     fileName: fileRelativeLoc,
     lineNumber: sourceLoc && sourceLoc.line ? sourceLoc.line : undefined,
@@ -128,16 +137,51 @@ const setFileRef = (allImports, src, file, pathnode) => {
   }
 };
 
+const vueCleaningRegex = /<\/*script.*>|<style[\s\S]*style>|<\/*br>/gi;
+const vueTemplateRegex = /(<template.*>)([\s\S]*)(<\/template>)/gi;
+const vueCommentRegex = /<!--[\s\S]*?-->/gi;
+const vueBindRegex = /(:\[)([\s\S]*?)(\])/gi;
+const vuePropRegex = /\s([.:@])([a-zA-Z]*?=)/gi;
+
+const fileToParseableCode = (file) => {
+  let code = readFileSync(file, "utf-8");
+  if (file.endsWith(".vue") || file.endsWith(".svelte")) {
+    code = code
+      .replace(vueCommentRegex, function (match) {
+        return match.replaceAll(/\S/g, " ");
+      })
+      .replace(vueCleaningRegex, function (match) {
+        return match.replaceAll(/\S/g, " ").substring(1) + ";";
+      })
+      .replace(vueBindRegex, function (match, grA, grB, grC) {
+        return grA.replaceAll(/\S/g, " ") + grB + grC.replaceAll(/\S/g, " ");
+      })
+      .replace(vuePropRegex, function (match, grA, grB) {
+        return " " + grA.replace(/[.:@]/g, " ") + grB;
+      })
+      .replace(vueTemplateRegex, function (match, grA, grB, grC) {
+        return grA + grB.replaceAll("{{", "{ ").replaceAll("}}", " }") + grC;
+      });
+  }
+  return code;
+};
+
 /**
  * Check AST tree for any (j|tsx?) files and set a file
  * references for any import, require or dynamic import files.
  */
 const parseFileASTTree = (src, file, allImports) => {
-  const ast = parse(readFileSync(file, "utf-8"), babelParserOptions);
+  const ast = parse(fileToParseableCode(file), babelParserOptions);
   traverse.default(ast, {
     ImportDeclaration: (path) => {
       if (path && path.node) {
-        setFileRef(allImports, src, file, path.node.source);
+        setFileRef(
+          allImports,
+          src,
+          file,
+          path.node.source,
+          path.node.specifiers
+        );
       }
     },
     // For require('') statements
@@ -164,7 +208,13 @@ const parseFileASTTree = (src, file, allImports) => {
     ExportNamedDeclaration: (path) => {
       // ensure there is a path export
       if (path && path.node && path.node.source) {
-        setFileRef(allImports, src, file, path.node.source);
+        setFileRef(
+          allImports,
+          src,
+          file,
+          path.node.source,
+          path.node.specifiers
+        );
       }
     }
   });
@@ -177,8 +227,12 @@ const getAllSrcJSAndTSFiles = (src) =>
   Promise.all([
     getAllFiles(src, ".js"),
     getAllFiles(src, ".jsx"),
+    getAllFiles(src, ".cjs"),
+    getAllFiles(src, ".mjs"),
     getAllFiles(src, ".ts"),
-    getAllFiles(src, ".tsx")
+    getAllFiles(src, ".tsx"),
+    getAllFiles(src, ".vue"),
+    getAllFiles(src, ".svelte")
   ]);
 
 /**

--- a/analyzer.js
+++ b/analyzer.js
@@ -4,32 +4,35 @@ import { join } from "path";
 import { readdirSync, statSync, readFileSync } from "fs";
 import { basename, resolve, isAbsolute, relative } from "path";
 
-const IGNORE_DIRS = [
-  "node_modules",
-  "venv",
-  "docs",
-  "test",
-  "tests",
-  "e2e",
-  "examples",
-  "cypress",
-  "site-packages",
-  "typings",
-  "api_docs",
-  "dev_docs",
-  "types",
-  "mock",
-  "mocks",
-  "jest-cache",
-  "eslint-rules",
-  "codemods",
-  "flow-typed",
-  "i18n",
-  "__tests__"
-];
+const IGNORE_DIRS = process.env.ASTGEN_IGNORE_DIRS
+  ? process.env.ASTGEN_IGNORE_DIRS.split(",")
+  : [
+      "node_modules",
+      "venv",
+      "docs",
+      "test",
+      "tests",
+      "e2e",
+      "examples",
+      "cypress",
+      "site-packages",
+      "typings",
+      "api_docs",
+      "dev_docs",
+      "types",
+      "mock",
+      "mocks",
+      "jest-cache",
+      "eslint-rules",
+      "codemods",
+      "flow-typed",
+      "i18n",
+      "__tests__"
+    ];
 
 const IGNORE_FILE_PATTERN = new RegExp(
-  "(conf|config|test|spec|mock|\\.d)\\.(js|ts|tsx)$",
+  process.env.ASTGEN_IGNORE_FILE_PATTERN ||
+    "(conf|config|test|spec|mock|\\.d)\\.(js|ts|tsx)$",
   "i"
 );
 

--- a/bin/evinse.js
+++ b/bin/evinse.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 // Evinse (Evinse Verification Is Nearly SBoM Evidence)
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";

--- a/bin/repl.js
+++ b/bin/repl.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import repl from "node:repl";
 import jsonata from "jsonata";
 import fs from "node:fs";

--- a/bin/verify.js
+++ b/bin/verify.js
@@ -21,7 +21,10 @@ const args = yargs(hideBin(process.argv))
   .help("h").argv;
 
 const bomJson = JSON.parse(fs.readFileSync(args.input, "utf8"));
-const bomSignature = bomJson?.signature?.value;
+const bomSignature =
+  bomJson.signature && bomJson.signature.value
+    ? bomJson.signature.value
+    : undefined;
 if (!bomSignature) {
   console.log("No signature was found!");
 } else {

--- a/display.js
+++ b/display.js
@@ -58,6 +58,19 @@ export const printServices = (bomJson) => {
   }
 };
 
+const locationComparator = (a, b) => {
+  if (a && b && a.includes("#") && b.includes("#")) {
+    const tmpA = a.split("#");
+    const tmpB = b.split("#");
+    if (tmpA.length === 2 && tmpB.length === 2) {
+      if (tmpA[0] == tmpB[0]) {
+        return tmpA[1] - tmpB[1];
+      }
+    }
+  }
+  return a.localeCompare(b);
+};
+
 export const printOccurrences = (bomJson) => {
   const data = [["Group", "Name", "Version", "Occurrences"]];
   if (!bomJson || !bomJson.components) {
@@ -73,7 +86,7 @@ export const printOccurrences = (bomJson) => {
       comp.version,
       comp.evidence.occurrences
         .map((l) => l.location)
-        .sort()
+        .sort(locationComparator)
         .join("\n")
     ]);
   }
@@ -106,7 +119,7 @@ export const printCallStack = (bomJson) => {
           (c) => `${c.fullFilename}${c.line ? "#" + c.line : ""}`
         )
       )
-    ).sort();
+    ).sort(locationComparator);
     let frameDisplay = [frames[0]];
     if (frames.length > 1) {
       for (let i = 1; i < frames.length - 1; i++) {

--- a/evinser.js
+++ b/evinser.js
@@ -874,12 +874,12 @@ export const collectDataFlowFrames = async (
         continue;
       }
       let typeFullName = theNode.typeFullName;
-      if (
-        language === "javascript" &&
-        theNode.label === "CALL" &&
-        typeFullName == "ANY"
-      ) {
-        if (theNode.code && theNode.code.startsWith("new ")) {
+      if (language === "javascript" && typeFullName == "ANY") {
+        if (
+          theNode.code &&
+          (theNode.code.startsWith("new ") ||
+            theNode.label === "METHOD_PARAMETER_IN")
+        ) {
           typeFullName = theNode.code.split("(")[0].replace("new ", "");
         } else {
           typeFullName = theNode.fullName || theNode.name;

--- a/evinser.js
+++ b/evinser.js
@@ -650,7 +650,7 @@ export const detectServicesFromUsages = (language, slice, servicesMap = {}) => {
         if (acall.resolvedMethod) {
           const tmpEndpoints = extractEndpoints(language, acall.resolvedMethod);
           if (tmpEndpoints && tmpEndpoints.length) {
-            endpoints = endpoints.concat(tmpEndpoints);
+            endpoints = (endpoints || []).concat(tmpEndpoints);
           }
         }
       }

--- a/evinser.js
+++ b/evinser.js
@@ -522,7 +522,9 @@ export const parseSliceUsages = async (
             if (!purlLocationMap[apurl]) {
               purlLocationMap[apurl] = new Set();
             }
-            purlLocationMap[apurl].add(...(lKeyOverrides[atype] || []));
+            if (lKeyOverrides[atype]) {
+              purlLocationMap[apurl].add(...lKeyOverrides[atype]);
+            }
           } else {
             // This would work well for java since each call node could be mapped to a method
             purlsSet.add(apurl);
@@ -598,7 +600,8 @@ export const isFilterableType = (
       typeFullName.startsWith("JSON") ||
       typeFullName.startsWith("void:") ||
       typeFullName.startsWith("LAMBDA") ||
-      typeFullName.startsWith("../")
+      typeFullName.startsWith("../") ||
+      typeFullName.startsWith("node:")
     ) {
       return true;
     }
@@ -991,7 +994,10 @@ export const getClassTypeFromSignature = (language, typeFullName) => {
       typeFullName = tmpA.join("/");
     }
   }
-  if (typeFullName.startsWith("<unresolved")) {
+  if (
+    typeFullName.startsWith("<unresolved") ||
+    typeFullName.startsWith("<operator")
+  ) {
     return undefined;
   }
   if (typeFullName.includes("$")) {

--- a/evinser.test.js
+++ b/evinser.test.js
@@ -13,8 +13,9 @@ test("Service detection test", () => {
     readFileSync("./test/data/usages.json", { encoding: "utf-8" })
   );
   const objectSlices = usageSlice.objectSlices;
+  const servicesMap = {};
   for (const slice of objectSlices) {
-    const servicesMap = detectServicesFromUsages("java", slice);
+    detectServicesFromUsages("java", slice, servicesMap);
     expect(servicesMap).toBeDefined();
     const serviceName = constructServiceName("java", slice);
     expect(serviceName).toBeDefined();
@@ -32,4 +33,46 @@ test("extract endpoints test", () => {
     )
   ).toEqual(["/issue"]);
   expect(extractEndpoints("java", '@GetMapping("/token")')).toEqual(["/token"]);
+  expect(
+    extractEndpoints(
+      "javascript",
+      'router.use("/api/v2/users",userRoutes.routes(),userRoutes.allowedMethods())'
+    )
+  ).toEqual(["/api/v2/users"]);
+  expect(
+    extractEndpoints(
+      "javascript",
+      "app.use('/encryptionkeys', serveIndexMiddleware, serveIndex('encryptionkeys', { icons: true, view: 'details' }))"
+    )
+  ).toEqual(["/encryptionkeys"]);
+  expect(
+    extractEndpoints(
+      "javascript",
+      "app.use(express.static(path.resolve('frontend/dist/frontend')))"
+    )
+  ).toEqual(["frontend/dist/frontend"]);
+  expect(
+    extractEndpoints(
+      "javascript",
+      "app.use('/ftp(?!/quarantine)/:file', fileServer())"
+    )
+  ).toEqual(["/ftp(?!/quarantine)/:file"]);
+  expect(
+    extractEndpoints(
+      "javascript",
+      "app.use('/rest/basket/:id', security.isAuthorized())"
+    )
+  ).toEqual(["/rest/basket/:id"]);
+  expect(
+    extractEndpoints(
+      "javascript",
+      "app.get(['/.well-known/security.txt', '/security.txt'], verify.accessControlChallenges())"
+    )
+  ).toEqual(["/.well-known/security.txt", "/security.txt"]);
+  expect(
+    extractEndpoints(
+      "javascript",
+      'router.post("/convert",async(ctx:Context):Promise<void>=>{constparameters=ctx.request.body;constbatchClient=newBatchClient({region:"us-west-1"});constcommand=newSubmitJobCommand({jobName:parameters?.jobName,jobQueue:"FOO-ARN",jobDefinition:"BAR-ARN",parameters,});try{constobjectsOutput=awaitbatchClient.send(command);ctx.response.body=objectsOutput;}catch(err){//Poorexceptionhandlingctx.response.body=err;}})'
+    )
+  ).toEqual(["/convert"]);
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@appthreat/atom": "^1.1.2",
+        "@appthreat/atom": "^1.1.3",
         "@cyclonedx/cdxgen-plugins-bin": "^1.2.0",
         "body-parser": "^1.20.2",
         "compression": "^1.7.4",
@@ -83,9 +83,9 @@
       }
     },
     "node_modules/@appthreat/atom": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@appthreat/atom/-/atom-1.1.2.tgz",
-      "integrity": "sha512-WXkSFDoyuuiCjfXpxQZtEYnrEwXxm0WXzjGKdoWV/fveFmeYYaiURgpaCXo7juvI2lFZtiNGWdZQ8z1fDFTp9w==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@appthreat/atom/-/atom-1.1.3.tgz",
+      "integrity": "sha512-M2pRq/2DOVFgAWk638/r4m3hczekISg0rL7acxQaIWIDySHNq+ZLV5XZZ49OG2Y2RU1hxp2JpU/RdjL/WKRdAQ==",
       "optional": true,
       "dependencies": {
         "@babel/parser": "^7.22.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@appthreat/atom": "^1.1.0",
+        "@appthreat/atom": "^1.1.2",
         "@cyclonedx/cdxgen-plugins-bin": "^1.2.0",
         "body-parser": "^1.20.2",
         "compression": "^1.7.4",
@@ -83,9 +83,9 @@
       }
     },
     "node_modules/@appthreat/atom": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@appthreat/atom/-/atom-1.1.0.tgz",
-      "integrity": "sha512-ZKmWsEBmc6qZZOKwlfWjAPIGmbHHD8hw9I9WeOoxdCQycBoWboUbOBNp1Cnk3Y9W19nnnVZxsTBG/oA90Ug+ug==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@appthreat/atom/-/atom-1.1.2.tgz",
+      "integrity": "sha512-WXkSFDoyuuiCjfXpxQZtEYnrEwXxm0WXzjGKdoWV/fveFmeYYaiURgpaCXo7juvI2lFZtiNGWdZQ8z1fDFTp9w==",
       "optional": true,
       "dependencies": {
         "@babel/parser": "^7.22.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@appthreat/atom": "^1.1.3",
+        "@appthreat/atom": "^1.1.4",
         "@cyclonedx/cdxgen-plugins-bin": "^1.2.0",
         "body-parser": "^1.20.2",
         "compression": "^1.7.4",
@@ -83,9 +83,9 @@
       }
     },
     "node_modules/@appthreat/atom": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@appthreat/atom/-/atom-1.1.3.tgz",
-      "integrity": "sha512-M2pRq/2DOVFgAWk638/r4m3hczekISg0rL7acxQaIWIDySHNq+ZLV5XZZ49OG2Y2RU1hxp2JpU/RdjL/WKRdAQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@appthreat/atom/-/atom-1.1.4.tgz",
+      "integrity": "sha512-Zp5q/Q+SIZdOzntwyhMl3ZYwuabYgu5gN2fks7jWhz91olUcgX2/enXg+1gJsqVMZ3JXVoqo5kbUgAQ3KayudQ==",
       "optional": true,
       "dependencies": {
         "@babel/parser": "^7.22.10",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "yargs": "^17.7.2"
   },
   "optionalDependencies": {
-    "@appthreat/atom": "^1.1.0",
+    "@appthreat/atom": "^1.1.2",
     "@cyclonedx/cdxgen-plugins-bin": "^1.2.0",
     "body-parser": "^1.20.2",
     "compression": "^1.7.4",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "yargs": "^17.7.2"
   },
   "optionalDependencies": {
-    "@appthreat/atom": "^1.1.3",
+    "@appthreat/atom": "^1.1.4",
     "@cyclonedx/cdxgen-plugins-bin": "^1.2.0",
     "body-parser": "^1.20.2",
     "compression": "^1.7.4",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "yargs": "^17.7.2"
   },
   "optionalDependencies": {
-    "@appthreat/atom": "^1.1.2",
+    "@appthreat/atom": "^1.1.3",
     "@cyclonedx/cdxgen-plugins-bin": "^1.2.0",
     "body-parser": "^1.20.2",
     "compression": "^1.7.4",

--- a/utils.js
+++ b/utils.js
@@ -344,7 +344,7 @@ const _getDepPkgList = async function (
         continue;
       }
       const pl = pkg.packages[k];
-      versionCache[k.replace("node_modules/", "")] = pl.version;
+      versionCache[k.replaceAll("node_modules/", "")] = pl.version;
     }
   }
   if (pkg && pkgDependencies) {
@@ -359,7 +359,7 @@ const _getDepPkgList = async function (
       const purl = new PackageURL(
         "npm",
         "",
-        name.replace("node_modules/", ""),
+        name.replaceAll("node_modules/", ""),
         version,
         null,
         null
@@ -367,7 +367,7 @@ const _getDepPkgList = async function (
       const purlString = decodeURIComponent(purl.toString());
       const scope = pkgDependencies[name].dev === true ? "optional" : undefined;
       const apkg = {
-        name: name.replace("node_modules/", ""),
+        name: name.replaceAll("node_modules/", ""),
         version,
         _integrity: pkgDependencies[name].integrity,
         scope,
@@ -402,13 +402,12 @@ const _getDepPkgList = async function (
           const depVersion =
             versionCache[depName] || dependencies[depName].version;
           if (!depVersion) {
-            console.log(depName, "has no version");
             continue;
           }
           const deppurl = new PackageURL(
             "npm",
             "",
-            depName.replace("node_modules/", ""),
+            depName.replaceAll("node_modules/", ""),
             depVersion,
             null,
             null
@@ -6058,6 +6057,12 @@ export const addEvidenceForImports = (pkgList, allImports) => {
                 }`
               });
               importedModules.add(evidence.importedAs);
+              for (const importedSm of evidence.importedModules || []) {
+                if (!importedSm) {
+                  continue;
+                }
+                importedModules.add(`${evidence.importedAs}/${importedSm}`);
+              }
             }
           }
           importedModules = Array.from(importedModules);

--- a/utils.js
+++ b/utils.js
@@ -6033,7 +6033,7 @@ export const addEvidenceForImports = (pkgList, allImports) => {
     const { group, name } = pkg;
     let aliases =
       group && group.length
-        ? [name, group + "/" + name, "@" + group + "/" + name]
+        ? [name, `${group}/${name}`, `@${group}/${name}`]
         : [name];
     for (const alias of aliases) {
       if (impPkgs.includes(alias)) {

--- a/utils.js
+++ b/utils.js
@@ -6033,13 +6033,7 @@ export const addEvidenceForImports = (pkgList, allImports) => {
     const { group, name } = pkg;
     let aliases =
       group && group.length
-        ? [
-            name,
-            group + "/" + name,
-            "@" + group + "/" + name,
-            group,
-            "@" + group
-          ]
+        ? [name, group + "/" + name, "@" + group + "/" + name]
         : [name];
     for (const alias of aliases) {
       if (impPkgs.includes(alias)) {
@@ -6061,6 +6055,8 @@ export const addEvidenceForImports = (pkgList, allImports) => {
                 if (!importedSm) {
                   continue;
                 }
+                // Store both the short and long form of the imported sub modules
+                importedModules.add(importedSm);
                 importedModules.add(`${evidence.importedAs}/${importedSm}`);
               }
             }


### PR DESCRIPTION
Sample output for juice shop

[out.txt](https://github.com/CycloneDX/cdxgen/files/12388939/out.txt)

```shell
# For juice-shop, we need to parse every directory so uncomment the below
# export ASTGEN_IGNORE_DIRS="" 

# Generate an SBoM for a JavaScript/TypeScript project with cdxgen
node bin/cdxgen.js -t js -o bom.json
# Ensure java >17 is installed. Needed for any language type.
node bin/evinse.js -i bom.json -o bom.evinse.json -l javascript --with-data-flow -p
```

## Focus areas

- [x] Callstack evidence for frontend frameworks such as angular, react, nuxt etc.

## What to report

- [ ] Crashes/hangs when collecting evidence for js projects
- [ ] SQLite3 installation errors. Although SQLite is not required for js analysis
- [ ] Slow performance. Report the first scan time you see with the number of components in SBoM and lines of code in the application
- [ ] If any package was not listed under evidence.occurrences or has incorrect filenames or line numbers

## Todo

- [x] Services detection for backend frameworks like express

## Discord

https://discord.gg/pF4BYWEJcS

## Screenshots

![Component](https://github.com/CycloneDX/cdxgen/assets/7842/36731acb-0e64-4171-b34d-3b971c8de469)

![Call Stack](https://github.com/CycloneDX/cdxgen/assets/7842/82359c74-0ead-480d-bd46-5ef5a44df9df)

![JS](https://github.com/CycloneDX/cdxgen/assets/7842/bd7c1b0b-3797-4813-80d2-49f50744183d)

