### PR TITLE
feat: allow Maven Central URL overwrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@ cdxgen can retain the dependency tree under the `dependencies` attribute for a s
 | MVN_CMD                      | Set to override maven command                                                                                                        |
 | MVN_ARGS                     | Set to pass additional arguments such as profile or settings to maven                                                                |
 | MAVEN_HOME                   | Specify maven home                                                                                                                   |
+| MAVEN_CENTRAL_URL            | Specify URL of Maven Central for metadata fetching (e.g. when private repo is used)                                                  |
 | GRADLE_CACHE_DIR             | Specify gradle cache directory. Useful for class name resolving                                                                      |
 | GRADLE_MULTI_PROJECT_MODE    | Unused. Automatically handled                                                                                                        |
 | GRADLE_ARGS                  | Set to pass additional arguments such as profile or settings to gradle (all tasks). Eg: --configuration runtimeClassPath             |

--- a/utils.js
+++ b/utils.js
@@ -2007,7 +2007,7 @@ export const guessLicenseId = function (content) {
  * @param {Array} pkgList Package list
  */
 export const getMvnMetadata = async function (pkgList) {
-  const MAVEN_CENTRAL_URL = "https://repo1.maven.org/maven2/";
+  const MAVEN_CENTRAL_URL = process.env.MAVEN_CENTRAL_URL || "https://repo1.maven.org/maven2/";
   const ANDROID_MAVEN = "https://maven.google.com/";
   const cdepList = [];
   if (!pkgList || !pkgList.length) {


### PR DESCRIPTION
feat: allow user to overwrite URL of Maven Central for metadata fetching (e.g. when private repos are used)