### PR TITLE
feat: allow to customize the Maven prefix for Bazel

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,7 @@ cdxgen can retain the dependency tree under the `dependencies` attribute for a s
 | MVN_ARGS                     | Set to pass additional arguments such as profile or settings to maven                                                                |
 | MAVEN_HOME                   | Specify maven home                                                                                                                   |
 | MAVEN_CENTRAL_URL            | Specify URL of Maven Central for metadata fetching (e.g. when private repo is used)                                                  |
+| BAZEL_STRIP_MAVEN_PREFIX     | Strip Maven group prefix (e.g. useful when private repo is used, defaults to `/maven2/`)                                             |
 | GRADLE_CACHE_DIR             | Specify gradle cache directory. Useful for class name resolving                                                                      |
 | GRADLE_MULTI_PROJECT_MODE    | Unused. Automatically handled                                                                                                        |
 | GRADLE_ARGS                  | Set to pass additional arguments such as profile or settings to gradle (all tasks). Eg: --configuration runtimeClassPath             |

--- a/utils.js
+++ b/utils.js
@@ -1878,8 +1878,9 @@ export const parseBazelSkyframe = function (rawOutput) {
             // Remove the protocol, registry url and then file name
             let prefix_slice_count = 2;
             // Bug: #169
-            if (l.includes("/maven2/")) {
-              prefix_slice_count = 3;
+            const prefix = process.env.BAZEL_STRIP_MAVEN_PREFIX || "/maven2/";
+            if (l.includes(prefix)) {
+              prefix_slice_count = prefix.split("/").length;
             }
             jarPathParts = jarPathParts.slice(prefix_slice_count, -1);
             // The last part would be the version


### PR DESCRIPTION
Allow to customize the Maven prefix for Bazel (new env variable `BAZEL_STRIP_MAVEN_PREFIX`) as current default `/maven2/` might not work for proxy repos like Nexus OSS