### PR TITLE
Fixed microservices-demo to tag v0.8.1

### DIFF
--- a/.github/workflows/repotests.yml
+++ b/.github/workflows/repotests.yml
@@ -95,14 +95,17 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: 'flutter/gallery'
+          ref: 'v2.10.2'
           path: 'repotests/gallery'
       - uses: actions/checkout@v4
         with:
           repository: 'gojek/ziggurat'
+          ref: '4.9.4'
           path: 'repotests/ziggurat'
       - uses: actions/checkout@v4
         with:
           repository: 'apple/swift-markdown'
+          ref: '0.3.0'
           path: 'repotests/swift-markdown'
       - uses: actions/checkout@v4
         with:
@@ -112,6 +115,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: 'zoom/meetingsdk-vuejs-sample'
+          ref: 'v2.18.0'
           path: 'repotests/meetingsdk-vuejs-sample'
       - uses: actions/checkout@v4
         with:
@@ -120,34 +124,42 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: 'openpbs/openpbs'
+          ref: 'v23.06.06'
           path: 'repotests/openpbs'
       - uses: actions/checkout@v4
         with:
           repository: 'home-assistant/android'
+          ref: '2023.11.3'
           path: 'repotests/ha-android'
       - uses: actions/checkout@v4
         with:
           repository: 'rust-lang/rust'
+          ref: '1.74.0'
           path: 'repotests/rs-rust'
       - uses: actions/checkout@v4
         with:
           repository: 'rust-lang/cargo'
+          ref: '0.75.0'
           path: 'repotests/rs-cargo'
       - uses: actions/checkout@v4
         with:
           repository: 'Keats/validator'
+          ref: 'v0.15.0'
           path: 'repotests/rs-validator'
       - uses: actions/checkout@v4
         with:
           repository: 'tokio-rs/axum'
+          ref: 'axum-v0.6.20'
           path: 'repotests/rs-axum'
       - uses: actions/checkout@v4
         with:
           repository: 'fsprojects/FAKE'
+          ref: '6.0.0'
           path: 'repotests/dotnet-paket'
       - uses: actions/checkout@v4
         with:
           repository: 'appthreat/blint'
+          ref: 'v1.0.34'
           path: 'repotests/blint'
       - uses: actions/checkout@v4
         with:
@@ -156,6 +168,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           repository: 'DefectDojo/django-DefectDojo'
+          ref: '2.28.2'
           path: 'repotests/django-DefectDojo'
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/repotests.yml
+++ b/.github/workflows/repotests.yml
@@ -264,7 +264,6 @@ jobs:
           CDXGEN_DEBUG_MODE=debug bin/cdxgen.js -p -r -t swift repotests/swift-markdown -o bomresults/bom-swift.json --validate
         shell: bash
       - name: repotests microservices-demo
-        if: matrix.os == 'windows-latest'
         run: |
           bin/cdxgen.js -p --no-recurse repotests/microservices-demo -o bomresults/bom-msd-1.json --validate
           bin/cdxgen.js -p -r repotests/microservices-demo -o bomresults/bom-msd-2.json --validate

--- a/.github/workflows/repotests.yml
+++ b/.github/workflows/repotests.yml
@@ -107,7 +107,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: 'GoogleCloudPlatform/microservices-demo'
-          ref: 'tags/v0.8.1'
+          ref: 'v0.8.1'
           path: 'repotests/microservices-demo'
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/repotests.yml
+++ b/.github/workflows/repotests.yml
@@ -264,6 +264,7 @@ jobs:
           CDXGEN_DEBUG_MODE=debug bin/cdxgen.js -p -r -t swift repotests/swift-markdown -o bomresults/bom-swift.json --validate
         shell: bash
       - name: repotests microservices-demo
+        if: matrix.os == 'windows-latest'
         run: |
           bin/cdxgen.js -p --no-recurse repotests/microservices-demo -o bomresults/bom-msd-1.json --validate
           bin/cdxgen.js -p -r repotests/microservices-demo -o bomresults/bom-msd-2.json --validate

--- a/.github/workflows/repotests.yml
+++ b/.github/workflows/repotests.yml
@@ -107,6 +107,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: 'GoogleCloudPlatform/microservices-demo'
+          ref: 'tags/v0.8.1'
           path: 'repotests/microservices-demo'
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Fixed following repositories to specific tag:

- flutter/gallery: v2.10.2
- gojek/ziggurat: 4.9.4
- apple/swift-markdown: 0.3.0
- GoogleCloudPlatform/microservices-demo: v0.8.1
- zoom/meetingsdk-vuejs-sample: v2.18.0
- openpbs/openpbs: v23.06.06
- home-assistant/android: 2023.11.3
- rust-lang/rust: 1.74.0
- rust-lang/cargo: 0.75.0
- Keats/validator: v0.15.0
- tokio-rs/axum: axum-v0.6.20
- fsprojects/FAKE: 6.0.0
- appthreat/blint: v1.0.34
- DefectDojo/django-DefectDojo: 2.28.2

Following repositories are still pulling default branch:

- ShiftLeftSecurity/shiftleft-java-example
- ShiftLeftSecurity/shiftleft-ts-example
- ShiftLeftSecurity/shiftleft-go-example
- prabhu/shiftleft-scala-example
- HooliCorp/vulnerable_net_core
- HooliCorp/Goatly.NET
- HooliCorp/DjanGoat
- prabhu/Vulnerable-Web-Application
- prabhu/railsgoat
- bazelbuild/examples
- sveltejs/examples
- hoolicorp/java-sec-code
- googleprojectzero/Jackalope
- hritik14/broken-mvn-wrapper