### PR TITLE
feat(oci): set repository_url to registry and name, not full image statement

### DIFF
--- a/index.js
+++ b/index.js
@@ -3809,7 +3809,8 @@ export const createContainerSpecLikeBom = async (path, options) => {
               type: "container"
             };
             if (imageObj.registry) {
-              pkg["qualifiers"]["repository_url"] = img.image;
+              pkg["qualifiers"]["repository_url"] =
+                `${imageObj.registry}/${imageObj.repo}`;
             }
             if (imageObj.platform) {
               pkg["qualifiers"]["platform"] = imageObj.platform;


### PR DESCRIPTION
Partially addresses #872 by not using a full image statement as the repository_url.

Behavior now matches the examples per [oci purl spec](https://github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst#oci), 