### PR TITLE
chore: add `--help` and `-v` support for help and version output

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,8 +161,8 @@ Options:
                                                        [boolean] [default: true]
       --spec-version           CycloneDX Specification version to use. Defaults
                                to 1.5                             [default: 1.5]
-      --version                Show version number                     [boolean]
-  -h                           Show help                               [boolean]
+  -h, --help                   Show help                               [boolean]
+  -v, --version                Show version number                     [boolean]
 ```
 
 All boolean arguments accepts `--no` prefix to toggle the behavior.

--- a/bin/cdxgen.js
+++ b/bin/cdxgen.js
@@ -121,7 +121,9 @@ const args = yargs(hideBin(process.argv))
   })
   .scriptName("cdxgen")
   .version()
-  .help("h").argv;
+  .alias("v", "version")
+  .help("h")
+  .alias("h", "help").argv;
 
 if (args.version) {
   const packageJsonAsString = fs.readFileSync(


### PR DESCRIPTION
```diff
-      --version                Show version number                     [boolean]
-  -h                           Show help                               [boolean]
+  -h, --help                   Show help                               [boolean]
+  -v, --version                Show version number                     [boolean]
```

This would at least help me to figure out the root cause in the future :) (like #521 )