### PR TITLE
Bundle dotnet sdk 8

### DIFF
--- a/binary.js
+++ b/binary.js
@@ -6,7 +6,8 @@ import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
-  rmSync
+  rmSync,
+  lstatSync
 } from "node:fs";
 import { basename, dirname, join, resolve } from "node:path";
 import { spawnSync } from "node:child_process";
@@ -802,10 +803,11 @@ export function getBinaryBom(src, binaryBomFile, deepMode) {
   if (DEBUG_MODE) {
     console.log("Executing", BLINT_BIN, args.join(" "));
   }
+  const cwd = lstatSync(src).isDirectory() ? src : dirname(src);
   const result = spawnSync(BLINT_BIN, args, {
     encoding: "utf-8",
     timeout: TIMEOUT_MS,
-    cwd: src
+    cwd
   });
   if (result.status !== 0 || result.error) {
     if (result.stderr) {

--- a/binary.js
+++ b/binary.js
@@ -20,12 +20,7 @@ let url = import.meta.url;
 if (!url.startsWith("file://")) {
   url = new URL(`file://${import.meta.url}`).toString();
 }
-let dirName = import.meta ? dirname(fileURLToPath(url)) : __dirname;
-// When cdxgen is used as a library, dirName would be inside the node_modules directory
-// we need to locate the base directory of the dependent project in this case.
-if (dirName.includes("node_modules")) {
-  dirName = dirName.split(join("node_modules", "@cyclonedx"))[0];
-}
+const dirName = import.meta ? dirname(fileURLToPath(url)) : __dirname;
 
 const isWin = _platform() === "win32";
 

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -66,7 +66,7 @@ RUN set -e; \
     && microdnf module enable php ruby -y \
     && microdnf install -y php php-curl php-zip php-bcmath php-json php-pear php-mbstring php-devel make gcc git-core \
         python3.11 python3.11-devel python3.11-pip ruby ruby-devel glibc-common glibc-all-langpacks \
-        pcre2 which tar gzip zip unzip sudo nodejs ncurses sqlite-devel \
+        pcre2 which tar gzip zip unzip sudo nodejs ncurses sqlite-devel dotnet-sdk-8.0 \
     && alternatives --install /usr/bin/python3 python /usr/bin/python3.11 1 \
     && python3 --version \
     && python3 -m pip install --upgrade pip virtualenv \

--- a/ci/Dockerfile-deno
+++ b/ci/Dockerfile-deno
@@ -63,7 +63,7 @@ RUN set -e; \
     microdnf module enable php ruby -y \
     && microdnf install -y php php-curl php-zip php-bcmath php-json php-pear php-mbstring php-devel make gcc git-core \
         python3.11 python3.11-devel python3.11-pip ruby ruby-devel \
-        pcre2 which tar gzip zip unzip sudo ncurses sqlite-devel \
+        pcre2 which tar gzip zip unzip sudo ncurses sqlite-devel dotnet-sdk-8.0 \
     && alternatives --install /usr/bin/python3 python /usr/bin/python3.11 1 \
     && python3 --version \
     && python3 -m pip install --upgrade pip virtualenv \

--- a/index.js
+++ b/index.js
@@ -83,7 +83,6 @@ import {
   parseGoModData,
   parseGoModGraph,
   parseGoModWhy,
-  parseGoVersionData,
   parseGopkgData,
   parseGosumData,
   parseGradleDep,
@@ -149,7 +148,6 @@ import {
   executeOsQuery,
   getCargoAuditableInfo,
   getDotnetSlices,
-  getGoBuildInfo,
   getOSPackages,
   getBinaryBom
 } from "./binary.js";
@@ -2696,25 +2694,8 @@ export async function createGoBom(path, options) {
   } catch (err) {
     maybeBinary = false;
   }
-  if (maybeBinary) {
-    const buildInfoData = getGoBuildInfo(path);
-    const dlist = await parseGoVersionData(buildInfoData);
-    if (dlist && dlist.length) {
-      pkgList = pkgList.concat(dlist);
-    }
-    // Since this pkg list is derived from the binary mark them as used.
-    const allImports = {};
-    for (const mpkg of pkgList) {
-      const pkgFullName = `${mpkg.group}/${mpkg.name}`;
-      allImports[pkgFullName] = true;
-    }
-    return buildBomNSData(options, pkgList, "golang", {
-      allImports,
-      dependencies,
-      parentComponent,
-      src: path,
-      filename: path
-    });
+  if (maybeBinary || options.lifecycle === "post-build") {
+    return createBinaryBom(path, options);
   }
 
   // Read in go.sum and merge all go.sum files.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cyclonedx/cdxgen",
-  "version": "10.3.0",
+  "version": "10.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cyclonedx/cdxgen",
-      "version": "10.3.0",
+      "version": "10.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/parser": "^7.24.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cyclonedx/cdxgen",
-  "version": "10.3.0",
+  "version": "10.3.1",
   "description": "Creates CycloneDX Software Bill of Materials (SBOM) from source or container image",
   "homepage": "http://github.com/cyclonedx/cdxgen",
   "author": "Prabhu Subramanian <prabhu@appthreat.com>",


### PR DESCRIPTION
- [ ] Include dotnet-sdk-8.0 in container images
- [ ] Use blint for go binary sbom removing the reliance on `go version` command.
- [ ] Regression: Binary plugins were not detected for global installs