### PR TITLE
feat: enhance oci purl spec compliance

### DIFF
--- a/docker.js
+++ b/docker.js
@@ -460,9 +460,6 @@ export const parseImageName = (fullImageName) => {
       fullImageName = fullImageName.replace(":" + nameObj.tag, "");
     }
   }
-  if (fullImageName && fullImageName.startsWith("library/")) {
-    fullImageName = fullImageName.replace("library/", "");
-  }
 
   // The left over string is the repo name
   nameObj.repo = fullImageName;

--- a/docker.js
+++ b/docker.js
@@ -243,8 +243,8 @@ const getDefaultOptions = (forRegistry) => {
         opts.prefixUrl = isWin
           ? WIN_LOCAL_TLS
           : isDockerRootless
-            ? `http://unix:${homedir()}/.docker/run/docker.sock:`
-            : "http://unix:/var/run/docker.sock:";
+          ? `http://unix:${homedir()}/.docker/run/docker.sock:`
+          : "http://unix:/var/run/docker.sock:";
       }
     }
   } else {
@@ -416,11 +416,16 @@ export const parseImageName = (fullImageName) => {
     repo: "",
     tag: "",
     digest: "",
-    platform: ""
+    platform: "",
+    group: "",
+    name: ""
   };
   if (!fullImageName) {
     return nameObj;
   }
+  // ensure it's lowercased
+  fullImageName = fullImageName.toLowerCase();
+
   // Extract registry name
   if (
     fullImageName.includes("/") &&
@@ -437,6 +442,7 @@ export const parseImageName = (fullImageName) => {
       fullImageName = fullImageName.replace(tmpA[0] + "/", "");
     }
   }
+
   // Extract digest name
   if (fullImageName.includes("@sha256:")) {
     const tmpA = fullImageName.split("@sha256:");
@@ -445,6 +451,7 @@ export const parseImageName = (fullImageName) => {
       fullImageName = fullImageName.replace("@sha256:" + nameObj.digest, "");
     }
   }
+
   // Extract tag name
   if (fullImageName.includes(":")) {
     const tmpA = fullImageName.split(":");
@@ -456,8 +463,20 @@ export const parseImageName = (fullImageName) => {
   if (fullImageName && fullImageName.startsWith("library/")) {
     fullImageName = fullImageName.replace("library/", "");
   }
+
   // The left over string is the repo name
   nameObj.repo = fullImageName;
+  nameObj.name = fullImageName;
+
+  // extract group name
+  if (fullImageName.includes("/")) {
+    const tmpA = fullImageName.split("/");
+    if (tmpA.length > 1) {
+      nameObj.name = tmpA[tmpA.length - 1];
+      nameObj.group = fullImageName.replace("/" + tmpA[tmpA.length - 1], "");
+    }
+  }
+
   return nameObj;
 };
 

--- a/docker.js
+++ b/docker.js
@@ -243,8 +243,8 @@ const getDefaultOptions = (forRegistry) => {
         opts.prefixUrl = isWin
           ? WIN_LOCAL_TLS
           : isDockerRootless
-          ? `http://unix:${homedir()}/.docker/run/docker.sock:`
-          : "http://unix:/var/run/docker.sock:";
+            ? `http://unix:${homedir()}/.docker/run/docker.sock:`
+            : "http://unix:/var/run/docker.sock:";
       }
     }
   } else {
@@ -688,7 +688,7 @@ export const extractTar = async (fullImageName, dir) => {
         strict: true,
         C: dir,
         portable: true,
-        onwarn: () => {},
+        onwarn: () => { },
         filter: (path, entry) => {
           // Some files are known to cause issues with extract
           if (
@@ -938,7 +938,7 @@ export const exportImage = async (fullImageName) => {
           strict: true,
           C: tempDir,
           portable: true,
-          onwarn: () => {}
+          onwarn: () => { }
         })
       );
     } catch (err) {
@@ -955,7 +955,7 @@ export const exportImage = async (fullImageName) => {
               strict: true,
               C: tempDir,
               portable: true,
-              onwarn: () => {}
+              onwarn: () => { }
             })
           );
         } catch (err) {

--- a/docker.js
+++ b/docker.js
@@ -688,7 +688,7 @@ export const extractTar = async (fullImageName, dir) => {
         strict: true,
         C: dir,
         portable: true,
-        onwarn: () => { },
+        onwarn: () => {},
         filter: (path, entry) => {
           // Some files are known to cause issues with extract
           if (
@@ -938,7 +938,7 @@ export const exportImage = async (fullImageName) => {
           strict: true,
           C: tempDir,
           portable: true,
-          onwarn: () => { }
+          onwarn: () => {}
         })
       );
     } catch (err) {
@@ -955,7 +955,7 @@ export const exportImage = async (fullImageName) => {
               strict: true,
               C: tempDir,
               portable: true,
-              onwarn: () => { }
+              onwarn: () => {}
             })
           );
         } catch (err) {

--- a/docker.test.js
+++ b/docker.test.js
@@ -37,6 +37,15 @@ test("parseImageName tests", () => {
     group: "",
     name: "debian"
   });
+  expect(parseImageName("library/debian:latest")).toEqual({
+    registry: "",
+    repo: "library/debian",
+    tag: "latest",
+    digest: "",
+    platform: "",
+    group: "library",
+    name: "debian"
+  });
   expect(parseImageName("shiftleft/scan:v1.15.6")).toEqual({
     registry: "",
     repo: "shiftleft/scan",

--- a/docker.test.js
+++ b/docker.test.js
@@ -24,35 +24,45 @@ test("parseImageName tests", () => {
     repo: "debian",
     tag: "",
     digest: "",
-    platform: ""
+    platform: "",
+    group: "",
+    name: "debian"
   });
   expect(parseImageName("debian:latest")).toEqual({
     registry: "",
     repo: "debian",
     tag: "latest",
     digest: "",
-    platform: ""
+    platform: "",
+    group: "",
+    name: "debian"
   });
   expect(parseImageName("shiftleft/scan:v1.15.6")).toEqual({
     registry: "",
     repo: "shiftleft/scan",
     tag: "v1.15.6",
     digest: "",
-    platform: ""
+    platform: "",
+    group: "shiftleft",
+    name: "scan"
   });
   expect(parseImageName("localhost:5000/shiftleft/scan:v1.15.6")).toEqual({
     registry: "localhost:5000",
     repo: "shiftleft/scan",
     tag: "v1.15.6",
     digest: "",
-    platform: ""
+    platform: "",
+    group: "shiftleft",
+    name: "scan"
   });
   expect(parseImageName("localhost:5000/shiftleft/scan")).toEqual({
     registry: "localhost:5000",
     repo: "shiftleft/scan",
     tag: "",
     digest: "",
-    platform: ""
+    platform: "",
+    group: "shiftleft",
+    name: "scan"
   });
   expect(
     parseImageName("foocorp.jfrog.io/docker/library/eclipse-temurin:latest")
@@ -61,7 +71,9 @@ test("parseImageName tests", () => {
     repo: "docker/library/eclipse-temurin",
     tag: "latest",
     digest: "",
-    platform: ""
+    platform: "",
+    group: "docker/library",
+    name: "eclipse-temurin"
   });
   expect(
     parseImageName(
@@ -72,7 +84,9 @@ test("parseImageName tests", () => {
     repo: "shiftleft/scan-java",
     tag: "",
     digest: "5d008306a7c5d09ba0161a3408fa3839dc2c9dd991ffb68adecc1040399fe9e1",
-    platform: ""
+    platform: "",
+    group: "shiftleft",
+    name: "scan-java"
   });
 }, 120000);
 

--- a/index.js
+++ b/index.js
@@ -3832,11 +3832,17 @@ export const createContainerSpecLikeBom = async (path, options) => {
               console.log(`Parsing image ${img.image}`);
             }
             const imageObj = parseImageName(img.image);
+
+            const imageObjParts = imageObj.repo.split("/");
+            const imageName = imageObjParts.pop().toLowerCase();
+            const groupName = imageObjParts.join("/");
+
             const pkg = {
-              name: imageObj.repo.split("/").pop().toLowerCase(),
+              name: imageName,
+              group: groupName ?? "",
               version:
                 imageObj.tag ||
-                (imageObj.digest ? "sha256:" + imageObj.digest : "latest"), // TODO - this may not work if both a tag and digest are provided
+                (imageObj.digest ? "sha256:" + imageObj.digest : "latest"),
               qualifiers: {},
               properties: commonProperties,
               type: "container"

--- a/index.js
+++ b/index.js
@@ -3833,13 +3833,9 @@ export const createContainerSpecLikeBom = async (path, options) => {
             }
             const imageObj = parseImageName(img.image);
 
-            const imageObjParts = imageObj.repo.split("/");
-            const imageName = imageObjParts.pop().toLowerCase();
-            const groupName = imageObjParts.join("/");
-
             const pkg = {
-              name: imageName,
-              group: groupName ?? "",
+              name: imageObj.name,
+              group: imageObj.group,
               version:
                 imageObj.tag ||
                 (imageObj.digest ? "sha256:" + imageObj.digest : "latest"),

--- a/index.js
+++ b/index.js
@@ -3833,18 +3833,23 @@ export const createContainerSpecLikeBom = async (path, options) => {
             }
             const imageObj = parseImageName(img.image);
             const pkg = {
-              name: imageObj.repo,
+              name: imageObj.repo.split("/").pop().toLowerCase(),
               version:
                 imageObj.tag ||
-                (imageObj.digest ? "sha256:" + imageObj.digest : "latest"),
+                (imageObj.digest ? "sha256:" + imageObj.digest : "latest"), // TODO - this may not work if both a tag and digest are provided
               qualifiers: {},
-              properties: commonProperties
+              properties: commonProperties,
+              type: "container"
             };
             if (imageObj.registry) {
-              pkg["qualifiers"]["repository_url"] = imageObj.registry;
+              pkg["qualifiers"]["repository_url"] =
+                imageObj.registry + "/" + imageObj.repo;
             }
             if (imageObj.platform) {
               pkg["qualifiers"]["platform"] = imageObj.platform;
+            }
+            if (imageObj.tag) {
+              pkg["qualifiers"]["tag"] = imageObj.tag;
             }
             // Create an entry for the oci image
             const imageBomData = buildBomNSData(options, [pkg], "oci", {

--- a/index.js
+++ b/index.js
@@ -3844,8 +3844,7 @@ export const createContainerSpecLikeBom = async (path, options) => {
               type: "container"
             };
             if (imageObj.registry) {
-              pkg["qualifiers"]["repository_url"] =
-                imageObj.registry + "/" + imageObj.repo;
+              pkg["qualifiers"]["repository_url"] = img.image;
             }
             if (imageObj.platform) {
               pkg["qualifiers"]["platform"] = imageObj.platform;


### PR DESCRIPTION
This PR addresses a few items that weren't fully aligned with the [oci pURL spec](https://github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst#oci)

These include
- `name` must be lowercased
- `name` is the last fragment from a repository name (eg: `library/debian` is `debian`)
- optional qualifiers `tag` can be added
- `repository_url` optional qualifier should be the `registry` + `name` combined
- component `type` explicitly set to `container` instead of `library`