### PR TITLE
refactor: remove dependency track spec downgrade

### DIFF
--- a/bin/cdxgen.js
+++ b/bin/cdxgen.js
@@ -213,11 +213,6 @@ if (!args.projectName) {
   }
 }
 
-// To help dependency track users, we downgrade the spec version to 1.4 automatically
-if (args.serverUrl || args.apiKey) {
-  args.specVersion = 1.4;
-}
-
 // Support for obom aliases
 if (process.argv[1].includes("obom") && !args.type) {
   args.type = "os";

--- a/server.js
+++ b/server.js
@@ -74,11 +74,6 @@ const parseQueryString = (q, body, options = {}) => {
     }
   }
 
-  // To help dependency track users, we downgrade the spec version to 1.4 automatically
-  if (options.serverUrl || options.apiKey) {
-    options.specVersion = 1.4;
-  }
-
   options.projectType == options.type;
   delete options.type;
 


### PR DESCRIPTION
Dependency Track 4.9.0 now supports CycloneDX 1.5

Removing the two downgrades we had.