### PR TITLE
feat: safely log git url

### DIFF
--- a/server.js
+++ b/server.js
@@ -27,12 +27,7 @@ app.use(compression());
 const gitClone = (repoUrl) => {
   const parsedUrl = new URL(repoUrl);
 
-  const userInfo =
-    parsedUrl.username && parsedUrl.password
-      ? `${parsedUrl.username}:*****`
-      : parsedUrl.username || "";
-
-  const sanitizedRepoUrl = `${parsedUrl.protocol}//${userInfo}${parsedUrl.host}${parsedUrl.pathname}`;
+  const sanitizedRepoUrl = `${parsedUrl.protocol}//${parsedUrl.host}${parsedUrl.pathname}`;
 
   const tempDir = fs.mkdtempSync(
     path.join(os.tmpdir(), path.basename(parsedUrl.pathname))

--- a/server.js
+++ b/server.js
@@ -35,7 +35,7 @@ const gitClone = (repoUrl) => {
   const sanitizedRepoUrl = `${parsedUrl.protocol}//${userInfo}${parsedUrl.host}${parsedUrl.pathname}`;
 
   const tempDir = fs.mkdtempSync(
-    path.join(os.tmpdir(), path.basename(repoUrl))
+    path.join(os.tmpdir(), path.basename(parsedUrl.pathname))
   );
   console.log("Cloning", sanitizedRepoUrl, "to", tempDir);
   const result = spawnSync("git", ["clone", repoUrl, "--depth", "1", tempDir], {

--- a/server.js
+++ b/server.js
@@ -8,6 +8,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { createBom, submitBom } from "./index.js";
 import compression from "compression";
+import { URL } from "url";
 
 // Timeout milliseconds. Default 10 mins
 const TIMEOUT_MS =
@@ -24,10 +25,19 @@ app.use(
 app.use(compression());
 
 const gitClone = (repoUrl) => {
+  const parsedUrl = new URL(repoUrl);
+
+  const userInfo =
+    parsedUrl.username && parsedUrl.password
+      ? `${parsedUrl.username}:*****`
+      : parsedUrl.username || "";
+
+  const sanitizedRepoUrl = `${parsedUrl.protocol}//${userInfo}${parsedUrl.host}${parsedUrl.pathname}`;
+
   const tempDir = fs.mkdtempSync(
     path.join(os.tmpdir(), path.basename(repoUrl))
   );
-  console.log("Cloning", repoUrl, "to", tempDir);
+  console.log("Cloning", sanitizedRepoUrl, "to", tempDir);
   const result = spawnSync("git", ["clone", repoUrl, "--depth", "1", tempDir], {
     encoding: "utf-8",
     shell: false


### PR DESCRIPTION
Ensure repoUrl username/password and query parameters aren't including within any logs or directory names