### PR TITLE
Fixes for Server params

### DIFF
--- a/docs/SERVER.md
+++ b/docs/SERVER.md
@@ -29,17 +29,25 @@ Use curl or your favorite tool to pass arguments to the `/sbom` route.
 
 Arguments can be passed either via the query string or as a JSON body. The following arguments are supported.
 
-| Argument       | Description                                                                                                                                 |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| type           | Project type                                                                                                                                |
-| multiProject   | [boolean]                                                                                                                                   |
-| requiredOnly   | Include only the packages with required scope on the SBOM. [boolean]                                                                        |
-| noBabel        | Do not use babel to perform usage analysis for JavaScript/TypeScript projects. [boolean]                                                    |
-| installDeps    | Install dependencies automatically for some projects. Defaults to true but disabled for containers and oci scans. [boolean] [default: true] |
-| project        |                                                                                                                                             |
-| projectName    | Dependency track project name. Default use the directory name                                                                               |
-| projectGroup   | Dependency track project group                                                                                                              |
-| projectVersion | Dependency track project version [default: ""]                                                                                              |
+| Argument         | Description                                                                                                                                      |
+|------------------|--------------------------------------------------------------------------------------------------------------------------------------------------|
+| type             | Project type                                                                                                                                     |
+| multiProject     | [boolean]                                                                                                                                        |
+| requiredOnly     | Include only the packages with required scope on the SBOM. [boolean]                                                                             |
+| noBabel          | Do not use babel to perform usage analysis for JavaScript/TypeScript projects. [boolean]                                                         |
+| installDeps      | Install dependencies automatically for some projects. Defaults to true but disabled for containers and oci scans. [boolean] [default: true]      |
+| projectId        | The UUID of the project.  You must provide the UUID or the projectName and projectVersion (or all three).                                        |
+| projectName      | Dependency Track project name. Default use the directory name                                                                                    |
+| projectGroup     | Dependency Track project group                                                                                                                   |
+| projectVersion   | Dependency Track project version [default: ""]                                                                                                   |
+| parentUUID       | UUID of the parent project.                                                                                                                      |
+| serverUrl        | URL to the Dependency Track API server.                                                                                                          |
+| apiKey           | API key for the Dependency Track API server.                                                                                                     |
+| specVersion      | CycloneDX Specification version to use. [default: 1.5]                                                                                           |
+| filter           | Filter components containing this word in purl. Multiple values allowed. [array]                                                                 |
+| only             | Include components only containing this word in purl. Useful to generate BOM with first party components alone. Multiple values allowed. [array] |
+| autoCompositions | Automatically set compositions when the BOM was filtered. [boolean] [default: true]                                                              |
+| gitBranch        | Git branch used when cloning the repository. If not specified will use the default branch assigned to the repository.                            |
 
 ## Ways to use server mode
 
@@ -59,6 +67,20 @@ You can POST the arguments.
 
 ```bash
 curl -H "Content-Type: application/json" http://localhost:9090/sbom -XPOST -d $'{"url": "https://github.com/HooliCorp/vulnerable-aws-koa-app.git", "type": "nodejs", "multiProject": "true"}'
+```
+Using requests.post in Python:
+```python
+import requests
+data = {
+    "url": f"https://user:{github_api_key}@github.com/{organization}/{repository}.git",
+    "serverUrl": dependencytrack_api_url,
+    "apiKey": dependencytrack_api_key
+    "projectId": project_uuid,
+    "projectName": project_name,
+    "projectVersion": project_version,
+    "parentUUID": parent_uuid
+}
+response = requests.post(url=cdxgen_server_url, json=data, allowed_retries=0)
 ```
 
 ### Health endpoint

--- a/index.js
+++ b/index.js
@@ -5544,19 +5544,36 @@ export async function submitBom(args, bomContents) {
   if (encodedBomContents.startsWith("77u/")) {
     encodedBomContents = encodedBomContents.substring(4);
   }
-  let projectVersion = args.projectVersion || "master";
-  if (projectVersion == true) {
-    projectVersion = "master";
-  }
   const bomPayload = {
-    project: args.projectId,
-    projectName: args.projectName,
-    projectVersion: projectVersion,
     autoCreate: "true",
     bom: encodedBomContents
   };
-  if (typeof args.parentProjectId !== "undefined") {
-    bomPayload.parentUUID = args.parentProjectId;
+  let projectVersion = args.projectVersion || "master";
+  if (
+    typeof args.projectId !== "undefined" ||
+    (typeof args.projectName !== "undefined" &&
+      typeof projectVersion !== "undefined")
+  ) {
+    if (typeof args.projectId !== "undefined") {
+      bomPayload.project = args.projectId;
+    }
+    if (typeof args.projectName !== "undefined") {
+      bomPayload.projectName = args.projectName;
+    }
+    if (typeof projectVersion !== "undefined") {
+      bomPayload.projectVersion = projectVersion;
+    }
+  } else {
+    console.log(
+      "projectId, projectName and projectVersion, or all three must be provided."
+    );
+    return;
+  }
+  if (
+    typeof args.parentProjectId !== "undefined" ||
+    typeof args.parentUUID !== "undefined"
+  ) {
+    bomPayload.parentUUID = args.parentProjectId || args.parentUUID;
   }
   if (DEBUG_MODE) {
     console.log(

--- a/server.js
+++ b/server.js
@@ -72,7 +72,7 @@ const parseQueryString = (q, body, options = {}) => {
     "requiredOnly",
     "noBabel",
     "installDeps",
-    "project",
+    "projectId",
     "projectName",
     "projectGroup",
     "projectVersion",


### PR DESCRIPTION
Correct project to projectId in server.js.  This should just pass through now and match, though anyone who's using the old param will have to move to the new one.

Handle DT requirement of having project ID OR name/version.  If you are missing the ID and the name or version, then it'll reject the BOM.  Pop a log message and return early if we are missing it.

Pass in parentUUID if running from server.js.  When looking at the projectId I noticed we're not actually catching the parentUUID from the server side.  I left this naming alone even though it's slightly different from ParentId.

Update SERVER.md.  There wasn't anything in for `project` (which got renamed to `projectId`), and added in all the other parameters that the server supports so they are no longer undocumented. Also added an example for posting a request using python.


I'm not a JS dev by trade, so please validate these changes.

Should resolve:
https://github.com/CycloneDX/cdxgen/issues/718