### PR TITLE
Use shell for windows command invocations

### DIFF
--- a/.github/workflows/dockertests.yml
+++ b/.github/workflows/dockertests.yml
@@ -3,7 +3,6 @@ name: docker tests
 on:
   push:
     branches:
-      - master
       - feature/*
       - release/*
       - fix/*

--- a/.github/workflows/repotests.yml
+++ b/.github/workflows/repotests.yml
@@ -3,7 +3,6 @@ name: Repo tests
 on:
   push:
     branches:
-      - master
       - feature/*
       - release/*
       - fix/*
@@ -47,6 +46,8 @@ jobs:
           mkdir -p denoresults
         env:
           CI: true
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v2
       - uses: swift-actions/setup-swift@v1
         if: matrix.os == 'ubuntu-latest'
       - uses: actions/checkout@v4
@@ -117,6 +118,10 @@ jobs:
         with:
           repository: 'openpbs/openpbs'
           path: 'repotests/openpbs'
+      - uses: actions/checkout@v4
+        with:
+          repository: 'home-assistant/android'
+          path: 'repotests/ha-android'
       - name: repotests
         run: |
           bin/cdxgen.js -p -r -t java repotests/shiftleft-java-example -o bomresults/bom-java.json --generate-key-and-sign
@@ -126,8 +131,8 @@ jobs:
           node bin/evinse.js -i bomresults/bom-ts.json -o bomresults/bom-ts.evinse.json -l javascript --with-data-flow -p repotests/shiftleft-ts-example
           FETCH_LICENSE=false bin/cdxgen.js -p -t js repotests/meetingsdk-vuejs-sample -o bomresults/bom-vue.json
           node bin/evinse.js -i bomresults/bom-vue.json -o bomresults/bom-vue.evinse.json -l javascript --with-data-flow -p repotests/meetingsdk-vuejs-sample
-          ASTGEN_IGNORE_DIRS="" FETCH_LICENSE=false bin/cdxgen.js -p -t js repotests/sveltejs-examples -o bomresults/bom-svelte.json
-          ASTGEN_IGNORE_DIRS="" node bin/evinse.js -i bomresults/bom-svelte.json -o bomresults/bom-svelte.evinse.json -l javascript --with-data-flow -p repotests/sveltejs-examples
+          CDXGEN_DEBUG_MODE=debug ASTGEN_IGNORE_DIRS="" FETCH_LICENSE=false bin/cdxgen.js -p -t js repotests/sveltejs-examples -o bomresults/bom-svelte.json
+          CDXGEN_DEBUG_MODE=debug ASTGEN_IGNORE_DIRS="" node bin/evinse.js -i bomresults/bom-svelte.json -o bomresults/bom-svelte.evinse.json -l javascript --with-data-flow -p repotests/sveltejs-examples
           FETCH_LICENSE=1 bin/cdxgen.js -p -t js repotests/shiftleft-ts-example --required-only -o bomresults/bom-ts.json --validate
           FETCH_LICENSE=false bin/cdxgen.js -p -r -t go repotests/shiftleft-go-example -o bomresults/bom-go.json --validate
           FETCH_LICENSE=true bin/cdxgen.js -p -r -t csharp repotests/vulnerable_net_core -o bomresults/bom-csharp2.json --validate
@@ -145,6 +150,9 @@ jobs:
           bin/cdxgen.js -r -t yaml-manifest repotests/microservices-demo -o bomresults/bom-yaml.json --validate
           FETCH_LICENSE=true bin/cdxgen.js -p -r -t js repotests/shiftleft-ts-example -o bomresults/bom-ts.json --validate
           bin/cdxgen.js -r -t c repotests/openpbs -o bomresults/bom-openpbs.json
+          cd repotests/ha-android && ./gradlew assembleDebug || true && cd ../..
+          bin/cdxgen.js -r -t java repotests/ha-android -o bomresults/bom-android.json
+          CDXGEN_DEBUG_MODE=debug bin/evinse.js -i bomresults/bom-android.json -o bomresults/bom-android.evinse.json -l java repotests/ha-android
           # mkdir -p jenkins
           # wget https://updates.jenkins.io/download/plugins/sonar/2.14/sonar.hpi
           # wget https://updates.jenkins.io/download/plugins/bouncycastle-api/2.26/bouncycastle-api.hpi

--- a/docs/ADVANCED.md
+++ b/docs/ADVANCED.md
@@ -151,3 +151,18 @@ node bin/cdxgen.js -o bom.json -t c --usages-slices-file usages.json <path to re
 ```
 
 Change 16g to 32g or above for very large projects. For the Linux kernel, a minimum of 128GB is required.
+
+## Remove the SQLite cache db used by evinse
+
+If you face a situation where the namespaces cached by evinse are outdated or incorrect, you can try deleting the file `.atomdb` to recreate it. Below are the locations where this file gets stored by default. This can be overridden by setting the environment variable `ATOM_DB`.
+
+```javascript
+// linux
+let ATOM_DB = join(homedir(), ".local", "share", ".atomdb");
+
+// Windows
+ATOM_DB = join(homedir(), "AppData", "Local", ".atomdb");
+
+// Mac
+ATOM_DB = join(homedir(), "Library", "Application Support", ".atomdb");
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cyclonedx/cdxgen",
-  "version": "9.8.2",
+  "version": "9.8.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cyclonedx/cdxgen",
-      "version": "9.8.2",
+      "version": "9.8.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/parser": "^7.22.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cyclonedx/cdxgen",
-  "version": "9.8.2",
+  "version": "9.8.3",
   "description": "Creates CycloneDX Software Bill-of-Materials (SBOM) from source or container image",
   "homepage": "http://github.com/cyclonedx/cdxgen",
   "author": "Prabhu Subramanian <prabhu@appthreat.com>",

--- a/utils.test.js
+++ b/utils.test.js
@@ -1143,7 +1143,7 @@ test("parse github actions workflow data", async () => {
   dep_list = parseGitHubWorkflowData(
     readFileSync("./.github/workflows/repotests.yml", { encoding: "utf-8" })
   );
-  expect(dep_list.length).toEqual(5);
+  expect(dep_list.length).toEqual(6);
   expect(dep_list[0]).toEqual({
     group: "actions",
     name: "checkout",


### PR DESCRIPTION
- [ ] Use shell for windows command invocations
- [ ] Update docs

With this PR, I could run evinse on Windows for an Android with gradle application. Install Android Sdk and set ANDROID_HOME before running evinse.

On my machine, the SDK got installed under `\AppData\Local\Android\Sdk`

https://github.com/home-assistant/android