### PR TITLE
prefix group name of swift package with unspecified versions

### DIFF
--- a/bin/cdxgen.js
+++ b/bin/cdxgen.js
@@ -220,6 +220,10 @@ const args = yargs(hideBin(process.argv))
     description: "Additional glob pattern(s) to ignore",
     hidden: true
   })
+  .option("unspecified-prefix", {
+    description:
+      "Set a  group name prefix for local swift packages with unspecified version. Needed to define packages as internal for DependencyTrack"
+  })
   .completion("completion", "Generate bash/zsh completion")
   .array("filter")
   .array("only")

--- a/index.js
+++ b/index.js
@@ -3698,6 +3698,13 @@ export const createSwiftBom = (path, options) => {
       }
     }
   }
+  if (options.unspecifiedPrefix) {
+    for (const p of pkgList) {
+      if (p.version === "unspecified") {
+        p.group = options.unspecifiedPrefix + "." + p.group;
+      }
+    }
+  }
   return buildBomNSData(options, pkgList, "swift", {
     src: path,
     filename: swiftFiles.join(", "),


### PR DESCRIPTION
adds an option to prefix group name of swift package with unspecified versions (local packages)
needed for DependencyTrack to mark dependencies as internal and to skip scanning them 