### PR TITLE
Fix dotnet project.assets dependency tree

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -4813,7 +4813,7 @@ export const parseCsProjAssetsData = async function (csProjData) {
           }
         }
         pkgList.push(pkg);
-        pkgNameVersionMap[name] = version;
+        pkgNameVersionMap[name + framework] = version;
         pkgAddedMap[name] = true;
       }
     }
@@ -4830,10 +4830,10 @@ export const parseCsProjAssetsData = async function (csProjData) {
         if (dependencies) {
           for (const p of Object.keys(dependencies)) {
             // This condition is not required for assets json that are well-formed.
-            if (!pkgNameVersionMap[p]) {
+            if (!pkgNameVersionMap[p + framework]) {
               continue;
             }
-            let dversion = pkgNameVersionMap[p];
+            let dversion = pkgNameVersionMap[p + framework];
             const ipurl = decodeURIComponent(
               new PackageURL("nuget", "", p, dversion, null, null).toString()
             );

--- a/utils.js
+++ b/utils.js
@@ -4702,7 +4702,7 @@ export const parseCsProjAssetsData = async function (csProjData) {
   // extract name, operator, version from .NET package representation
   // like "NLog >= 4.5.0"
   function extractNameOperatorVersion(inputStr) {
-    const extractNameOperatorVersion = /([\w.]+)\s*([><=!]+)\s*([\d.]+)/;
+    const extractNameOperatorVersion = /([\w.-]+)\s*([><=!]+)\s*([\d.]+)/;
     const match = inputStr.match(extractNameOperatorVersion);
 
     if (match) {

--- a/utils.test.js
+++ b/utils.test.js
@@ -1265,6 +1265,9 @@ test("parse project.assets.json", async () => {
   expect(dep_list["dependenciesList"][0]).toEqual({
     dependsOn: [
       "pkg:nuget/Castle.Core@0.0.0",
+      "pkg:nuget/Castle.Core-NLog@0.0.0",
+      "pkg:nuget/Castle.Core-Serilog@0.0.0",
+      "pkg:nuget/Castle.Core-log4net@0.0.0",
       "pkg:nuget/Microsoft.NET.Test.Sdk@17.1.0",
       "pkg:nuget/Microsoft.NETCore.App@2.1.0",
       "pkg:nuget/Microsoft.NETFramework.ReferenceAssemblies@1.0.0",


### PR DESCRIPTION
Expand the package name, version tracking by keeping a separate entry for each target framework.

Fixes an issue where package dependency versions were incorrect when different target frameworks contained different versions of the package.