### PR TITLE
Track exported modules for js in deep mode

### DIFF
--- a/analyzer.js
+++ b/analyzer.js
@@ -8,7 +8,6 @@ import { basename, resolve, isAbsolute, relative } from "node:path";
 const IGNORE_DIRS = process.env.ASTGEN_IGNORE_DIRS
   ? process.env.ASTGEN_IGNORE_DIRS.split(",")
   : [
-      "node_modules",
       "venv",
       "docs",
       "test",
@@ -37,7 +36,7 @@ const IGNORE_FILE_PATTERN = new RegExp(
   "i"
 );
 
-const getAllFiles = (dir, extn, files, result, regex) => {
+const getAllFiles = (deep, dir, extn, files, result, regex) => {
   files = files || readdirSync(dir);
   result = result || [];
   regex = regex || new RegExp(`\\${extn}$`);
@@ -60,8 +59,20 @@ const getAllFiles = (dir, extn, files, result, regex) => {
       ) {
         continue;
       }
+      // We need to include node_modules in deep mode to track exports
+      // Ignore only for non-deep analysis
+      if (!deep && dirName === "node_modules") {
+        continue;
+      }
       try {
-        result = getAllFiles(file, extn, readdirSync(file), result, regex);
+        result = getAllFiles(
+          deep,
+          file,
+          extn,
+          readdirSync(file),
+          result,
+          regex
+        );
       } catch (error) {
         continue;
       }
@@ -101,7 +112,14 @@ const babelParserOptions = {
  * Filter only references to (t|jsx?) or (less|scss) files for now.
  * Opt to use our relative paths.
  */
-const setFileRef = (allImports, src, file, pathnode, specifiers = []) => {
+const setFileRef = (
+  allImports,
+  allExports,
+  src,
+  file,
+  pathnode,
+  specifiers = []
+) => {
   const pathway = pathnode.value || pathnode.name;
   const sourceLoc = pathnode.loc?.start;
   if (!pathway) {
@@ -115,9 +133,13 @@ const setFileRef = (allImports, src, file, pathnode, specifiers = []) => {
   const importedModules = specifiers
     .map((s) => s.imported?.name)
     .filter((v) => v !== undefined);
+  const exportedModules = specifiers
+    .map((s) => s.exported?.name)
+    .filter((v) => v !== undefined);
   const occurrence = {
     importedAs: pathway,
     importedModules,
+    exportedModules,
     isExternal: true,
     fileName: fileRelativeLoc,
     lineNumber: sourceLoc && sourceLoc.line ? sourceLoc.line : undefined,
@@ -132,16 +154,29 @@ const setFileRef = (allImports, src, file, pathnode, specifiers = []) => {
       moduleFullPath = relative(src, moduleFullPath);
       wasAbsolute = true;
     }
-    occurrence.isExternal = false;
+    if (!moduleFullPath.startsWith("node_modules/")) {
+      occurrence.isExternal = false;
+    }
   }
   allImports[moduleFullPath] = allImports[moduleFullPath] || new Set();
   allImports[moduleFullPath].add(occurrence);
+
   // Handle module package name
   // Eg: zone.js/dist/zone will be referred to as zone.js in package.json
   if (!wasAbsolute && moduleFullPath.includes("/")) {
     const modPkg = moduleFullPath.split("/")[0];
     allImports[modPkg] = allImports[modPkg] || new Set();
     allImports[modPkg].add(occurrence);
+  }
+  if (exportedModules && exportedModules.length) {
+    moduleFullPath = moduleFullPath
+      .replace("node_modules/", "")
+      .replace("dist/", "")
+      .replace(/\.(js|ts|cjs|mjs)$/g, "")
+      .replace("src/", "");
+    allExports[moduleFullPath] = allExports[moduleFullPath] || new Set();
+    occurrence.exportedModules = exportedModules;
+    allExports[moduleFullPath].add(occurrence);
   }
 };
 
@@ -178,13 +213,14 @@ const fileToParseableCode = (file) => {
  * Check AST tree for any (j|tsx?) files and set a file
  * references for any import, require or dynamic import files.
  */
-const parseFileASTTree = (src, file, allImports) => {
+const parseFileASTTree = (src, file, allImports, allExports) => {
   const ast = parse(fileToParseableCode(file), babelParserOptions);
   traverse.default(ast, {
     ImportDeclaration: (path) => {
       if (path && path.node) {
         setFileRef(
           allImports,
+          allExports,
           src,
           file,
           path.node.source,
@@ -200,24 +236,25 @@ const parseFileASTTree = (src, file, allImports) => {
         path.node.name === "require" &&
         path.parent.type === "CallExpression"
       ) {
-        setFileRef(allImports, src, file, path.parent.arguments[0]);
+        setFileRef(allImports, allExports, src, file, path.parent.arguments[0]);
       }
     },
     // Use for dynamic imports like routes.jsx
     CallExpression: (path) => {
       if (path && path.node && path.node.callee.type === "Import") {
-        setFileRef(allImports, src, file, path.node.arguments[0]);
+        setFileRef(allImports, allExports, src, file, path.node.arguments[0]);
       }
     },
     // Use for export barrells
     ExportAllDeclaration: (path) => {
-      setFileRef(allImports, src, file, path.node.source);
+      setFileRef(allImports, allExports, src, file, path.node.source);
     },
     ExportNamedDeclaration: (path) => {
       // ensure there is a path export
       if (path && path.node && path.node.source) {
         setFileRef(
           allImports,
+          allExports,
           src,
           file,
           path.node.source,
@@ -231,36 +268,37 @@ const parseFileASTTree = (src, file, allImports) => {
 /**
  * Return paths to all (j|tsx?) files.
  */
-const getAllSrcJSAndTSFiles = (src) =>
+const getAllSrcJSAndTSFiles = (src, deep) =>
   Promise.all([
-    getAllFiles(src, ".js"),
-    getAllFiles(src, ".jsx"),
-    getAllFiles(src, ".cjs"),
-    getAllFiles(src, ".mjs"),
-    getAllFiles(src, ".ts"),
-    getAllFiles(src, ".tsx"),
-    getAllFiles(src, ".vue"),
-    getAllFiles(src, ".svelte")
+    getAllFiles(deep, src, ".js"),
+    getAllFiles(deep, src, ".jsx"),
+    getAllFiles(deep, src, ".cjs"),
+    getAllFiles(deep, src, ".mjs"),
+    getAllFiles(deep, src, ".ts"),
+    getAllFiles(deep, src, ".tsx"),
+    getAllFiles(deep, src, ".vue"),
+    getAllFiles(deep, src, ".svelte")
   ]);
 
 /**
- * Where Node CLI runs from.
+ * Find all imports and exports
  */
-export const findJSImports = async (src) => {
+export const findJSImportsExports = async (src, deep) => {
   const allImports = {};
+  const allExports = {};
   const errFiles = [];
   try {
-    const promiseMap = await getAllSrcJSAndTSFiles(src);
+    const promiseMap = await getAllSrcJSAndTSFiles(src, deep);
     const srcFiles = promiseMap.flatMap((d) => d);
     for (const file of srcFiles) {
       try {
-        parseFileASTTree(src, file, allImports);
+        parseFileASTTree(src, file, allImports, allExports);
       } catch (err) {
         errFiles.push(file);
       }
     }
-    return allImports;
+    return { allImports, allExports };
   } catch (err) {
-    return allImports;
+    return { allImports, allExports };
   }
 };

--- a/utils.js
+++ b/utils.js
@@ -8283,6 +8283,8 @@ export const addEvidenceForImports = async (
               pkg.description = lnmMetadata.description;
               pkg.author = lnmMetadata.author;
               pkg.license = lnmMetadata.license;
+              pkg.homepage = lnmMetadata.homepage;
+              pkg.repository = lnmMetadata.repository;
             }
           }
         }

--- a/utils.js
+++ b/utils.js
@@ -559,13 +559,29 @@ export const parsePkgJson = async (pkgJsonFile, simple = false) => {
         null,
         null
       ).toString();
+      const author = pkgData.author;
+      const authorString =
+        author instanceof Object
+          ? `${author.name}${author.email ? ` <${author.email}>` : ""}${
+              author.url ? ` (${author.url})` : ""
+            }`
+          : author;
       const apkg = {
         name,
         group,
         version: pkgData.version,
+        description: pkgData.description,
         purl: purl,
-        "bom-ref": decodeURIComponent(purl)
+        "bom-ref": decodeURIComponent(purl),
+        author: authorString,
+        license: pkgData.license
       };
+      if (pkgData.homepage) {
+        apkg.homepage = { url: pkgData.homepage };
+      }
+      if (pkgData.repository && pkgData.repository.url) {
+        apkg.repository = { url: pkgData.repository.url };
+      }
       if (!simple) {
         apkg.properties = [
           {
@@ -718,6 +734,12 @@ export const parsePkgLock = async (pkgLockFile, options = {}) => {
         pkg.properties.push({
           name: "ResolvedUrl",
           value: node.resolved
+        });
+      }
+      if (node.location) {
+        pkg.properties.push({
+          name: "LocalNodeModulesPath",
+          value: node.location
         });
       }
     }
@@ -8135,9 +8157,16 @@ export const parsePackageJsonName = (name) => {
  *
  * @param {array} pkgList List of package
  * @param {object} allImports Import statements object with package name as key and an object with file and location details
+ * @param {object} allExports Exported modules if available from node_modules
  */
-export const addEvidenceForImports = (pkgList, allImports) => {
+export const addEvidenceForImports = async (
+  pkgList,
+  allImports,
+  allExports,
+  deep
+) => {
   const impPkgs = Object.keys(allImports);
+  const exportedPkgs = Object.keys(allExports);
   for (const pkg of pkgList) {
     if (impPkgs && impPkgs.length) {
       // Assume that all packages are optional until we see an evidence
@@ -8158,6 +8187,47 @@ export const addEvidenceForImports = (pkgList, allImports) => {
           find_pkg.startsWith(alias) &&
           (find_pkg.length === alias.length || find_pkg[alias.length] === "/")
       );
+      const all_exports = exportedPkgs.filter((find_pkg) =>
+        find_pkg.startsWith(alias)
+      );
+      if (all_exports && all_exports.length) {
+        let exportedModules = new Set(all_exports);
+        pkg.properties = pkg.properties || [];
+        for (const subevidence of all_exports) {
+          const evidences = allExports[subevidence];
+          for (const evidence of evidences) {
+            if (evidence && Object.keys(evidence).length) {
+              if (evidence.exportedModules.length > 1) {
+                for (const aexpsubm of evidence.exportedModules) {
+                  // Be selective on the submodule names
+                  if (
+                    !evidence.importedAs
+                      .toLowerCase()
+                      .includes(aexpsubm.toLowerCase()) &&
+                    !alias.endsWith(aexpsubm)
+                  ) {
+                    // Store both the short and long form of the exported sub modules
+                    if (aexpsubm.length > 3) {
+                      exportedModules.add(aexpsubm);
+                    }
+                    exportedModules.add(
+                      `${evidence.importedAs.replace("./", "")}/${aexpsubm}`
+                    );
+                  }
+                }
+              }
+            }
+          }
+        }
+        exportedModules = Array.from(exportedModules);
+        if (exportedModules.length) {
+          pkg.properties.push({
+            name: "ExportedModules",
+            value: exportedModules.join(",")
+          });
+        }
+      }
+      // Identify all the imported modules of a component
       if (impPkgs.includes(alias) || all_includes.length) {
         let importedModules = new Set();
         pkg.scope = "required";
@@ -8178,7 +8248,9 @@ export const addEvidenceForImports = (pkgList, allImports) => {
                   continue;
                 }
                 // Store both the short and long form of the imported sub modules
-                importedModules.add(importedSm);
+                if (importedSm.length > 3) {
+                  importedModules.add(importedSm);
+                }
                 importedModules.add(`${evidence.importedAs}/${importedSm}`);
               }
             }
@@ -8194,8 +8266,33 @@ export const addEvidenceForImports = (pkgList, allImports) => {
         }
         break;
       }
-    }
-  }
+      // Capture metadata such as description from local node_modules in deep mode
+      if (deep && !pkg.description && pkg.properties) {
+        let localNodeModulesPath = undefined;
+        for (const aprop of pkg.properties) {
+          if (aprop.name === "LocalNodeModulesPath") {
+            localNodeModulesPath = resolve(join(aprop.value, "package.json"));
+            break;
+          }
+        }
+        if (localNodeModulesPath && existsSync(localNodeModulesPath)) {
+          const lnmPkgList = await parsePkgJson(localNodeModulesPath, true);
+          if (lnmPkgList && lnmPkgList.length === 1) {
+            const lnmMetadata = lnmPkgList[0];
+            if (lnmMetadata && Object.keys(lnmMetadata).length) {
+              pkg.description = lnmMetadata.description;
+              pkg.author = lnmMetadata.author;
+              pkg.license = lnmMetadata.license;
+            }
+          }
+        }
+      }
+    } // for alias
+    // Trim the properties
+    pkg.properties = pkg.properties.filter(
+      (p) => p.name !== "LocalNodeModulesPath"
+    );
+  } // for pkg
   return pkgList;
 };
 

--- a/utils.test.js
+++ b/utils.test.js
@@ -38,6 +38,7 @@ import {
   parsePom,
   getMvnMetadata,
   getLicenses,
+  parsePkgJson,
   parsePkgLock,
   parseBowerJson,
   parseNodeShrinkwrap,
@@ -1717,6 +1718,11 @@ test("get licenses", () => {
       }
     }
   ]);
+});
+
+test("parsePkgJson", async () => {
+  const pkgList = await parsePkgJson("./package.json", true);
+  expect(pkgList.length).toEqual(1);
 });
 
 test("parsePkgLock v1", async () => {


### PR DESCRIPTION
In deep mode, cdxgen now tracks both Exported and Imported modules for npm components. By tracking all the exported modules, we can potentially get reachable hits for transitive dependencies (assuming there is a symbols database for vulnerabilities) without direct usage in the code (Absent in ImportedModules).

In addition, if `node_modules` directory is present, cdxgen would try to retrieve the description, author, homepage, and license information to enhance the SBOM.

For the juice shop, the new time is over 5 minutes. However, the depth of information would improve atom auto-tagging and subsequent identification of more reachable flows.

[bom.json.txt](https://github.com/CycloneDX/cdxgen/files/14130434/bom.json.txt)
