### PR TITLE
Fallback to location based lookups for npm when integrity is unavailable

### DIFF
--- a/index.js
+++ b/index.js
@@ -4412,7 +4412,7 @@ export async function createCsharpBom(path, options) {
     }
   } else if (pkgLockFiles.length) {
     manifestFiles = manifestFiles.concat(pkgLockFiles);
-    let parentDependsOn = new Set();
+    const parentDependsOn = new Set();
     // packages.lock.json from nuget
     for (const af of pkgLockFiles) {
       if (DEBUG_MODE) {
@@ -4432,7 +4432,7 @@ export async function createCsharpBom(path, options) {
       // Keep track of the direct dependencies so that we can construct one complete
       // list after processing all lock files
       if (rootList && rootList.length) {
-        for(const p of rootList) {
+        for (const p of rootList) {
           parentDependsOn.add(p["bom-ref"]);
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cyclonedx/cdxgen",
-  "version": "10.2.4",
+  "version": "10.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cyclonedx/cdxgen",
-      "version": "10.2.4",
+      "version": "10.2.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/parser": "^7.24.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cyclonedx/cdxgen",
-  "version": "10.2.4",
+  "version": "10.2.5",
   "description": "Creates CycloneDX Software Bill of Materials (SBOM) from source or container image",
   "homepage": "http://github.com/cyclonedx/cdxgen",
   "author": "Prabhu Subramanian <prabhu@appthreat.com>",


### PR DESCRIPTION
Related to #795 

When there is no integrity available, the dependency tree is incomplete. With this PR, the location attribute is used as a fallback to solve and complete the tree.