### PR TITLE
Fixes #795

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cyclonedx/cdxgen",
-  "version": "9.10.2",
+  "version": "9.10.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cyclonedx/cdxgen",
-      "version": "9.10.2",
+      "version": "9.10.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/parser": "^7.23.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cyclonedx/cdxgen",
-  "version": "9.10.2",
+  "version": "9.10.3",
   "description": "Creates CycloneDX Software Bill of Materials (SBOM) from source or container image",
   "homepage": "http://github.com/cyclonedx/cdxgen",
   "author": "Prabhu Subramanian <prabhu@appthreat.com>",

--- a/utils.test.js
+++ b/utils.test.js
@@ -1710,7 +1710,7 @@ test("parsePkgLock v2 workspace", async () => {
   );
   let pkgs = parsedList.pkgList;
   let deps = parsedList.dependenciesList;
-  expect(pkgs.length).toEqual(1032);
+  expect(pkgs.length).toEqual(1034);
   expect(pkgs[0].license).toEqual("MIT");
   let hasAppWorkspacePkg = pkgs.some(
     (obj) => obj["bom-ref"] === "pkg:npm/app@0.0.0"


### PR DESCRIPTION
Fixes #795 
Removed some obvious cycles while constructing dependency list.
Also introduced a new property called `ResolvedUrl` to capture the `resolved` attribute from the lock file.