### PR TITLE
feat(utils): retrieve licenses for Dart packages

### DIFF
--- a/utils.test.js
+++ b/utils.test.js
@@ -1020,17 +1020,17 @@ test("get dart metadata", async () => {
     {
       group: "",
       name: "async",
-      version: "2.8.2"
+      version: "2.11.0"
     }
   ]);
   expect(dep_list.length).toEqual(1);
   expect(dep_list[0]).toEqual({
     group: "",
     name: "async",
-    version: "2.8.2",
+    version: "2.11.0",
     description:
       "Utility functions and classes related to the 'dart:async' library.",
-    license: "https://pub.dev/packages/async/license",
+    license: "BSD-3-Clause",
     repository: {
       url: "https://github.com/dart-lang/async"
     }


### PR DESCRIPTION
I found an api to retrieve the licenses.
I only tested via the npm run test.

- Replace list, if by a find
- Extract license with /api/packages/<package_name>/score json
```json
{
	"grantedPoints": 130,
	"maxPoints": 140,
	"likeCount": 511,
	"popularityScore": 0.9982012522051956,
	"tags": [
		"publisher:dart.dev",
		"sdk:dart",
		"sdk:flutter",
		"platform:android",
		"platform:ios",
		"platform:windows",
		"platform:linux",
		"platform:macos",
		"platform:web",
		"runtime:native-aot",
		"runtime:native-jit",
		"runtime:web",
		"is:null-safe",
		"is:wasm-ready",
		"is:dart3-compatible",
		"license:bsd-3-clause",
		"license:fsf-libre",
		"license:osi-approved"
	],
	"lastUpdated": "2024-02-13T13:42:27.418719"
}
```

#891