### PR TITLE
Do not log maven errors for multi-module projects by default

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cyclonedx/cdxgen",
-  "version": "9.11.1",
+  "version": "9.11.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cyclonedx/cdxgen",
-      "version": "9.11.1",
+      "version": "9.11.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/parser": "^7.23.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cyclonedx/cdxgen",
-  "version": "9.11.1",
+  "version": "9.11.2",
   "description": "Creates CycloneDX Software Bill of Materials (SBOM) from source or container image",
   "homepage": "http://github.com/cyclonedx/cdxgen",
   "author": "Prabhu Subramanian <prabhu@appthreat.com>",


### PR DESCRIPTION
We have multiple things working against us when it comes to java + maven projects.

1. We recurse by default. Many maven projects can only be built from a specific directory (rootPath)
2. We run the maven plugin in aggregate bom mode to reduce false negatives. Many projects can support such aggregation only from specific base modules.
3. There could be 100s of other factors that could prevent Maven from working smoothly, such as weather, etc.

For now, this PR moves several console.log within an if condition to tune down the logs for multi-module projects.

cc: @heubeck 