### PR TITLE
Refactor code to return an object

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,7 +98,8 @@ import {
   parseSbtTree,
   parseCmakeLikeFile,
   getCppModules,
-  FETCH_LICENSE, getNugetMetadata,
+  FETCH_LICENSE,
+  getNugetMetadata
 } from "./utils.js";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
@@ -4035,7 +4036,13 @@ export const createCsharpBom = async (
     pkgList = trimComponents(pkgList, "json");
   }
   if (FETCH_LICENSE) {
-    pkgList, dependencies = await getNugetMetadata(pkgList, dependencies);
+    const retMap = await getNugetMetadata(pkgList, dependencies);
+    if (retMap.pkgList && retMap.pkgList.length) {
+      pkgList = pkgList.concat(retMap.pkgList);
+    }
+    if (retMap.dependencies && retMap.dependencies.length) {
+      dependencies = dependencies.concat(retMap.dependencies);
+    }
     dependencies = mergeDependencies(dependencies, [], parentComponent);
     pkgList = trimComponents(pkgList, "json");
   }

--- a/index.js
+++ b/index.js
@@ -4037,9 +4037,6 @@ export const createCsharpBom = async (
   }
   if (FETCH_LICENSE) {
     const retMap = await getNugetMetadata(pkgList, dependencies);
-    if (retMap.pkgList && retMap.pkgList.length) {
-      pkgList = pkgList.concat(retMap.pkgList);
-    }
     if (retMap.dependencies && retMap.dependencies.length) {
       dependencies = dependencies.concat(retMap.dependencies);
     }

--- a/utils.js
+++ b/utils.js
@@ -1,6 +1,14 @@
-import {globSync} from "glob";
-import {homedir, platform, tmpdir} from "node:os";
-import {basename, delimiter as _delimiter, dirname, extname, join, resolve, sep as _sep} from "node:path";
+import { globSync } from "glob";
+import { homedir, platform, tmpdir } from "node:os";
+import {
+  basename,
+  delimiter as _delimiter,
+  dirname,
+  extname,
+  join,
+  resolve,
+  sep as _sep
+} from "node:path";
 import {
   chmodSync,
   constants,
@@ -16,17 +24,25 @@ import {
 import got from "got";
 import Arborist from "@npmcli/arborist";
 import path from "path";
-import {xml2js} from "xml-js";
-import {fileURLToPath} from "node:url";
-import {load} from "cheerio";
-import {load as _load} from "js-yaml";
-import {spawnSync} from "node:child_process";
+import { xml2js } from "xml-js";
+import { fileURLToPath } from "node:url";
+import { load } from "cheerio";
+import { load as _load } from "js-yaml";
+import { spawnSync } from "node:child_process";
 import propertiesReader from "properties-reader";
-import {clean, coerce, compare, maxSatisfying, satisfies, valid, parse} from "semver";
+import {
+  clean,
+  coerce,
+  compare,
+  maxSatisfying,
+  satisfies,
+  valid,
+  parse
+} from "semver";
 import StreamZip from "node-stream-zip";
-import {parseEDNString} from "edn-data";
-import {PackageURL} from "packageurl-js";
-import {getTreeWithPlugin} from "./piptree.js";
+import { parseEDNString } from "edn-data";
+import { PackageURL } from "packageurl-js";
+import { getTreeWithPlugin } from "./piptree.js";
 import iconv from "iconv-lite";
 
 let url = import.meta.url;
@@ -4517,9 +4533,9 @@ export const parseCsProjAssetsData = async function (csProjData) {
     }
   }
   return {
-      pkgList,
-      dependenciesList
-    };
+    pkgList,
+    dependenciesList
+  };
 };
 
 export const parseCsPkgLockData = async function (csLockData) {
@@ -7135,25 +7151,32 @@ async function queryNuget(p, NUGET_URL) {
     console.log(`Querying nuget for ${p.name}`);
   }
   const np = JSON.parse(JSON.stringify(p));
-  const body = []
-  const newBody = []
+  const body = [];
+  const newBody = [];
   let res = await cdxgenAgent.get(
-    NUGET_URL +
-    np.name.toLowerCase() +
-    "/index.json",
-    {responseType: "json"}
+    NUGET_URL + np.name.toLowerCase() + "/index.json",
+    { responseType: "json" }
   );
   let items = res.body.items;
   if (!items || !items[0]) {
-    return [np, newBody, body]
+    return [np, newBody, body];
   }
   if (items[0] && !items[0].items) {
     if (!p.version || p.version === "0.0.0" || p.version === "latest") {
       const tmpVersion = parse(res.body.items[res.body.items.length - 1].upper);
-      np.version = tmpVersion.major + "." + tmpVersion.minor + "." + tmpVersion.patch;
-      if (compare(np.version, res.body.items[res.body.items.length - 1].upper) === 1) {
+      np.version =
+        tmpVersion.major + "." + tmpVersion.minor + "." + tmpVersion.patch;
+      if (
+        compare(np.version, res.body.items[res.body.items.length - 1].upper) ===
+        1
+      ) {
         if (tmpVersion.patch > 0) {
-          np.version = tmpVersion.major + "." + tmpVersion.minor + "." + (tmpVersion.patch - 1).toString();
+          np.version =
+            tmpVersion.major +
+            "." +
+            tmpVersion.minor +
+            "." +
+            (tmpVersion.patch - 1).toString();
         }
       }
     }
@@ -7167,12 +7190,14 @@ async function queryNuget(p, NUGET_URL) {
         let lower = compare(item.lower, np.version);
         let upper = compare(item.upper, np.version);
         if (lower !== 1 && upper !== -1) {
-          res = await cdxgenAgent.get(item["@id"], {responseType: "json"});
-          newBody.push(res.body.items
-            .reverse()
-            .filter(
-              (i) => i.catalogEntry && i.catalogEntry.version === np.version
-            ));
+          res = await cdxgenAgent.get(item["@id"], { responseType: "json" });
+          newBody.push(
+            res.body.items
+              .reverse()
+              .filter(
+                (i) => i.catalogEntry && i.catalogEntry.version === np.version
+              )
+          );
           break;
         }
       }
@@ -7180,20 +7205,23 @@ async function queryNuget(p, NUGET_URL) {
   } else {
     if (!p.version || p.version === "0.0.0" || p.version === "latest") {
       const tmpVersion = parse(res.body.items[res.body.items.length - 1].upper);
-      np.version = tmpVersion.major + "." + tmpVersion.minor + "." + tmpVersion.patch;
+      np.version =
+        tmpVersion.major + "." + tmpVersion.minor + "." + tmpVersion.patch;
     }
     const firstItem = items[0];
     // Work backwards to find the body for the matching version
     // body.push(firstItem.items[firstItem.items.length - 1])
     if (np.version) {
-      newBody.push(firstItem.items
-        .reverse()
-        .filter(
-          (i) => i.catalogEntry && i.catalogEntry.version === np.version
-        ));
+      newBody.push(
+        firstItem.items
+          .reverse()
+          .filter(
+            (i) => i.catalogEntry && i.catalogEntry.version === np.version
+          )
+      );
     }
   }
-  return [np, newBody]
+  return [np, newBody];
 }
 
 /**
@@ -7201,7 +7229,10 @@ async function queryNuget(p, NUGET_URL) {
  *
  * @param {Array} pkgList Package list
  */
-export const getNugetMetadata = async function (pkgList, dependencies = undefined) {
+export const getNugetMetadata = async function (
+  pkgList,
+  dependencies = undefined
+) {
   const NUGET_URL = await getNugetUrl();
   const cdepList = [];
   const depRepList = {};
@@ -7220,7 +7251,7 @@ export const getNugetMetadata = async function (pkgList, dependencies = undefine
       if (!body) {
         let newBody = {};
         let np = {};
-        [np, newBody] = await queryNuget(p, NUGET_URL)
+        [np, newBody] = await queryNuget(p, NUGET_URL);
         if (p.version !== np.version) {
           const oldRef = p["bom-ref"];
           p["bom-ref"] = decodeURIComponent(
@@ -7258,7 +7289,7 @@ export const getNugetMetadata = async function (pkgList, dependencies = undefine
             p.license = findLicenseId(body.catalogEntry.licenseUrl);
           }
           if (body.catalogEntry.projectUrl) {
-            p.repository = {url: body.catalogEntry.projectUrl};
+            p.repository = { url: body.catalogEntry.projectUrl };
             p.homepage = {
               url:
                 "https://www.nuget.org/packages/" +
@@ -7271,17 +7302,15 @@ export const getNugetMetadata = async function (pkgList, dependencies = undefine
           cdepList.push(p);
         }
       }
-    } catch
-      (err) {
+    } catch (err) {
       if (cacheKey) {
-        metadata_cache[cacheKey] = {error: err.code};
+        metadata_cache[cacheKey] = { error: err.code };
       }
       cdepList.push(p);
     }
   }
   const newDependencies = [].concat(dependencies);
   if (depRepList && newDependencies.length) {
-
     const changed = Object.keys(depRepList);
     // if (!parentComponent.version || parentComponent.version === "latest" || parentComponent.version === "0.0.0"){
     //   if (changed.includes(parentComponent["bom-ref"])) {
@@ -7300,5 +7329,8 @@ export const getNugetMetadata = async function (pkgList, dependencies = undefine
       }
     }
   }
-  return cdepList, newDependencies;
+  return {
+    pkgList: cdepList,
+    dependencies: newDependencies
+  };
 };

--- a/utils.test.js
+++ b/utils.test.js
@@ -1249,25 +1249,25 @@ test("parse .net cs proj", async () => {
 test("get nget metadata", async () => {
   let dep_list = [
     {
-    dependsOn: [
-      "pkg:nuget/Microsoft.NET.Test.Sdk@17.1.0",
-      "pkg:nuget/Microsoft.NETCore.App@2.1.0",
-      "pkg:nuget/Microsoft.NETFramework.ReferenceAssemblies@1.0.0",
-      "pkg:nuget/NLog@4.5.0",
-      "pkg:nuget/NUnit.Console@3.11.1",
-      "pkg:nuget/NUnit3TestAdapter@3.16.1",
-      "pkg:nuget/NUnitLite@3.13.3",
-      "pkg:nuget/Serilog@0.0.0",
-      "pkg:nuget/Serilog.Sinks.TextWriter@2.0.0",
-      "pkg:nuget/System.Security.Permissions@4.7.0",
-      "pkg:nuget/log4net@2.0.13",
-      "pkg:nuget/System.Net.NameResolution@4.3.0",
-      "pkg:nuget/System.Net.Primitives@4.3.0",
-      "pkg:nuget/PublicApiGenerator@10.1.2",
-      "pkg:nuget/System.Security.Permissions@6.0.0"
-    ],
-    ref: "pkg:nuget/Castle.Core@4.4.0"
-  },
+      dependsOn: [
+        "pkg:nuget/Microsoft.NET.Test.Sdk@17.1.0",
+        "pkg:nuget/Microsoft.NETCore.App@2.1.0",
+        "pkg:nuget/Microsoft.NETFramework.ReferenceAssemblies@1.0.0",
+        "pkg:nuget/NLog@4.5.0",
+        "pkg:nuget/NUnit.Console@3.11.1",
+        "pkg:nuget/NUnit3TestAdapter@3.16.1",
+        "pkg:nuget/NUnitLite@3.13.3",
+        "pkg:nuget/Serilog@0.0.0",
+        "pkg:nuget/Serilog.Sinks.TextWriter@2.0.0",
+        "pkg:nuget/System.Security.Permissions@4.7.0",
+        "pkg:nuget/log4net@2.0.13",
+        "pkg:nuget/System.Net.NameResolution@4.3.0",
+        "pkg:nuget/System.Net.Primitives@4.3.0",
+        "pkg:nuget/PublicApiGenerator@10.1.2",
+        "pkg:nuget/System.Security.Permissions@6.0.0"
+      ],
+      ref: "pkg:nuget/Castle.Core@4.4.0"
+    },
     {
       dependsOn: [
         "pkg:nuget/Microsoft.CSharp@4.0.1",
@@ -1299,43 +1299,42 @@ test("get nget metadata", async () => {
       "bom-ref": "pkg:nuget/Serilog@0.0.0"
     }
   ];
-  let pkgList;
-  let dependencies;
-  pkgList, dependencies = await getNugetMetadata(pkg_list,dep_list);
-  expect(pkg_list.length).toEqual(2);
+  const { pkgList, dependencies } = await getNugetMetadata(pkg_list, dep_list);
   // This data will need to be updated periodically as it tests that missing versions are set to the latest rc
-  expect(pkg_list).toEqual([
+  expect(pkgList).toEqual([
     {
-      "author": "Castle Project Contributors",
+      author: "Castle Project Contributors",
       "bom-ref": "pkg:nuget/Castle.Core@4.4.0",
-      "description": "Castle Core, including DynamicProxy, Logging Abstractions and DictionaryAdapter",
-      "group": "",
-      "homepage": {
-        "url": "https://www.nuget.org/packages/Castle.Core/4.4.0/"
+      description:
+        "Castle Core, including DynamicProxy, Logging Abstractions and DictionaryAdapter",
+      group: "",
+      homepage: {
+        url: "https://www.nuget.org/packages/Castle.Core/4.4.0/"
       },
-      "license": "Apache-2.0",
-      "name": "Castle.Core",
-      "repository": {
-        "url": "http://www.castleproject.org/"
+      license: "Apache-2.0",
+      name: "Castle.Core",
+      repository: {
+        url: "http://www.castleproject.org/"
       },
-      "version": "4.4.0"
+      version: "4.4.0"
     },
     {
-      "author": "Serilog Contributors",
+      author: "Serilog Contributors",
       "bom-ref": "pkg:nuget/Serilog@3.0.1",
-      "description": "Simple .NET logging with fully-structured events",
-      "group": "",
-      "homepage": {
-        "url": "https://www.nuget.org/packages/Serilog/3.0.1/"
+      description: "Simple .NET logging with fully-structured events",
+      group: "",
+      homepage: {
+        url: "https://www.nuget.org/packages/Serilog/3.0.1/"
       },
-      "license": "Apache-2.0",
-      "name": "Serilog",
-      "repository": {
-        "url": "https://serilog.net/"
+      license: "Apache-2.0",
+      name: "Serilog",
+      repository: {
+        url: "https://serilog.net/"
       },
-      "version": "3.0.1"
+      version: "3.0.1"
     }
   ]);
+  expect(pkgList.length).toEqual(2);
   expect(dependencies).toEqual([
     {
       dependsOn: [
@@ -1373,8 +1372,7 @@ test("get nget metadata", async () => {
       ],
       ref: "pkg:nuget/Serilog@3.0.1"
     }
-  ]
-  )
+  ]);
 }, 240000);
 
 test("parsePomFile", () => {


### PR DESCRIPTION
Currently, pkgList is updated inline via reference, while dependencies are copied with a fresh copy returned. Since javascript doesn't have multiple returns this wasn't immediately evident.

I have tried to improve this and also ran prettier 3.0.3.