### PR TITLE
parsePnpmLock: handle files with no packages field

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -1298,7 +1298,7 @@ export const parsePnpmLock = async function (pnpmLock, parentComponent = null) {
     } catch (e) {
       // ignore parse errors
     }
-    const packages = yamlObj.packages;
+    const packages = yamlObj.packages || {};
     const pkgKeys = Object.keys(packages);
     for (const k in pkgKeys) {
       // Eg: @babel/code-frame/7.10.1

--- a/utils.js
+++ b/utils.js
@@ -1260,6 +1260,9 @@ export const parsePnpmLock = async function (pnpmLock, parentComponent = null) {
       ).toString();
   }
   if (existsSync(pnpmLock)) {
+    if (DEBUG_MODE) {
+      console.log(`Parsing file ${pnpmLock}`);
+    }
     const lockData = readFileSync(pnpmLock, "utf8");
     const yamlObj = _load(lockData);
     if (!yamlObj) {


### PR DESCRIPTION
`parsePnpmLock` crach with the following error when parsing a `pnpm-lock.yaml` without a packages field.

```
file:///opt/node/lib/node_modules/@cyclonedx/cdxgen/utils.js:1299
    const pkgKeys = Object.keys(packages);
                           ^

TypeError: Cannot convert undefined or null to object
    at Function.keys (<anonymous>)
    at parsePnpmLock (file:///opt/node/lib/node_modules/@cyclonedx/cdxgen/utils.js:1299:28)
    at createNodejsBom (file:///opt/node/lib/node_modules/@cyclonedx/cdxgen/index.js:1995:32)
    at async createMultiXBom (file:///opt/node/lib/node_modules/@cyclonedx/cdxgen/index.js:4620:15)
    at async createBom (file:///opt/node/lib/node_modules/@cyclonedx/cdxgen/index.js:5663:16)
    at async file:///opt/node/lib/node_modules/@cyclonedx/cdxgen/bin/cdxgen.js:377:20
```