### PR TITLE
Enable deep mode for poetry 

### DIFF
--- a/.github/workflows/repotests.yml
+++ b/.github/workflows/repotests.yml
@@ -140,6 +140,10 @@ jobs:
         with:
           repository: 'fsprojects/FAKE'
           path: 'repotests/dotnet-paket'
+      - uses: actions/checkout@v4
+        with:
+          repository: 'appthreat/blint'
+          path: 'repotests/blint'
       - uses: dtolnay/rust-toolchain@stable
       - name: repotests
         run: |
@@ -178,6 +182,8 @@ jobs:
           bin/cdxgen.js -r -t rust repotests/rs-validator -o bomresults/bom-rs-validator.json --validate
           bin/cdxgen.js -r -t rust repotests/rs-axum -o bomresults/bom-rs-axum.json --validate
           bin/cdxgen.js -p -r -t dotnet repotests/dotnet-paket -o bomresults/bom-dotnet-paket.json --validate
+          bin/cdxgen.js -p -t python repotests/blint -o bomresults/bom-blint.json
+          bin/cdxgen.js -p -t python repotests/blint -o bomresults/bom-blint-deep.json --deep
           # mkdir -p jenkins
           # wget https://updates.jenkins.io/download/plugins/sonar/2.14/sonar.hpi
           # wget https://updates.jenkins.io/download/plugins/bouncycastle-api/2.26/bouncycastle-api.hpi

--- a/index.js
+++ b/index.js
@@ -2321,8 +2321,10 @@ export const createPythonBom = async (path, options) => {
           retMap.dependenciesList,
           parentComponent
         );
-      } else {
-        // Fallback to retrieving the tree using virtualenv
+      }
+      // Retrieve the tree using virtualenv in deep mode and as a fallback
+      // This is a slow operation
+      if (options.deep || !dependencies.length) {
         retMap = getPipFrozenTree(basePath, f, tempDir);
         if (retMap.pkgList && retMap.pkgList.length) {
           pkgList = pkgList.concat(retMap.pkgList);


### PR DESCRIPTION
This uses the piptree-based dependency tree construction, which captures more indirect dependencies (at least double) that may not be present in the poetry lock file.

Also added poetry normal and deep tests to repotest to showcase the difference.