### PR TITLE
Added support for components filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,8 +175,9 @@ Options:
                                es.                    [boolean] [default: false]
       --spec-version           CycloneDX Specification version to use. Defaults
                                to 1.5                             [default: 1.5]
-      --filter                 Filter components containing this word in purl.
-                                Multiple values allowed.                 [array]
+      --filter                 Filter components containing this word in purl or
+                                component.properties.value. Multiple values allo
+                               wed.                                      [array]
       --only                   Include components only containing this word in
                                 purl. Useful to generate BOM with first party co
                                mponents alone. Multiple values allowed.  [array]

--- a/bin/cdxgen.js
+++ b/bin/cdxgen.js
@@ -193,7 +193,7 @@ const args = yargs(hideBin(process.argv))
   })
   .option("filter", {
     description:
-      "Filter components containing this word in purl. Multiple values allowed."
+      "Filter components containing this word in purl or component.properties.value. Multiple values allowed."
   })
   .option("only", {
     description:

--- a/docs/ADVANCED.md
+++ b/docs/ADVANCED.md
@@ -19,12 +19,20 @@ Languages supported:
 - Go
 - Php
 
-### Purl filter
+### Purl and properties filter
 
-Use `--filter` to filter components containing the string in the purl.
+Use `--filter` to filter components containing the string in the purl or components.properties.value. Filters are case-insensitive.
+
+Example 1: Filter all "springframework" packages
 
 ```shell
 cdxgen -t java -o /tmp/bom.json -p --filter org.springframework
+```
+
+Example 2: Filter components belonging to the gradle profile "debugAndroidTestCompileClasspath" or "debugRuntimeClasspath"
+
+```shell
+cdxgen -t gradle -o /tmp/bom.json -p --filter debugAndroidTestCompileClasspath --filter debugRuntimeClasspath
 ```
 
 ### Include only filter

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -110,8 +110,9 @@ Options:
                                es.                    [boolean] [default: false]
       --spec-version           CycloneDX Specification version to use. Defaults
                                to 1.5                             [default: 1.5]
-      --filter                 Filter components containing this word in purl.
-                                Multiple values allowed.                 [array]
+      --filter                 Filter components containing this word in purl or
+                                component.properties.value. Multiple values allo
+                               wed.                                      [array]
       --only                   Include components only containing this word in
                                 purl. Useful to generate BOM with first party co
                                mponents alone. Multiple values allowed.  [array]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cyclonedx/cdxgen",
-  "version": "10.0.3",
+  "version": "10.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cyclonedx/cdxgen",
-      "version": "10.0.3",
+      "version": "10.0.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/parser": "^7.23.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cyclonedx/cdxgen",
-  "version": "10.0.3",
+  "version": "10.0.4",
   "description": "Creates CycloneDX Software Bill of Materials (SBOM) from source or container image",
   "homepage": "http://github.com/cyclonedx/cdxgen",
   "author": "Prabhu Subramanian <prabhu@appthreat.com>",

--- a/postgen.js
+++ b/postgen.js
@@ -27,7 +27,10 @@ export const filterBom = (bomJson, options) => {
       }
       let purlfiltered = false;
       for (const filterstr of options.only) {
-        if (filterstr.length && !comp.purl.toLowerCase().includes(filterstr)) {
+        if (
+          filterstr.length &&
+          !comp.purl.toLowerCase().includes(filterstr.toLowerCase())
+        ) {
           filtered = true;
           purlfiltered = true;
           continue;
@@ -42,10 +45,27 @@ export const filterBom = (bomJson, options) => {
       }
       let purlfiltered = false;
       for (const filterstr of options.filter) {
-        if (filterstr.length && comp.purl.toLowerCase().includes(filterstr)) {
+        // Check the purl
+        if (
+          filterstr.length &&
+          comp.purl.toLowerCase().includes(filterstr.toLowerCase())
+        ) {
           filtered = true;
           purlfiltered = true;
           continue;
+        }
+        // Look for any properties value matching the string
+        const properties = comp.properties || [];
+        for (const aprop of properties) {
+          if (
+            aprop &&
+            aprop.value &&
+            aprop.value.toLowerCase().includes(filterstr.toLowerCase())
+          ) {
+            filtered = true;
+            purlfiltered = true;
+            continue;
+          }
         }
       }
       if (!purlfiltered) {


### PR DESCRIPTION
With this PR, `--filter` argument checks both purl and properties.value to filter components. This unlocks new use cases, such as the ability to filter based on a gradle profile.

Example: Filter components belonging to the gradle profile "debugAndroidTestCompileClasspath" or "debugRuntimeClasspath"

```shell
cdxgen -t gradle -o /tmp/bom.json -p --filter debugAndroidTestCompileClasspath --filter debugRuntimeClasspath
```

cc: @heubeck 