### PR TITLE
cdxgen crash when scala project isn't at repository root dir

### DIFF
--- a/index.js
+++ b/index.js
@@ -1718,7 +1718,18 @@ export const createJavaBom = async (path, options) => {
         }
       } else {
         const SBT_CMD = process.env.SBT_CMD || "sbt";
-        const sbtVersion = determineSbtVersion(path);
+        let sbtVersion = determineSbtVersion(path);
+        // If can't find sbt version at the root of repository then search in
+        // sbt project array too because sometimes the project folder isn't at
+        // root of repository
+	if (sbtVersion == null) {
+	  for (const i in sbtProjects) {
+	    sbtVersion = determineSbtVersion(sbtProjects[i]);
+	    if (sbtVersion != null) {
+	      break;
+	    }
+	  }
+	}
         if (DEBUG_MODE) {
           console.log("Detected sbt version: " + sbtVersion);
         }

--- a/index.js
+++ b/index.js
@@ -1722,14 +1722,14 @@ export const createJavaBom = async (path, options) => {
         // If can't find sbt version at the root of repository then search in
         // sbt project array too because sometimes the project folder isn't at
         // root of repository
-	if (sbtVersion == null) {
-	  for (const i in sbtProjects) {
-	    sbtVersion = determineSbtVersion(sbtProjects[i]);
-	    if (sbtVersion != null) {
-	      break;
-	    }
-	  }
-	}
+        if (sbtVersion == null) {
+          for (const i in sbtProjects) {
+            sbtVersion = determineSbtVersion(sbtProjects[i]);
+            if (sbtVersion != null) {
+              break;
+            }
+          }
+        }
         if (DEBUG_MODE) {
           console.log("Detected sbt version: " + sbtVersion);
         }

--- a/index.js
+++ b/index.js
@@ -1828,8 +1828,8 @@ export const createJavaBom = async (path, options) => {
             options.failOnError && process.exit(1);
           }
 
-        // Cleanup
-        unlinkSync(tempSbtPlugins);
+          // Cleanup
+          unlinkSync(tempSbtPlugins);
         } // for
       } // else
 

--- a/index.js
+++ b/index.js
@@ -1718,37 +1718,38 @@ export const createJavaBom = async (path, options) => {
         }
       } else {
         const SBT_CMD = process.env.SBT_CMD || "sbt";
-        const sbtVersion = determineSbtVersion(path);
-        if (DEBUG_MODE) {
-          console.log("Detected sbt version: " + sbtVersion);
-        }
-        // Introduced in 1.2.0 https://www.scala-sbt.org/1.x/docs/sbt-1.2-Release-Notes.html#addPluginSbtFile+command,
-        // however working properly for real only since 1.3.4: https://github.com/sbt/sbt/releases/tag/v1.3.4
-        const standalonePluginFile =
-          sbtVersion != null &&
-          gte(sbtVersion, "1.3.4") &&
-          lte(sbtVersion, "1.4.0");
-        const useSlashSyntax = gte(sbtVersion, "1.5.0");
-        const isDependencyTreeBuiltIn =
-          sbtVersion != null && gte(sbtVersion, "1.4.0");
-        const tempDir = mkdtempSync(join(tmpdir(), "cdxsbt-"));
-        const tempSbtgDir = mkdtempSync(join(tmpdir(), "cdxsbtg-"));
-        mkdirSync(tempSbtgDir, { recursive: true });
-        // Create temporary plugins file
-        const tempSbtPlugins = join(tempSbtgDir, "dep-plugins.sbt");
 
-        // Requires a custom version of `sbt-dependency-graph` that
-        // supports `--append` for `toFile` subtask.
-        let sbtPluginDefinition = `\naddSbtPlugin("io.shiftleft" % "sbt-dependency-graph" % "0.10.0-append-to-file3")\n`;
-        if (isDependencyTreeBuiltIn) {
-          sbtPluginDefinition = `\naddDependencyTreePlugin\n`;
-          if (DEBUG_MODE) {
-            console.log("Using addDependencyTreePlugin as the custom plugin");
-          }
-        }
-        writeFileSync(tempSbtPlugins, sbtPluginDefinition);
         for (const i in sbtProjects) {
           const basePath = sbtProjects[i];
+          const sbtVersion = determineSbtVersion(basePath);
+          if (DEBUG_MODE) {
+            console.log("Detected sbt version: " + sbtVersion);
+          }
+          // Introduced in 1.2.0 https://www.scala-sbt.org/1.x/docs/sbt-1.2-Release-Notes.html#addPluginSbtFile+command,
+          // however working properly for real only since 1.3.4: https://github.com/sbt/sbt/releases/tag/v1.3.4
+          const standalonePluginFile =
+            sbtVersion != null &&
+            gte(sbtVersion, "1.3.4") &&
+            lte(sbtVersion, "1.4.0");
+          const useSlashSyntax = gte(sbtVersion, "1.5.0");
+          const isDependencyTreeBuiltIn =
+            sbtVersion != null && gte(sbtVersion, "1.4.0");
+          const tempDir = mkdtempSync(join(tmpdir(), "cdxsbt-"));
+          const tempSbtgDir = mkdtempSync(join(tmpdir(), "cdxsbtg-"));
+          mkdirSync(tempSbtgDir, { recursive: true });
+          // Create temporary plugins file
+          const tempSbtPlugins = join(tempSbtgDir, "dep-plugins.sbt");
+
+          // Requires a custom version of `sbt-dependency-graph` that
+          // supports `--append` for `toFile` subtask.
+          let sbtPluginDefinition = `\naddSbtPlugin("io.shiftleft" % "sbt-dependency-graph" % "0.10.0-append-to-file3")\n`;
+          if (isDependencyTreeBuiltIn) {
+            sbtPluginDefinition = `\naddDependencyTreePlugin\n`;
+            if (DEBUG_MODE) {
+              console.log("Using addDependencyTreePlugin as the custom plugin");
+            }
+          }
+          writeFileSync(tempSbtPlugins, sbtPluginDefinition);
           const dlFile = join(tempDir, "dl-" + i + ".tmp");
           let sbtArgs = [];
           let pluginFile = null;
@@ -1826,10 +1827,10 @@ export const createJavaBom = async (path, options) => {
             }
             options.failOnError && process.exit(1);
           }
-        }
 
         // Cleanup
         unlinkSync(tempSbtPlugins);
+        } // for
       } // else
 
       if (DEBUG_MODE) {

--- a/index.js
+++ b/index.js
@@ -1718,38 +1718,37 @@ export const createJavaBom = async (path, options) => {
         }
       } else {
         const SBT_CMD = process.env.SBT_CMD || "sbt";
+        const sbtVersion = determineSbtVersion(path);
+        if (DEBUG_MODE) {
+          console.log("Detected sbt version: " + sbtVersion);
+        }
+        // Introduced in 1.2.0 https://www.scala-sbt.org/1.x/docs/sbt-1.2-Release-Notes.html#addPluginSbtFile+command,
+        // however working properly for real only since 1.3.4: https://github.com/sbt/sbt/releases/tag/v1.3.4
+        const standalonePluginFile =
+          sbtVersion != null &&
+          gte(sbtVersion, "1.3.4") &&
+          lte(sbtVersion, "1.4.0");
+        const useSlashSyntax = gte(sbtVersion, "1.5.0");
+        const isDependencyTreeBuiltIn =
+          sbtVersion != null && gte(sbtVersion, "1.4.0");
+        const tempDir = mkdtempSync(join(tmpdir(), "cdxsbt-"));
+        const tempSbtgDir = mkdtempSync(join(tmpdir(), "cdxsbtg-"));
+        mkdirSync(tempSbtgDir, { recursive: true });
+        // Create temporary plugins file
+        const tempSbtPlugins = join(tempSbtgDir, "dep-plugins.sbt");
 
+        // Requires a custom version of `sbt-dependency-graph` that
+        // supports `--append` for `toFile` subtask.
+        let sbtPluginDefinition = `\naddSbtPlugin("io.shiftleft" % "sbt-dependency-graph" % "0.10.0-append-to-file3")\n`;
+        if (isDependencyTreeBuiltIn) {
+          sbtPluginDefinition = `\naddDependencyTreePlugin\n`;
+          if (DEBUG_MODE) {
+            console.log("Using addDependencyTreePlugin as the custom plugin");
+          }
+        }
+        writeFileSync(tempSbtPlugins, sbtPluginDefinition);
         for (const i in sbtProjects) {
           const basePath = sbtProjects[i];
-          const sbtVersion = determineSbtVersion(basePath);
-          if (DEBUG_MODE) {
-            console.log("Detected sbt version: " + sbtVersion);
-          }
-          // Introduced in 1.2.0 https://www.scala-sbt.org/1.x/docs/sbt-1.2-Release-Notes.html#addPluginSbtFile+command,
-          // however working properly for real only since 1.3.4: https://github.com/sbt/sbt/releases/tag/v1.3.4
-          const standalonePluginFile =
-            sbtVersion != null &&
-            gte(sbtVersion, "1.3.4") &&
-            lte(sbtVersion, "1.4.0");
-          const useSlashSyntax = gte(sbtVersion, "1.5.0");
-          const isDependencyTreeBuiltIn =
-            sbtVersion != null && gte(sbtVersion, "1.4.0");
-          const tempDir = mkdtempSync(join(tmpdir(), "cdxsbt-"));
-          const tempSbtgDir = mkdtempSync(join(tmpdir(), "cdxsbtg-"));
-          mkdirSync(tempSbtgDir, { recursive: true });
-          // Create temporary plugins file
-          const tempSbtPlugins = join(tempSbtgDir, "dep-plugins.sbt");
-
-          // Requires a custom version of `sbt-dependency-graph` that
-          // supports `--append` for `toFile` subtask.
-          let sbtPluginDefinition = `\naddSbtPlugin("io.shiftleft" % "sbt-dependency-graph" % "0.10.0-append-to-file3")\n`;
-          if (isDependencyTreeBuiltIn) {
-            sbtPluginDefinition = `\naddDependencyTreePlugin\n`;
-            if (DEBUG_MODE) {
-              console.log("Using addDependencyTreePlugin as the custom plugin");
-            }
-          }
-          writeFileSync(tempSbtPlugins, sbtPluginDefinition);
           const dlFile = join(tempDir, "dl-" + i + ".tmp");
           let sbtArgs = [];
           let pluginFile = null;
@@ -1827,10 +1826,10 @@ export const createJavaBom = async (path, options) => {
             }
             options.failOnError && process.exit(1);
           }
+        }
 
-          // Cleanup
-          unlinkSync(tempSbtPlugins);
-        } // for
+        // Cleanup
+        unlinkSync(tempSbtPlugins);
       } // else
 
       if (DEBUG_MODE) {

--- a/utils.js
+++ b/utils.js
@@ -7207,6 +7207,9 @@ export const extractJarArchive = async function (
  */
 export const determineSbtVersion = function (projectPath) {
   const buildPropFile = join(projectPath, "project", "build.properties");
+  if (DEBUG_MODE) {
+    console.log("Looking for", buildPropFile);
+  }
   if (existsSync(buildPropFile)) {
     const properties = propertiesReader(buildPropFile);
     const property = properties.get("sbt.version");


### PR DESCRIPTION
cdxgen crach when analyse a scala repository where the project dir isn't at the root directory. The following directory structure can be used to reproduce the bug. 

```
/git/test/
└── src
    └── scala
        ├── build.sbt
        ├── project
        │   ├── build.properties
```

This is happening because `determineSbtVersion()` function is being called against the root dir [here](https://github.com/CycloneDX/cdxgen/blob/d9953876572280cd82ec2d967d7cbc11c31175e3/index.js#L1721C28-L1721C47) and it can't find the `build.properties` file. cdxgen crash with the following error:

```
Scanning /git/test/
Detected sbt version: null
/opt/node/lib/node_modules/@cyclonedx/cdxgen/node_modules/semver/classes/semver.js:19
      throw new TypeError(`Invalid version. Must be a string. Got type "${typeof version}".`)
```

With this PR if cdxgen can't detect sbt version at the root of repository being analysed it will loop over sbtProjects array trying to find a valid `build.properties` file.