### PR TITLE
Paket.lock - include patch versions when omitted by Paket

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -4888,6 +4888,14 @@ export const parseCsPkgLockData = async function (csLockData) {
 };
 
 export const parsePaketLockData = async function (paketLockData) {
+  // Include patch version when not set by Paket
+  function formatVersion(version) {
+    if (version.split(".").length == 2) {
+      return version + ".0";
+    }
+    return version;
+  }
+
   const pkgList = [];
   const dependenciesList = [];
   const dependenciesMap = {};
@@ -4914,7 +4922,7 @@ export const parsePaketLockData = async function (paketLockData) {
     match = l.match(pkgRegex);
     if (match) {
       const name = match[1];
-      const version = match[2];
+      const version = formatVersion(match[2]);
       const purl = decodeURIComponent(
         new PackageURL("nuget", "", name, version, null, null).toString()
       );
@@ -4944,7 +4952,7 @@ export const parsePaketLockData = async function (paketLockData) {
     match = l.match(pkgRegex);
     if (match) {
       const pkgName = match[1];
-      const pkgVersion = match[2];
+      const pkgVersion = formatVersion(match[2]);
       purl = decodeURIComponent(
         new PackageURL("nuget", "", pkgName, pkgVersion, null, null).toString()
       );

--- a/utils.test.js
+++ b/utils.test.js
@@ -1313,15 +1313,15 @@ test("parse paket.lock", async () => {
   expect(dep_list.pkgList[0]).toEqual({
     group: "",
     name: "0x53A.ReferenceAssemblies.Paket",
-    version: "0.2",
-    purl: "pkg:nuget/0x53A.ReferenceAssemblies.Paket@0.2"
+    version: "0.2.0",
+    purl: "pkg:nuget/0x53A.ReferenceAssemblies.Paket@0.2.0"
   });
   expect(dep_list.dependenciesList.length).toEqual(13);
   expect(dep_list.dependenciesList[2]).toEqual({
     ref: "pkg:nuget/FSharp.Compiler.Service@17.0.1",
     dependsOn: [
-      "pkg:nuget/System.Collections.Immutable@1.4",
-      "pkg:nuget/System.Reflection.Metadata@1.5"
+      "pkg:nuget/System.Collections.Immutable@1.4.0",
+      "pkg:nuget/System.Reflection.Metadata@1.5.0"
     ]
   });
 });


### PR DESCRIPTION
Add .0 patch versions to the BOM when Paket omits them from the lockfile. Improves querying licesense information, and version handling in Dependency-Track.