### PR TITLE
Safely get the resolved version for nuget

### DIFF
--- a/.github/workflows/repotests.yml
+++ b/.github/workflows/repotests.yml
@@ -191,6 +191,10 @@ jobs:
         with:
           repository: 'microsoft/dotnet-podcasts'
           path: 'repotests/dotnet-podcasts'
+      - uses: actions/checkout@v4
+        with:
+          repository: 'microsoft/react-native-windows'
+          path: 'repotests/react-native-windows'
       - uses: dtolnay/rust-toolchain@stable
       - name: repotests java-sec-code
         run: |
@@ -310,6 +314,7 @@ jobs:
           bin/cdxgen.js -p -r -t dotnet repotests/dotnet-paket -o bomresults/bom-dotnet-paket.json --validate
           FETCH_LICENSE=true bin/cdxgen.js -p -r -t dotnet repotests/dotnet-paket -o bomresults/bom-dotnet-paket-2.json --validate
           bin/cdxgen.js -p -r -t dotnet repotests/dotnet-podcasts -o bomresults/bom-dotnet-podcasts.json --profile research --export-proto
+          bin/cdxgen.js -p -r -t dotnet repotests/react-native-windows -o bomresults/bom-react-native-windows.json
         shell: bash
       - name: repotests blint
         run: |

--- a/index.js
+++ b/index.js
@@ -4313,6 +4313,13 @@ export async function createCsharpBom(path, options) {
     getAllFiles(path, (options.multiProject ? "**/" : "") + "*.vbproj", options)
   );
   csProjFiles = csProjFiles.concat(
+    getAllFiles(
+      path,
+      (options.multiProject ? "**/" : "") + "*.vcxproj",
+      options
+    )
+  );
+  csProjFiles = csProjFiles.concat(
     getAllFiles(path, (options.multiProject ? "**/" : "") + "*.fsproj", options)
   );
   const pkgConfigFiles = getAllFiles(

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cyclonedx/cdxgen",
-  "version": "10.2.5",
+  "version": "10.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cyclonedx/cdxgen",
-      "version": "10.2.5",
+      "version": "10.2.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/parser": "^7.24.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cyclonedx/cdxgen",
-  "version": "10.2.5",
+  "version": "10.2.6",
   "description": "Creates CycloneDX Software Bill of Materials (SBOM) from source or container image",
   "homepage": "http://github.com/cyclonedx/cdxgen",
   "author": "Prabhu Subramanian <prabhu@appthreat.com>",

--- a/utils.js
+++ b/utils.js
@@ -6042,6 +6042,10 @@ export function parseCsPkgLockData(csLockData, pkgLockFile) {
           ) {
             adepResolvedVersion =
               assetData.dependencies[aversion][adep].resolved;
+          } else if (DEBUG_MODE) {
+            console.warn(
+              `Unable to find the resolved version for ${adep} ${aversion}. Using ${adepResolvedVersion} which may be incorrect.`
+            );
           }
           const adpurl = new PackageURL(
             "nuget",

--- a/utils.js
+++ b/utils.js
@@ -6033,10 +6033,16 @@ export function parseCsPkgLockData(csLockData, pkgLockFile) {
       const dependsOn = [];
       if (libData.dependencies) {
         for (const adep of Object.keys(libData.dependencies)) {
-          // get the resolved version of the dependency
-          const adepResolvedVersion =
-            assetData.dependencies[aversion][adep].resolved;
-
+          let adepResolvedVersion = libData.dependencies[adep];
+          // Try to get the resolved version of the dependency. See #930 and #937
+          if (
+            assetData.dependencies[aversion] &&
+            assetData.dependencies[aversion][adep] &&
+            assetData.dependencies[aversion][adep].resolved
+          ) {
+            adepResolvedVersion =
+              assetData.dependencies[aversion][adep].resolved;
+          }
           const adpurl = new PackageURL(
             "nuget",
             "",

--- a/utils.js
+++ b/utils.js
@@ -6027,13 +6027,15 @@ export function parseCsPkgLockData(csLockData, pkgLockFile) {
         }
       };
       pkgList.push(pkg);
-      if (libData.type === "Direct") {
+      if (["Direct", "Project"].includes(libData.type)) {
         rootList.push(pkg);
       }
       const dependsOn = [];
       if (libData.dependencies) {
-        for (const adep of Object.keys(libData.dependencies)) {
+        for (let adep of Object.keys(libData.dependencies)) {
           let adepResolvedVersion = libData.dependencies[adep];
+          const aversionNoRuntime = aversion.split("/")[0];
+          let isProjectType = false;
           // Try to get the resolved version of the dependency. See #930 and #937
           if (
             assetData.dependencies[aversion] &&
@@ -6042,10 +6044,61 @@ export function parseCsPkgLockData(csLockData, pkgLockFile) {
           ) {
             adepResolvedVersion =
               assetData.dependencies[aversion][adep].resolved;
+          } else if (
+            aversion.includes("/") &&
+            assetData.dependencies[aversionNoRuntime] &&
+            assetData.dependencies[aversionNoRuntime][adep] &&
+            assetData.dependencies[aversionNoRuntime][adep].resolved
+          ) {
+            adepResolvedVersion =
+              assetData.dependencies[aversionNoRuntime][adep].resolved;
           } else if (DEBUG_MODE) {
-            console.warn(
-              `Unable to find the resolved version for ${adep} ${aversion}. Using ${adepResolvedVersion} which may be incorrect.`
-            );
+            // Only Microsoft can call a lock file that uses version ranges as a "lock file" for "reproducible" builds.
+            if (adepResolvedVersion.startsWith("[")) {
+              const versionToUse = adepResolvedVersion.replace(/[[, )]/g, "");
+              if (
+                (assetData.dependencies[aversion] &&
+                  assetData.dependencies[aversion][adep] &&
+                  assetData.dependencies[aversion][adep].type === "Project") ||
+                (assetData.dependencies[aversionNoRuntime] &&
+                  assetData.dependencies[aversionNoRuntime][adep] &&
+                  assetData.dependencies[aversionNoRuntime][adep].type ===
+                    "Project")
+              ) {
+                isProjectType = true;
+              }
+              // To make matters worse, the name of the project could be all lowercased
+              // Eg: In react-native-windows repo, folly and Folly are used for the project name
+              else if (
+                (assetData.dependencies[aversion] &&
+                  assetData.dependencies[aversion][adep.toLowerCase()] &&
+                  assetData.dependencies[aversion][adep.toLowerCase()].type ===
+                    "Project") ||
+                (assetData.dependencies[aversionNoRuntime] &&
+                  assetData.dependencies[aversionNoRuntime][
+                    adep.toLowerCase()
+                  ] &&
+                  assetData.dependencies[aversionNoRuntime][adep.toLowerCase()]
+                    .type === "Project")
+              ) {
+                isProjectType = true;
+                adep = adep.toLowerCase();
+              }
+              // If this component is a project type, the version information would be often missing.
+              // So we remove the version to match based on name alone
+              if (isProjectType) {
+                adepResolvedVersion = undefined;
+              } else {
+                console.warn(
+                  `The version used for ${adep} is a range - ${adepResolvedVersion}. Using the min version ${versionToUse} which may be incorrect.`
+                );
+                adepResolvedVersion = versionToUse;
+              }
+            } else {
+              console.warn(
+                `Unable to find the resolved version for ${adep} ${aversion}. Using ${adepResolvedVersion} which may be incorrect.`
+              );
+            }
           }
           const adpurl = new PackageURL(
             "nuget",

--- a/utils.test.js
+++ b/utils.test.js
@@ -1410,6 +1410,29 @@ test("parse packages.lock.json", async () => {
     "./test/data/packages3.lock.json"
   );
   expect(dep_list["pkgList"].length).toEqual(15);
+  expect(dep_list["pkgList"][1]).toEqual({
+    group: "",
+    name: "FSharp.Core",
+    version: "4.5.2",
+    purl: "pkg:nuget/FSharp.Core@4.5.2",
+    "bom-ref": "pkg:nuget/FSharp.Core@4.5.2",
+    _integrity:
+      "sha512-apbdQOjzsjQ637kTWQuW29jqwY18jsHMyNC5A+TPJZKFEIE2cIfQWf3V7+mXrxlbX69BueYkv293/g70wuXuRw==",
+    properties: [{ name: "SrcFile", value: "./test/data/packages3.lock.json" }],
+    evidence: {
+      identity: {
+        field: "purl",
+        confidence: 1,
+        methods: [
+          {
+            technique: "manifest-analysis",
+            confidence: 1,
+            value: "./test/data/packages3.lock.json"
+          }
+        ]
+      }
+    }
+  });
   expect(dep_list["dependenciesList"].length).toEqual(15);
 });
 

--- a/utils.test.js
+++ b/utils.test.js
@@ -1230,9 +1230,9 @@ test("parse github actions workflow data", () => {
   expect(dep_list.length).toEqual(3);
 });
 
-test("parse cs pkg data", async () => {
-  expect(await parseCsPkgData(null)).toEqual([]);
-  const dep_list = await parseCsPkgData(
+test("parse cs pkg data", () => {
+  expect(parseCsPkgData(null)).toEqual([]);
+  const dep_list = parseCsPkgData(
     readFileSync("./test/data/packages.config", { encoding: "utf-8" })
   );
   expect(dep_list.length).toEqual(21);
@@ -1243,9 +1243,9 @@ test("parse cs pkg data", async () => {
   });
 });
 
-test("parse cs pkg data 2", async () => {
-  expect(await parseCsPkgData(null)).toEqual([]);
-  const dep_list = await parseCsPkgData(
+test("parse cs pkg data 2", () => {
+  expect(parseCsPkgData(null)).toEqual([]);
+  const dep_list = parseCsPkgData(
     readFileSync("./test/data/packages2.config", { encoding: "utf-8" })
   );
   expect(dep_list.length).toEqual(1);
@@ -1256,9 +1256,9 @@ test("parse cs pkg data 2", async () => {
   });
 });
 
-test("parse cs proj", async () => {
-  expect(await parseCsProjData(null)).toEqual([]);
-  const dep_list = await parseCsProjData(
+test("parse cs proj", () => {
+  expect(parseCsProjData(null)).toEqual([]);
+  const dep_list = parseCsProjData(
     readFileSync("./test/sample.csproj", { encoding: "utf-8" })
   );
   expect(dep_list.length).toEqual(5);
@@ -1269,12 +1269,12 @@ test("parse cs proj", async () => {
   });
 });
 
-test("parse project.assets.json", async () => {
-  expect(await parseCsProjAssetsData(null)).toEqual({
+test("parse project.assets.json", () => {
+  expect(parseCsProjAssetsData(null)).toEqual({
     dependenciesList: [],
     pkgList: []
   });
-  let dep_list = await parseCsProjAssetsData(
+  let dep_list = parseCsProjAssetsData(
     readFileSync("./test/data/project.assets.json", { encoding: "utf-8" }),
     "./test/data/project.assets.json"
   );
@@ -1312,7 +1312,7 @@ test("parse project.assets.json", async () => {
     ],
     ref: "pkg:nuget/Castle.Core.Tests@0.0.0"
   });
-  dep_list = await parseCsProjAssetsData(
+  dep_list = parseCsProjAssetsData(
     readFileSync("./test/data/project.assets1.json", { encoding: "utf-8" }),
     "./test/data/project.assets1.json"
   );
@@ -1334,13 +1334,13 @@ test("parse project.assets.json", async () => {
   */
 });
 
-test("parse packages.lock.json", async () => {
-  expect(await parseCsPkgLockData(null)).toEqual({
+test("parse packages.lock.json", () => {
+  expect(parseCsPkgLockData(null)).toEqual({
     dependenciesList: [],
     pkgList: [],
     rootList: []
   });
-  let dep_list = await parseCsPkgLockData(
+  let dep_list = parseCsPkgLockData(
     readFileSync("./test/data/packages.lock.json", { encoding: "utf-8" }),
     "./test/data/packages.lock.json"
   );
@@ -1368,7 +1368,7 @@ test("parse packages.lock.json", async () => {
       }
     }
   });
-  dep_list = await parseCsPkgLockData(
+  dep_list = parseCsPkgLockData(
     readFileSync("./test/data/packages2.lock.json", { encoding: "utf-8" }),
     "./test/data/packages2.lock.json"
   );
@@ -1405,7 +1405,7 @@ test("parse packages.lock.json", async () => {
       "pkg:nuget/Microsoft.Extensions.Logging.Abstractions@6.0.0"
     ]
   });
-  dep_list = await parseCsPkgLockData(
+  dep_list = parseCsPkgLockData(
     readFileSync("./test/data/packages3.lock.json", { encoding: "utf-8" }),
     "./test/data/packages3.lock.json"
   );
@@ -1436,12 +1436,12 @@ test("parse packages.lock.json", async () => {
   expect(dep_list["dependenciesList"].length).toEqual(15);
 });
 
-test("parse paket.lock", async () => {
-  expect(await parsePaketLockData(null)).toEqual({
+test("parse paket.lock", () => {
+  expect(parsePaketLockData(null)).toEqual({
     pkgList: [],
     dependenciesList: []
   });
-  const dep_list = await parsePaketLockData(
+  const dep_list = parsePaketLockData(
     readFileSync("./test/data/paket.lock", { encoding: "utf-8" }),
     "./test/data/paket.lock"
   );
@@ -1477,9 +1477,9 @@ test("parse paket.lock", async () => {
   });
 });
 
-test("parse .net cs proj", async () => {
-  expect(await parseCsProjData(null)).toEqual([]);
-  const dep_list = await parseCsProjData(
+test("parse .net cs proj", () => {
+  expect(parseCsProjData(null)).toEqual([]);
+  const dep_list = parseCsProjData(
     readFileSync("./test/data/sample-dotnet.csproj", { encoding: "utf-8" })
   );
   expect(dep_list.length).toEqual(19);
@@ -2858,7 +2858,7 @@ test("parse nupkg file", async () => {
   );
   expect(deps.length).toEqual(1);
   expect(deps[0].name).toEqual("Microsoft.Web.Infrastructure");
-  deps = await parseNuspecData(
+  deps = parseNuspecData(
     "./test/data/Microsoft.Web.Infrastructure.1.0.0.0.nuspec",
     readFileSync(
       "./test/data/Microsoft.Web.Infrastructure.1.0.0.0.nuspec",


### PR DESCRIPTION
Fixes #937

@scrocquesel could you check this PR and let me know if the version numbers are still correct for project.assets.json and packages.lock.json based projects? Do you have the test case to reproduce the warnings mentioned in this [comment](https://github.com/CycloneDX/cdxgen/issues/930#issuecomment-2016229907)?

```shell
export CDXGEN_DEBUG_MODE=debug
git clone https://github.com/CycloneDX/cdxgen
cd cdxgen
git checkout fix/issue-937
npm install
node bin/cdxgen.js -t csharp -o bom.json ...
```