### PR TITLE
Ensure fallback to system maven works

### DIFF
--- a/.github/workflows/repotests.yml
+++ b/.github/workflows/repotests.yml
@@ -156,6 +156,10 @@ jobs:
         with:
           repository: 'googleprojectzero/Jackalope'
           path: 'repotests/Jackalope'
+      - uses: actions/checkout@v3
+        with:
+          repository: 'hritik14/broken-mvn-wrapper'
+          path: 'repotests/broken-mvn-wrapper'
       - uses: dtolnay/rust-toolchain@stable
       - name: repotests evidence
         run: |
@@ -277,6 +281,7 @@ jobs:
         run: |
           bin/cdxgen.js -p -t python repotests/blint -o bomresults/bom-blint.json
           bin/cdxgen.js -p -t python repotests/blint -o bomresults/bom-blint-deep.json --deep
+          bin/cdxgen.js -p -t java repotests/broken-mvn-wrapper -o bomresults/bom-broken-mvn-wrapper.json
         shell: bash
       - name: jenkins plugins
         run: |

--- a/utils.js
+++ b/utils.js
@@ -6999,6 +6999,7 @@ export const getMavenCommand = (srcPath, rootPath) => {
   let isWrapperReady = false;
   let isWrapperFound = false;
   let findMavenFile = "mvnw";
+  let mavenWrapperCmd = null;
   if (platform() == "win32") {
     findMavenFile = "mvnw.bat";
     if (
@@ -7017,7 +7018,7 @@ export const getMavenCommand = (srcPath, rootPath) => {
     } catch (e) {
       // continue regardless of error
     }
-    mavenCmd = resolve(join(srcPath, findMavenFile));
+    mavenWrapperCmd = resolve(join(srcPath, findMavenFile));
     isWrapperFound = true;
   } else if (rootPath && existsSync(join(rootPath, findMavenFile))) {
     // Check if the root directory has a wrapper script
@@ -7026,7 +7027,7 @@ export const getMavenCommand = (srcPath, rootPath) => {
     } catch (e) {
       // continue regardless of error
     }
-    mavenCmd = resolve(join(rootPath, findMavenFile));
+    mavenWrapperCmd = resolve(join(rootPath, findMavenFile));
     isWrapperFound = true;
   }
   if (isWrapperFound) {
@@ -7035,14 +7036,15 @@ export const getMavenCommand = (srcPath, rootPath) => {
         "Testing the wrapper script by invoking wrapper:wrapper task"
       );
     }
-    const result = spawnSync(mavenCmd, ["wrapper:wrapper"], {
+    const result = spawnSync(mavenWrapperCmd, ["wrapper:wrapper"], {
       encoding: "utf-8",
       cwd: rootPath,
       timeout: TIMEOUT_MS,
       shell: isWin
     });
-    if (!result.error) {
+    if (!result.error && !result.status) {
       isWrapperReady = true;
+      mavenCmd = mavenWrapperCmd;
     } else {
       if (DEBUG_MODE) {
         console.log(


### PR DESCRIPTION
1. In case the maven wrapper is found but is not ready or functioning, make sure the fallback to initially assumed "mvn" command works.
2. spawnSync returns an ``error`` object only in case child process is timed out or the invocation itself fails. Read ``status`` as well to ensure that the child process executed successfully