### PR TITLE
Improved detection for standalone jar files by using pom.properties file if available

### DIFF
--- a/.github/workflows/repotests.yml
+++ b/.github/workflows/repotests.yml
@@ -220,6 +220,16 @@ jobs:
           mv *.hpi jenkins
           CDXGEN_DEBUG_MODE=debug bin/cdxgen.js -p -r -t jenkins jenkins -o bomresults/bom-jenkins.json --validate
         shell: bash
+      - name: standalone jar files
+        run: |
+          mkdir -p standalone-jar-files
+          curl --output-dir standalone-jar-files -LO https://repo1.maven.org/maven2/org/jacoco/org.jacoco.report/0.8.8/org.jacoco.report-0.8.8.jar
+          curl --output-dir standalone-jar-files -LO https://repo1.maven.org/maven2/org/apache/ws/xmlschema/xmlschema-core/2.2.5/xmlschema-core-2.2.5.jar
+          curl --output-dir standalone-jar-files -LO https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-core/2.16.0/jackson-core-2.16.0.jar
+          curl --output-dir standalone-jar-files -LO https://repo1.maven.org/maven2/junit/junit/4.13.2/junit-4.13.2.jar
+          curl --output-dir standalone-jar-files -LO https://repo1.maven.org/maven2/wsdl4j/wsdl4j/1.6.3/wsdl4j-1.6.3.jar
+          FETCH_LICENSE=true bin/cdxgen.js -p -o bomresults/bom-standalone-jar-files.json --validate
+        shell: bash
       - name: repotests 1.4
         run: |
           bin/cdxgen.js -p -r -t java repotests/shiftleft-java-example -o bomresults/bom-java.json --generate-key-and-sign --spec-version 1.4

--- a/.github/workflows/repotests.yml
+++ b/.github/workflows/repotests.yml
@@ -228,7 +228,7 @@ jobs:
           curl --output-dir standalone-jar-files -LO https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-core/2.16.0/jackson-core-2.16.0.jar
           curl --output-dir standalone-jar-files -LO https://repo1.maven.org/maven2/junit/junit/4.13.2/junit-4.13.2.jar
           curl --output-dir standalone-jar-files -LO https://repo1.maven.org/maven2/wsdl4j/wsdl4j/1.6.3/wsdl4j-1.6.3.jar
-          FETCH_LICENSE=true bin/cdxgen.js -p -o bomresults/bom-standalone-jar-files.json --validate
+          FETCH_LICENSE=true bin/cdxgen.js -p standalone-jar-files -o bomresults/bom-standalone-jar-files.json --validate
         shell: bash
       - name: repotests 1.4
         run: |

--- a/utils.js
+++ b/utils.js
@@ -6787,7 +6787,7 @@ export const extractJarArchive = function (
           pkgList.push(apkg);
         } else {
           if (DEBUG_MODE) {
-            console.log(`Ignored jar ${jarname}`, jarMetadata, name, version);
+            console.log(`Ignored jar ${jarname}`, name, version);
           }
         }
         try {

--- a/utils.js
+++ b/utils.js
@@ -6636,7 +6636,9 @@ export const extractJarArchive = function (
       if (jarResult.status !== 0) {
         console.error(jarResult.stdout, jarResult.stderr);
       } else {
-        let group = "", name = "", version = "";
+        let group = "",
+          name = "",
+          version = "";
         // When maven descriptor is available take group, name and version from pom.properties
         // META-INF/maven/${groupId}/${artifactId}/pom.properties
         // see https://maven.apache.org/shared/maven-archiver/index.html
@@ -6645,7 +6647,12 @@ export const extractJarArchive = function (
           if (groupDir && groupDir.length) {
             let artifactDir = readdirSync(join(mavenDir, groupDir[0]));
             if (artifactDir && artifactDir.length) {
-              let pomPropertiesFile = join(mavenDir, groupDir[0], artifactDir[0], "pom.properties");
+              let pomPropertiesFile = join(
+                mavenDir,
+                groupDir[0],
+                artifactDir[0],
+                "pom.properties"
+              );
               if (existsSync(pomPropertiesFile)) {
                 const pomProperties = parsePomProperties(
                   readFileSync(pomPropertiesFile, {
@@ -6665,14 +6672,16 @@ export const extractJarArchive = function (
               encoding: "utf-8"
             })
           );
-          group = group ||
+          group =
+            group ||
             jarMetadata["Extension-Name"] ||
             jarMetadata["Implementation-Vendor-Id"] ||
             jarMetadata["Bundle-SymbolicName"] ||
             jarMetadata["Bundle-Vendor"] ||
             jarMetadata["Automatic-Module-Name"] ||
             "";
-          version = version ||
+          version =
+            version ||
             jarMetadata["Bundle-Version"] ||
             jarMetadata["Implementation-Version"] ||
             jarMetadata["Specification-Version"];

--- a/utils.js
+++ b/utils.js
@@ -19,7 +19,8 @@ import {
   readFileSync,
   rmSync,
   unlinkSync,
-  writeFileSync
+  writeFileSync,
+  readdirSync
 } from "node:fs";
 import got from "got";
 import Arborist from "@npmcli/arborist";
@@ -6514,6 +6515,23 @@ export const parseJarManifest = function (jarMetadata) {
   return metadata;
 };
 
+export const parsePomProperties = function (pomProperties) {
+  const properties = {};
+  if (!pomProperties) {
+    return properties;
+  }
+  pomProperties.split("\n").forEach((l) => {
+    l = l.replace("\r", "");
+    if (l.includes("=")) {
+      const tmpA = l.split("=");
+      if (tmpA && tmpA.length === 2) {
+        properties[tmpA[0]] = tmpA[1].replace("\r", "");
+      }
+    }
+  });
+  return properties;
+};
+
 export const encodeForPurl = (s) => {
   return s && !s.includes("%40")
     ? encodeURIComponent(s).replace(/%3A/g, ":").replace(/%2F/g, "/")
@@ -6601,13 +6619,14 @@ export const extractJarArchive = function (
       }
       const manifestDir = join(tempDir, "META-INF");
       const manifestFile = join(manifestDir, "MANIFEST.MF");
+      const mavenDir = join(manifestDir, "maven");
       let jarResult = {
         status: 1
       };
       if (existsSync(pomname)) {
         jarResult = { status: 0 };
       } else {
-        jarResult = spawnSync("jar", ["-xf", jf], {
+        jarResult = spawnSync("jar", ["-xf", jf, "META-INF"], {
           encoding: "utf-8",
           cwd: tempDir,
           shell: isWin,
@@ -6617,27 +6636,49 @@ export const extractJarArchive = function (
       if (jarResult.status !== 0) {
         console.error(jarResult.stdout, jarResult.stderr);
       } else {
-        if (existsSync(manifestFile)) {
+        let group = "", name = "", version = "";
+        // When maven descriptor is available take group, name and version from pom.properties
+        // META-INF/maven/${groupId}/${artifactId}/pom.properties
+        // see https://maven.apache.org/shared/maven-archiver/index.html
+        if (existsSync(mavenDir)) {
+          let groupDir = readdirSync(mavenDir);
+          if (groupDir && groupDir.length) {
+            let artifactDir = readdirSync(join(mavenDir, groupDir[0]));
+            if (artifactDir && artifactDir.length) {
+              let pomPropertiesFile = join(mavenDir, groupDir[0], artifactDir[0], "pom.properties");
+              if (existsSync(pomPropertiesFile)) {
+                const pomProperties = parsePomProperties(
+                  readFileSync(pomPropertiesFile, {
+                    encoding: "utf-8"
+                  })
+                );
+                group = pomProperties["groupId"];
+                name = pomProperties["artifactId"];
+                version = pomProperties["version"];
+              }
+            }
+          }
+        }
+        if ((!group || !name || !version) && existsSync(manifestFile)) {
           const jarMetadata = parseJarManifest(
             readFileSync(manifestFile, {
               encoding: "utf-8"
             })
           );
-          let group =
+          group = group ||
             jarMetadata["Extension-Name"] ||
             jarMetadata["Implementation-Vendor-Id"] ||
             jarMetadata["Bundle-SymbolicName"] ||
             jarMetadata["Bundle-Vendor"] ||
             jarMetadata["Automatic-Module-Name"] ||
             "";
-          let version =
+          version = version ||
             jarMetadata["Bundle-Version"] ||
             jarMetadata["Implementation-Version"] ||
             jarMetadata["Specification-Version"];
           if (version && version.includes(" ")) {
             version = version.split(" ")[0];
           }
-          let name = "";
           // Prefer jar filename to construct name and version
           if (!name || !version || name === "" || version === "") {
             const tmpA = jarname.split("-");
@@ -6688,56 +6729,56 @@ export const extractJarArchive = function (
               break;
             }
           }
-          if (name && version) {
-            // if group is empty use name as group
-            group = encodeForPurl(group === "." ? name : group || name) || "";
-            let apkg = {
+          // if group is empty use name as group
+          group = group === "." ? name : group || name;
+        }
+        if (name && version) {
+          let apkg = {
+            group: group ? encodeForPurl(group) : "",
+            name: name ? encodeForPurl(name) : "",
+            version,
+            purl: new PackageURL(
+              "maven",
               group,
-              name: name ? encodeForPurl(name) : "",
+              name,
               version,
-              purl: new PackageURL(
-                "maven",
-                group,
-                name,
-                version,
-                { type: "jar" },
-                null
-              ).toString(),
-              evidence: {
-                identity: {
-                  field: "purl",
-                  confidence: 0.5,
-                  methods: [
-                    {
-                      technique: "filename",
-                      confidence: 0.5,
-                      value: jarname
-                    }
-                  ]
-                }
-              },
-              properties: [
-                {
-                  name: "SrcFile",
-                  value: jarname
-                }
-              ]
-            };
-            if (
-              jarNSMapping &&
-              jarNSMapping[apkg.purl] &&
-              jarNSMapping[apkg.purl].namespaces
-            ) {
-              apkg.properties.push({
-                name: "Namespaces",
-                value: jarNSMapping[apkg.purl].namespaces.join("\n")
-              });
-            }
-            pkgList.push(apkg);
-          } else {
-            if (DEBUG_MODE) {
-              console.log(`Ignored jar ${jarname}`, jarMetadata, name, version);
-            }
+              { type: "jar" },
+              null
+            ).toString(),
+            evidence: {
+              identity: {
+                field: "purl",
+                confidence: 0.5,
+                methods: [
+                  {
+                    technique: "filename",
+                    confidence: 0.5,
+                    value: jarname
+                  }
+                ]
+              }
+            },
+            properties: [
+              {
+                name: "SrcFile",
+                value: jarname
+              }
+            ]
+          };
+          if (
+            jarNSMapping &&
+            jarNSMapping[apkg.purl] &&
+            jarNSMapping[apkg.purl].namespaces
+          ) {
+            apkg.properties.push({
+              name: "Namespaces",
+              value: jarNSMapping[apkg.purl].namespaces.join("\n")
+            });
+          }
+          pkgList.push(apkg);
+        } else {
+          if (DEBUG_MODE) {
+            console.log(`Ignored jar ${jarname}`, jarMetadata, name, version);
           }
         }
         try {

--- a/utils.js
+++ b/utils.js
@@ -6638,7 +6638,9 @@ export const extractJarArchive = function (
       } else {
         let group = "",
           name = "",
-          version = "";
+          version = "",
+          confidence = 1,
+          technique = "manifest-analysis";
         // When maven descriptor is available take group, name and version from pom.properties
         // META-INF/maven/${groupId}/${artifactId}/pom.properties
         // see https://maven.apache.org/shared/maven-archiver/index.html
@@ -6667,6 +6669,7 @@ export const extractJarArchive = function (
           }
         }
         if ((!group || !name || !version) && existsSync(manifestFile)) {
+          confidence = 0.8;
           const jarMetadata = parseJarManifest(
             readFileSync(manifestFile, {
               encoding: "utf-8"
@@ -6690,6 +6693,8 @@ export const extractJarArchive = function (
           }
           // Prefer jar filename to construct name and version
           if (!name || !version || name === "" || version === "") {
+            confidence = 0.5;
+            technique = "filename";
             const tmpA = jarname.split("-");
             if (tmpA && tmpA.length > 1) {
               const lastPart = tmpA[tmpA.length - 1];
@@ -6757,11 +6762,11 @@ export const extractJarArchive = function (
             evidence: {
               identity: {
                 field: "purl",
-                confidence: 0.5,
+                confidence: confidence,
                 methods: [
                   {
-                    technique: "filename",
-                    confidence: 0.5,
+                    technique: technique,
+                    confidence: confidence,
                     value: jarname
                   }
                 ]


### PR DESCRIPTION
Another improvement for standalone jar files

1. Optimized extract jar to only spawn "META-INF" directory
2. First checks if pom.properties is available - see: https://maven.apache.org/shared/maven-archiver/index.html
4. Fallback to old logic if pom.properties is not available

Steps to reproduce:

1. Download [org.jacoco.report-0.8.8.jar](https://repo1.maven.org/maven2/org/jacoco/org.jacoco.report/0.8.8/org.jacoco.report-0.8.8.jar), [xmlschema-core-2.2.5.jar](https://repo1.maven.org/maven2/org/apache/ws/xmlschema/xmlschema-core/2.2.5/xmlschema-core-2.2.5.jar), [jackson-core-2.16.0.jar](https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-core/2.16.0/jackson-core-2.16.0.jar), [junit-4.13.2.jar](https://repo1.maven.org/maven2/junit/junit/4.13.2/junit-4.13.2.jar), [wsdl4j-1.6.3.jar](https://repo1.maven.org/maven2/wsdl4j/wsdl4j/1.6.3/wsdl4j-1.6.3.jar) and put them into empty folder.
2. Run cdxgen against this folder

xmlschema-core and org.jacoco.report before my change:
```
"components": [
    {
      "group": "org.apache",
      "name": "xmlschema-core",
      "version": "2.2.5",
      "purl": "pkg:maven/org.apache/xmlschema-core@2.2.5?type=jar",
      "type": "framework",
      "bom-ref": "pkg:maven/org.apache/xmlschema-core@2.2.5?type=jar",
      "evidence": {
        "identity": {
          "field": "purl",
          "confidence": 0.5,
          "methods": [
            {
              "technique": "filename",
              "confidence": 0.5,
              "value": "xmlschema-core-2.2.5.jar"
            }
          ]
        }
      },
      "properties": [
        {
          "name": "SrcFile",
          "value": "xmlschema-core-2.2.5.jar"
        }
      ]
    },
    {
      "group": "org.jacoco.report",
      "name": "org.jacoco.report",
      "version": "0.8.8.202204050719",
      "purl": "pkg:maven/org.jacoco.report/org.jacoco.report@0.8.8.202204050719?type=jar",
      "type": "library",
      "bom-ref": "pkg:maven/org.jacoco.report/org.jacoco.report@0.8.8.202204050719?type=jar",
      "evidence": {
        "identity": {
          "field": "purl",
          "confidence": 0.5,
          "methods": [
            {
              "technique": "filename",
              "confidence": 0.5,
              "value": "org.jacoco.report-0.8.8.jar"
            }
          ]
        }
      },
      "properties": [
        {
          "name": "SrcFile",
          "value": "org.jacoco.report-0.8.8.jar"
        }
      ]
    }
]
```

and after my change with correct group, name and version, which results also in successfully fetched license information:

```
"components": [
    {
      "publisher": "The Apache Software Foundation",
      "group": "org.apache.ws.xmlschema",
      "name": "xmlschema-core",
      "version": "2.2.5",
      "description": "Commons XMLSchema is a light weight schema object model that can be used to manipulate or\n        generate XML schema.",
      "licenses": [
        {
          "license": {
            "id": "Apache-2.0",
            "url": "https://opensource.org/licenses/Apache-2.0"
          }
        }
      ],
      "purl": "pkg:maven/org.apache.ws.xmlschema/xmlschema-core@2.2.5?type=jar",
      "externalReferences": [
        {
          "type": "vcs",
          "url": "https://gitbox.apache.org/repos/asf?p=ws-xmlschema.git;a=summary"
        }
      ],
      "type": "framework",
      "bom-ref": "pkg:maven/org.apache.ws.xmlschema/xmlschema-core@2.2.5?type=jar",
      "evidence": {
        "identity": {
          "field": "purl",
          "confidence": 1,
          "methods": [
            {
              "technique": "manifest-analysis",
              "confidence": 1,
              "value": "xmlschema-core-2.2.5.jar"
            }
          ]
        }
      },
      "properties": [
        {
          "name": "SrcFile",
          "value": "xmlschema-core-2.2.5.jar"
        }
      ]
    },
    {
      "publisher": "Mountainminds GmbH & Co. KG",
      "group": "org.jacoco",
      "name": "org.jacoco.report",
      "version": "0.8.8",
      "description": "JaCoCo Report",
      "licenses": [
        {
          "license": {
            "name": "Eclipse Public License 2.0"
          }
        }
      ],
      "purl": "pkg:maven/org.jacoco/org.jacoco.report@0.8.8?type=jar",
      "externalReferences": [
        {
          "type": "vcs",
          "url": "https://github.com/jacoco/jacoco"
        }
      ],
      "type": "library",
      "bom-ref": "pkg:maven/org.jacoco/org.jacoco.report@0.8.8?type=jar",
      "evidence": {
        "identity": {
          "field": "purl",
          "confidence": 1,
          "methods": [
            {
              "technique": "manifest-analysis",
              "confidence": 1,
              "value": "org.jacoco.report-0.8.8.jar"
            }
          ]
        }
      },
      "properties": [
        {
          "name": "SrcFile",
          "value": "org.jacoco.report-0.8.8.jar"
        }
      ]
    }
```

In both cases FETCH_LICENSE was set to true. Other components have unchanged results, as they were resolved correctly already before my change.