### PR TITLE
Granular signing. sae builds from verify

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -21,7 +21,7 @@ jobs:
         appimage-builder --recipe appimage-builder.yml --skip-test
       env:
         UPDATE_INFO: gh-releases-zsync|cyclonedx|cdxgen|latest|*x86_64.AppImage.zsync
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: AppImage
         path: './*.AppImage*'

--- a/.github/workflows/dockertests.yml
+++ b/.github/workflows/dockertests.yml
@@ -54,7 +54,7 @@ jobs:
           bin/cdxgen.js -t docker-compose test/data -o bomresults/bom-dc.json --validate
           bin/cdxgen.js -t operator repotests/grafana-operator -o bomresults/bom-op.json --validate
           ls -ltr bomresults
-      - uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v3
         with:
           name: bomresults
           path: bomresults
@@ -89,7 +89,7 @@ jobs:
           bin/cdxgen.js -t os -o bomresults/bom-os.json --validate
         env:
           CDXGEN_DEBUG_MODE: debug
-      - uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v3
         with:
           name: bomresults-os
           path: bomresults
@@ -125,7 +125,7 @@ jobs:
           dir bomresults
         env:
           CDXGEN_DEBUG_MODE: debug
-      - uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v3
         with:
           name: bomresults-win
           path: bomresults

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -40,20 +40,38 @@ jobs:
               npx caxa --input . --output "cdxgen.exe" -- "{{caxa}}/node_modules/.bin/node" "{{caxa}}/bin/cdxgen.js"
               .\cdxgen.exe --version
               (Get-FileHash .\cdxgen.exe).hash | Out-File -FilePath .\cdxgen.exe.sha256
+              npm install --omit=optional
+              npx caxa --input . --exclude cdxgen.exe cdxgen.exe.sha256 --output "cdx-verify.exe" -- "{{caxa}}/node_modules/.bin/node" "{{caxa}}/bin/verify.js"
+              .\cdx-verify.exe --version
+              (Get-FileHash .\cdx-verify.exe).hash | Out-File -FilePath .\cdx-verify.exe.sha256
             artifact: cdxgen.exe
+            vartifact: cdx-verify.exe
           - os: macos
             build: |
               npx caxa --input . --output "cdxgen.app" -- "{{caxa}}/node_modules/.bin/node" "{{caxa}}/bin/cdxgen.js"
               tar -czf "cdxgen.app.tgz" cdxgen.app
               shasum -a 256 cdxgen.app.tgz > cdxgen.app.tgz.sha256
+              rm -rf node_modules
+              npm install --omit=optional
+              npx caxa --input .  --exclude cdxgen.app cdxgen.app.tgz cdxgen.app.tgz.sha256 --output "cdx-verify.app" -- "{{caxa}}/node_modules/.bin/node" "{{caxa}}/bin/verify.js"
+              tar -czf "cdx-verify.app.tgz" cdx-verify.app
+              shasum -a 256 cdx-verify.app.tgz > cdx-verify.app.tgz.sha256
             artifact: cdxgen.app.tgz
+            vartifact: cdx-verify.app.tgz
           - os: ubuntu
             build: |
               npx caxa --input . --output "cdxgen" -- "{{caxa}}/node_modules/.bin/node" "{{caxa}}/bin/cdxgen.js"
               chmod +x cdxgen
               ./cdxgen --version
               sha256sum cdxgen > cdxgen.sha256
+              rm -rf node_modules
+              npm install --omit=optional
+              npx caxa --input . --exclude cdxgen cdxgen.sha256 --output "cdx-verify" -- "{{caxa}}/node_modules/.bin/node" "{{caxa}}/bin/verify.js"
+              chmod +x cdx-verify
+              ./cdx-verify --version
+              sha256sum cdx-verify > cdx-verify.sha256
             artifact: cdxgen
+            vartifact: cdx-verify
     runs-on: ${{ matrix.os }}-latest
     steps:
       - uses: actions/checkout@v3
@@ -65,10 +83,14 @@ jobs:
         run: |
           npm ci
           ${{ matrix.build }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.artifact }}
           path: ${{ matrix.artifact }}
+      - uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.vartifact }}
+          path: ${{ matrix.vartifact }}
       - name: Release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
@@ -76,3 +98,5 @@ jobs:
           files: |
             ${{ matrix.artifact }}
             ${{ matrix.artifact }}.sha256
+            ${{ matrix.vartifact }}
+            ${{ matrix.vartifact }}.sha256

--- a/.github/workflows/repotests.yml
+++ b/.github/workflows/repotests.yml
@@ -171,7 +171,7 @@ jobs:
           docker run --rm -t -e "CDXGEN_DEBUG_MODE=debug" -v $(pwd):/app ghcr.io/cyclonedx/cdxgen-deno -p -r -t java /app/repotests/shiftleft-java-example -o /app/denoresults/bom-java.json
           docker run --rm -t -e "CDXGEN_DEBUG_MODE=debug" -v $(pwd):/app ghcr.io/cyclonedx/cdxgen-deno -p -r -t python /app/repotests/DjanGoat -o /app/denoresults/bom-python.json
           ls -ltr denoresults
-      - uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v3
         with:
           name: bomresults
           path: bomresults

--- a/bin/verify.js
+++ b/bin/verify.js
@@ -5,6 +5,14 @@ import { hideBin } from "yargs/helpers";
 import fs from "node:fs";
 import jws from "jws";
 import process from "node:process";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+let url = import.meta.url;
+if (!url.startsWith("file://")) {
+  url = new URL(`file://${import.meta.url}`).toString();
+}
+const dirName = import.meta ? dirname(fileURLToPath(url)) : __dirname;
 
 const args = yargs(hideBin(process.argv))
   .option("input", {
@@ -19,6 +27,17 @@ const args = yargs(hideBin(process.argv))
   .scriptName("cdx-verify")
   .version()
   .help("h").argv;
+
+if (args.version) {
+  const packageJsonAsString = fs.readFileSync(
+    join(dirName, "..", "package.json"),
+    "utf-8"
+  );
+  const packageJson = JSON.parse(packageJsonAsString);
+
+  console.log(packageJson.version);
+  process.exit(0);
+}
 
 const bomJson = JSON.parse(fs.readFileSync(args.input, "utf8"));
 const bomSignature =


### PR DESCRIPTION
@troy256, could you help test the new single binary builds and the granular signing (each component is signed in addition to the document)?

You can download the executable from the workflow run.

https://github.com/CycloneDX/cdxgen/actions/runs/5944361616

To do

- [x] Reduce binary size by excluding optional dependencies for verify