### PR TITLE
fix: remove purl decoding

### DIFF
--- a/.github/workflows/repotests.yml
+++ b/.github/workflows/repotests.yml
@@ -122,6 +122,23 @@ jobs:
         with:
           repository: 'home-assistant/android'
           path: 'repotests/ha-android'
+      - uses: actions/checkout@v4
+        with:
+          repository: 'rust-lang/rust'
+          path: 'repotests/rs-rust'
+      - uses: actions/checkout@v4
+        with:
+          repository: 'rust-lang/cargo'
+          path: 'repotests/rs-cargo'
+      - uses: actions/checkout@v4
+        with:
+          repository: 'Keats/validator'
+          path: 'repotests/rs-validator'
+      - uses: actions/checkout@v4
+        with:
+          repository: 'tokio-rs/axum'
+          path: 'repotests/rs-axum'
+      - uses: dtolnay/rust-toolchain@stable
       - name: repotests
         run: |
           bin/cdxgen.js -p -r -t java repotests/shiftleft-java-example -o bomresults/bom-java.json --generate-key-and-sign
@@ -153,6 +170,11 @@ jobs:
           cd repotests/ha-android && ./gradlew assembleDebug || true && cd ../..
           bin/cdxgen.js -r -t java repotests/ha-android -o bomresults/bom-android.json
           CDXGEN_DEBUG_MODE=debug bin/evinse.js -i bomresults/bom-android.json -o bomresults/bom-android.evinse.json -l java repotests/ha-android
+          bin/cdxgen.js -r -t rust repotests/rs-rust -o bomresults/bom-rs-rust.json --validate
+          bin/cdxgen.js -r -t rust repotests/rs-cargo -o bomresults/bom-rs-cargo.json --validate
+          cargo generate-lockfile --manifest-path repotests/rs-validator/validator/Cargo.toml
+          bin/cdxgen.js -r -t rust repotests/rs-validator -o bomresults/bom-rs-validator.json --validate
+          bin/cdxgen.js -r -t rust repotests/rs-axum -o bomresults/bom-rs-axum.json --validate
           # mkdir -p jenkins
           # wget https://updates.jenkins.io/download/plugins/sonar/2.14/sonar.hpi
           # wget https://updates.jenkins.io/download/plugins/bouncycastle-api/2.26/bouncycastle-api.hpi

--- a/index.js
+++ b/index.js
@@ -686,7 +686,6 @@ function addComponent(
         encodeForPurl(pkg.subpath)
       );
     let purlString = purl.toString();
-    purlString = decodeURIComponent(purlString);
     let description = { "#cdata": pkg.description };
     if (format === "json") {
       description = pkg.description || undefined;

--- a/utils.test.js
+++ b/utils.test.js
@@ -1143,7 +1143,7 @@ test("parse github actions workflow data", async () => {
   dep_list = parseGitHubWorkflowData(
     readFileSync("./.github/workflows/repotests.yml", { encoding: "utf-8" })
   );
-  expect(dep_list.length).toEqual(6);
+  expect(dep_list.length).toEqual(7);
   expect(dep_list[0]).toEqual({
     group: "actions",
     name: "checkout",


### PR DESCRIPTION
this breaks PackageURL.fromString from packageurl-js when the version contains e.g. a +

fixes https://github.com/CycloneDX/cdxgen/issues/589