### PR TITLE
feat(server): set projectType is passed via POST JSON Body

### DIFF
--- a/server.js
+++ b/server.js
@@ -41,6 +41,7 @@ const gitClone = (repoUrl) => {
 const parseQueryString = (q, body, options = {}) => {
   if (body && Object.keys(body).length) {
     options = Object.assign(options, body);
+    options.projectType = options.type;
   }
   if (q.type) {
     options.projectType = q.type;


### PR DESCRIPTION
I noticed that when parsing arguments via POST JSON Body that there was a mismatch in how `type` and `projectType` are handled, when compared to the queryString equivalent