### PR TITLE
Check for existence of oaData.info (and title/version)

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -4680,8 +4680,11 @@ export const parseOpenapiSpecData = function (oaData) {
   } catch (e) {
     return servlist;
   }
-  const name = oaData.info.title.replace(/ /g, "-");
-  const version = oaData.info.version || "latest";
+
+  // Check if 'info' and 'info.title' exist
+  const name = oaData.info && oaData.info.title ? oaData.info.title.replace(/ /g, "-") : "default-name";
+  const version = oaData.info && oaData.info.version ? oaData.info.version : "latest";
+
   const aservice = {
     "bom-ref": `urn:service:${name}:${version}`,
     name,


### PR DESCRIPTION
Adds a check to make sure that info and title/version exists before we try and manipulate them, adds defaults if missing.

We're getting a stacktrace from this as show here:
```
Parsing /tmp/<repo>gitbi8JPT/src/<path>/<file>.json
file:///opt/cdxgen/utils.js:4621
  const name = oaData.info.title.replace(/ /g, "-");
                           ^

TypeError: Cannot read properties of undefined (reading 'title')
    at parseOpenapiSpecData (file:///opt/cdxgen/utils.js:4621:28)
    at createContainerSpecLikeBom (file:///opt/cdxgen/index.js:3897:24)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async createBom (file:///opt/cdxgen/index.js:5518:14)
    at async file:///opt/cdxgen/server.js:142:22
```

We probably shouldn't even be parsing this json file in the first place (it's just a random json), but that's a bigger/trickier fix.  This just fixes the problem where we try and manipulate things that don't exist.