### PR TITLE
adding dir that starts with __ to ignore

### DIFF
--- a/analyzer.js
+++ b/analyzer.js
@@ -27,6 +27,7 @@ const IGNORE_DIRS = process.env.ASTGEN_IGNORE_DIRS
       "flow-typed",
       "i18n",
       "__tests__",
+      "__mocks__",
     ];
 
 const IGNORE_FILE_PATTERN = new RegExp(
@@ -53,7 +54,7 @@ const getAllFiles = (deep, dir, extn, files, result, regex) => {
       // Ignore directories
       const dirName = basename(file);
       if (
-        dirName.startsWith(".") ||
+        dirName.startsWith(".") || dirName.startsWith("__") ||
         IGNORE_DIRS.includes(dirName.toLowerCase())
       ) {
         continue;


### PR DESCRIPTION
I came across a Node component that was located in the __mocks__ folder, but was still specified as scope: "required". It turned out that there is no ignoring in cdxgen for a similar directory. This directory has been added