### PR TITLE
Adding the SIGKILL signal to kill the atom subprocess post timeout

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -7495,6 +7495,7 @@ export const executeAtom = (src, args) => {
     timeout: TIMEOUT_MS,
     detached: !isWin && !process.env.CI,
     shell: isWin,
+    killSignal: "SIGKILL",
     env
   });
   if (result.stderr) {


### PR DESCRIPTION
Reference Issue: https://github.com/CycloneDX/cdxgen/issues/813