### PR TITLE
fix: correctly set projectType option

### DIFF
--- a/server.js
+++ b/server.js
@@ -92,7 +92,7 @@ const parseQueryString = (q, body, options = {}) => {
     }
   }
 
-  options.projectType == options.type;
+  options.projectType = options.type;
   delete options.type;
 
   return options;


### PR DESCRIPTION
Previously parsing a `type` argument/param was not being correctly passed through