### PR TITLE
Enhance route detection for java with latest atom

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -11,6 +11,7 @@ module.exports = {
     "sourceType": "module"
   },
   "rules": {
-    "prettier/prettier": "error"
+    "prettier/prettier": "error",
+    "no-constant-binary-expression": "error"
   }
 };

--- a/bin/cdxgen.js
+++ b/bin/cdxgen.js
@@ -520,7 +520,6 @@ const checkPermissions = (filePath) => {
       if (bomNSData.nsMapping && Object.keys(bomNSData.nsMapping).length) {
         const nsFile = jsonFile + ".map";
         fs.writeFileSync(nsFile, JSON.stringify(bomNSData.nsMapping));
-        console.log("Namespace mapping file written to", nsFile);
       }
     }
   } else if (!options.print) {

--- a/evinser.js
+++ b/evinser.js
@@ -834,7 +834,7 @@ export const extractEndpoints = (language, code) => {
     case "jar":
       if (
         code.startsWith("@") &&
-        code.includes("Mapping") &&
+        (code.includes("Mapping") || code.includes("Path")) &&
         code.includes("(")
       ) {
         const matches = code.match(/['"](.*?)['"]/gi) || [];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cyclonedx/cdxgen",
-  "version": "9.9.3",
+  "version": "9.9.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cyclonedx/cdxgen",
-      "version": "9.9.3",
+      "version": "9.9.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/parser": "^7.23.0",
@@ -56,7 +56,7 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@appthreat/atom": "1.5.6",
+        "@appthreat/atom": "1.5.7",
         "@cyclonedx/cdxgen-plugins-bin": "^1.4.0",
         "@cyclonedx/cdxgen-plugins-bin-arm64": "^1.4.0",
         "@cyclonedx/cdxgen-plugins-bin-ppc64": "^1.4.0",
@@ -91,9 +91,9 @@
       }
     },
     "node_modules/@appthreat/atom": {
-      "version": "1.5.6",
-      "resolved": "https://registry.npmjs.org/@appthreat/atom/-/atom-1.5.6.tgz",
-      "integrity": "sha512-TkE22sAfEGsUWGE5LTwsn70HR/0mEVK9BXyas+EMlgevu1kj/6QkMFQDOF1hINvKL0C1fOQ7dvs9S6A4eXL1vw==",
+      "version": "1.5.7",
+      "resolved": "https://registry.npmjs.org/@appthreat/atom/-/atom-1.5.7.tgz",
+      "integrity": "sha512-ZCxdzLADOixmPB8uU0siE8Y2zsdCExxQwW/gB5adpoe+3mM6xI17DIeTY2wHc0DdtwnATI4rG7cfAohLGwlaVg==",
       "optional": true,
       "dependencies": {
         "@babel/parser": "^7.23.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cyclonedx/cdxgen",
-  "version": "9.9.3",
+  "version": "9.9.4",
   "description": "Creates CycloneDX Software Bill of Materials (SBOM) from source or container image",
   "homepage": "http://github.com/cyclonedx/cdxgen",
   "author": "Prabhu Subramanian <prabhu@appthreat.com>",
@@ -83,7 +83,7 @@
     "yargs": "^17.7.2"
   },
   "optionalDependencies": {
-    "@appthreat/atom": "1.5.6",
+    "@appthreat/atom": "1.5.7",
     "@cyclonedx/cdxgen-plugins-bin": "^1.4.0",
     "@cyclonedx/cdxgen-plugins-bin-arm64": "^1.4.0",
     "@cyclonedx/cdxgen-plugins-bin-ppc64": "^1.4.0",


### PR DESCRIPTION
With the new atom and this PR, we can resolve the routes and add endpoints to the generated BOM for dependency track.

<img width="1006" alt="Screenshot_20231109_093721-1" src="https://github.com/CycloneDX/cdxgen/assets/7842/082dce1d-1449-498a-8b92-9ed6858fb9d9">

Related: https://github.com/DependencyTrack/dependency-track/pull/3181