### PR TITLE
Add NPM License Support from Package-Lock v2+

### DIFF
--- a/test/data/package-json/v2-workspace/package-lock.json
+++ b/test/data/package-json/v2-workspace/package-lock.json
@@ -8,6 +8,7 @@
       "name": "root",
       "version": "0.0.0",
       "hasInstallScript": true,
+      "license": "MIT",
       "workspaces": [
         "app",
         "edge",

--- a/test/data/package-json/v2-workspace/package.json
+++ b/test/data/package-json/v2-workspace/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "packageManager": "yarn@4.0.0-rc.50",
   "type": "module",
+  "license": "MIT",
   "workspaces": [
     "app",
     "edge",

--- a/test/data/package-json/v2/package-lock.json
+++ b/test/data/package-json/v2/package-lock.json
@@ -174,6 +174,7 @@
       "version": "0.8.11",
       "resolved": "https://registry.npmjs.org/@types/shelljs/-/shelljs-0.8.11.tgz",
       "integrity": "sha512-x9yaMvEh5BEaZKeVQC4vp3l+QoFj3BXcd4aYfuKSzIIyihjdVARAadYy3SMNIz0WCCdS2vB9JL/U6GQk5PaxQw==",
+      "license": "Apache-2.0",
       "dev": true,
       "dependencies": {
         "@types/glob": "*",

--- a/utils.js
+++ b/utils.js
@@ -513,6 +513,11 @@ export const parsePkgLock = async (pkgLockFile, options = {}) => {
         "bom-ref": purlString
       };
     }
+    const packageLicense = node.package.license;
+    if (packageLicense) {
+      // License will be overridden if FETCH_LICENSE is enabled
+      pkg.license = packageLicense;
+    }
     pkgList.push(pkg);
 
     // retrieve workspace node pkglists

--- a/utils.js
+++ b/utils.js
@@ -323,7 +323,9 @@ export const getNpmMetadata = async function (pkgList) {
         metadata_cache[key] = body;
       }
       p.description = body.description;
-      p.license = body.license;
+      if (!p.license) {
+        p.license = body.license;
+      }
       if (body.repository && body.repository.url) {
         p.repository = { url: body.repository.url };
       }
@@ -515,7 +517,6 @@ export const parsePkgLock = async (pkgLockFile, options = {}) => {
     }
     const packageLicense = node.package.license;
     if (packageLicense) {
-      // License will be overridden if FETCH_LICENSE is enabled
       pkg.license = packageLicense;
     }
     pkgList.push(pkg);
@@ -659,7 +660,7 @@ export const parsePkgLock = async (pkgLockFile, options = {}) => {
     options
   ));
 
-  if (FETCH_LICENSE && pkgList && pkgList.length) {
+  if (FETCH_LICENSE && pkgList?.length) {
     if (DEBUG_MODE) {
       console.log(
         `About to fetch license information for ${pkgList.length} packages in parsePkgLock`

--- a/utils.js
+++ b/utils.js
@@ -323,9 +323,7 @@ export const getNpmMetadata = async function (pkgList) {
         metadata_cache[key] = body;
       }
       p.description = body.description;
-      if (!p.license) {
-        p.license = body.license;
-      }
+      p.license = body.license;
       if (body.repository && body.repository.url) {
         p.repository = { url: body.repository.url };
       }
@@ -517,6 +515,7 @@ export const parsePkgLock = async (pkgLockFile, options = {}) => {
     }
     const packageLicense = node.package.license;
     if (packageLicense) {
+      // License will be overridden if FETCH_LICENSE is enabled
       pkg.license = packageLicense;
     }
     pkgList.push(pkg);
@@ -660,7 +659,7 @@ export const parsePkgLock = async (pkgLockFile, options = {}) => {
     options
   ));
 
-  if (FETCH_LICENSE && pkgList?.length) {
+  if (FETCH_LICENSE && pkgList && pkgList.length) {
     if (DEBUG_MODE) {
       console.log(
         `About to fetch license information for ${pkgList.length} packages in parsePkgLock`

--- a/utils.test.js
+++ b/utils.test.js
@@ -1533,11 +1533,13 @@ test("parsePkgLock v2", async () => {
   expect(deps[1]._integrity).toEqual(
     "sha512-x9yaMvEh5BEaZKeVQC4vp3l+QoFj3BXcd4aYfuKSzIIyihjdVARAadYy3SMNIz0WCCdS2vB9JL/U6GQk5PaxQw=="
   );
+  expect(deps[1].license).toEqual("Apache-2.0");
   expect(deps[0]).toEqual({
     "bom-ref": "pkg:npm/shopify-theme-tailwindcss@2.2.1",
     author: "Wessel van Ree <hello@wesselvanree.com>",
     group: "",
     name: "shopify-theme-tailwindcss",
+    license: "MIT",
     type: "application",
     version: "2.2.1"
   });
@@ -1568,6 +1570,7 @@ test("parsePkgLock v2 workspace", async () => {
   let pkgs = parsedList.pkgList;
   let deps = parsedList.dependenciesList;
   expect(pkgs.length).toEqual(1032);
+  expect(pkgs[0].license).toEqual("MIT");
   let hasAppWorkspacePkg = pkgs.some(
     (obj) => obj["bom-ref"] === "pkg:npm/app@0.0.0"
   );
@@ -1605,6 +1608,7 @@ test("parsePkgLock v3", async () => {
     "bom-ref": "pkg:npm/cdxgen@latest",
     group: "",
     author: "",
+    license: "ISC",
     name: "cdxgen",
     type: "application",
     version: "latest"


### PR DESCRIPTION
Package-lock, starting in version 2, optionally provides package licenses that should be incorporated into BOM generation.