### PR TITLE
Adding the "gid" flag to successfully build the cdxgen-deno docker image (CI).

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ $ brew install cdxgen
 Deno install is also supported.
 
 ```shell
-deno install --allow-read --allow-env --allow-run --allow-sys=uid,systemMemoryInfo --allow-write --allow-net -n cdxgen "npm:@cyclonedx/cdxgen/cdxgen"
+deno install --allow-read --allow-env --allow-run --allow-sys=uid,systemMemoryInfo,gid --allow-write --allow-net -n cdxgen "npm:@cyclonedx/cdxgen/cdxgen"
 ```
 
 You can also use the cdxgen container image

--- a/ci/Dockerfile-deno
+++ b/ci/Dockerfile-deno
@@ -70,7 +70,7 @@ RUN set -e; \
     && python3 -m pip install --upgrade pip virtualenv \
     && python3 -m pip install --user pipenv poetry \
     && curl -fsSL https://deno.land/x/install/install.sh | sh \
-    && deno install --allow-read --allow-env --allow-run --allow-sys=uid,systemMemoryInfo --allow-write --allow-net -n cdxgen "npm:@cyclonedx/cdxgen/cdxgen" \
+    && deno install --allow-read --allow-env --allow-run --allow-sys=uid,systemMemoryInfo,gid --allow-write --allow-net -n cdxgen "npm:@cyclonedx/cdxgen/cdxgen" \
     && curl -s "https://get.sdkman.io" | bash \
     && source "$HOME/.sdkman/bin/sdkman-init.sh" \
     && echo -e "sdkman_auto_answer=true\nsdkman_selfupdate_feature=false\nsdkman_auto_env=true" >> $HOME/.sdkman/etc/config \

--- a/contrib/deno/README.md
+++ b/contrib/deno/README.md
@@ -10,5 +10,5 @@ Install deno by following the [instructions](https://deno.land/manual@v1.34.3/ge
 
 ```shell
 cd contrib/deno
-deno run --allow-read --allow-env --allow-run --allow-sys=uid,systemMemoryInfo --allow-write --allow-net main.ts <path to repo>
+deno run --allow-read --allow-env --allow-run --allow-sys=uid,systemMemoryInfo,gid --allow-write --allow-net main.ts <path to repo>
 ```

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -18,7 +18,7 @@ $ brew install cdxgen
 Deno install is also supported.
 
 ```shell
-deno install --allow-read --allow-env --allow-run --allow-sys=uid,systemMemoryInfo --allow-write --allow-net -n cdxgen "npm:@cyclonedx/cdxgen/cdxgen"
+deno install --allow-read --allow-env --allow-run --allow-sys=uid,systemMemoryInfo,gid --allow-write --allow-net -n cdxgen "npm:@cyclonedx/cdxgen/cdxgen"
 ```
 
 You can also use the cdxgen container image


### PR DESCRIPTION
Adding the "gid" flag to successfully build the cdxgen-deno docker image (CI).

Ref: https://docs.deno.com/runtime/manual/basics/permissions#permissions-list

GH Issue: https://github.com/CycloneDX/cdxgen/issues/558