### PR TITLE
Add support for executing dependencies task in parallel for Gradle

### DIFF
--- a/index.js
+++ b/index.js
@@ -125,6 +125,7 @@ import {
   parseSwiftResolved,
   parseYarnLock,
   readZipEntry,
+  splitOutputByGradleProjects,
 } from "./utils.js";
 let url = import.meta.url;
 if (!url.startsWith("file://")) {
@@ -1534,31 +1535,36 @@ export async function createJavaBom(path, options) {
     !["scala", "sbt"].includes(options.projectType)
   ) {
     const gradleCmd = getGradleCommand(path, null);
-    const defaultDepTaskArgs = ["-q", "--console", "plain", "--build-cache"];
+    const defaultDepTaskArgs = ["--console", "plain", "--build-cache"];
     allProjects.push(parentComponent);
     let depTaskWithArgs = ["dependencies"];
     if (process.env.GRADLE_DEPENDENCY_TASK) {
       depTaskWithArgs = process.env.GRADLE_DEPENDENCY_TASK.split(" ");
     }
-    for (const sp of allProjects) {
-      let gradleDepArgs = [
-        sp.purl === parentComponent.purl
-          ? depTaskWithArgs[0]
-          : `:${sp.name}:${depTaskWithArgs[0]}`,
-      ];
-      gradleDepArgs = gradleDepArgs
-        .concat(depTaskWithArgs.slice(1))
-        .concat(defaultDepTaskArgs);
-      // Support custom GRADLE_ARGS such as --configuration runtimeClassPath (used for all tasks)
-      if (process.env.GRADLE_ARGS) {
-        const addArgs = process.env.GRADLE_ARGS.split(" ");
-        gradleDepArgs = gradleDepArgs.concat(addArgs);
+    let gradleDepArgs = [];
+    gradleDepArgs = gradleDepArgs
+      .concat(depTaskWithArgs.slice(1))
+      .concat(defaultDepTaskArgs);
+    // Support custom GRADLE_ARGS such as --configuration runtimeClassPath (used for all tasks)
+    if (process.env.GRADLE_ARGS) {
+      const addArgs = process.env.GRADLE_ARGS.split(" ");
+      gradleDepArgs = gradleDepArgs.concat(addArgs);
+    }
+    // gradle args only for the dependencies task
+    if (process.env.GRADLE_ARGS_DEPENDENCIES) {
+      const addArgs = process.env.GRADLE_ARGS_DEPENDENCIES.split(" ");
+      gradleDepArgs = gradleDepArgs.concat(addArgs);
+    }
+
+    if (process.env.GRADLE_MULTI_THREADED) {
+      gradleDepArgs.push(depTaskWithArgs[0]);
+      for (const sp of allProjects) {
+        //create single command for dependencies tasks on all subprojects
+        if (sp.purl !== parentComponent.purl) {
+          gradleDepArgs.push(`:${sp.name}:${depTaskWithArgs[0]}`);
+        }
       }
-      // gradle args only for the dependencies task
-      if (process.env.GRADLE_ARGS_DEPENDENCIES) {
-        const addArgs = process.env.GRADLE_ARGS_DEPENDENCIES.split(" ");
-        gradleDepArgs = gradleDepArgs.concat(addArgs);
-      }
+      gradleDepArgs.push("--parallel"); //flag to enable multi-threading
       console.log("Executing", gradleCmd, gradleDepArgs.join(" "), "in", path);
       const sresult = spawnSync(gradleCmd, gradleDepArgs, {
         cwd: path,
@@ -1566,6 +1572,7 @@ export async function createJavaBom(path, options) {
         timeout: TIMEOUT_MS,
         maxBuffer: MAX_BUFFER,
       });
+
       if (sresult.status !== 0 || sresult.error) {
         if (options.failOnError || DEBUG_MODE) {
           console.error(sresult.stdout, sresult.stderr);
@@ -1575,35 +1582,105 @@ export async function createJavaBom(path, options) {
       const sstdout = sresult.stdout;
       if (sstdout) {
         const cmdOutput = Buffer.from(sstdout).toString();
-        const parsedList = parseGradleDep(
+        const perProjectOutput = splitOutputByGradleProjects(
           cmdOutput,
-          sp.group || parentComponent.group,
-          sp.name,
-          sp.version?.length && sp.version !== "latest"
-            ? sp.version
-            : parentComponent.version,
+          allProjects,
         );
-        const dlist = parsedList.pkgList;
-        if (parsedList.dependenciesList && parsedList.dependenciesList) {
-          dependencies = mergeDependencies(
-            dependencies,
-            parsedList.dependenciesList,
-            parentComponent,
+        for (const [key, singleProjectDepOut] of perProjectOutput.entries()) {
+          const sp = allProjects
+            .filter((project) => project.name === key)
+            .pop();
+          const parsedList = parseGradleDep(
+            singleProjectDepOut,
+            sp.group || parentComponent.group,
+            sp.name,
+            sp.version?.length && sp.version !== "latest"
+              ? sp.version
+              : parentComponent.version,
           );
-        }
-        if (dlist?.length) {
-          if (DEBUG_MODE) {
-            console.log(
-              "Found",
-              dlist.length,
-              "packages in gradle project",
-              sp.name,
+          const dlist = parsedList.pkgList;
+          if (parsedList.dependenciesList && parsedList.dependenciesList) {
+            dependencies = mergeDependencies(
+              dependencies,
+              parsedList.dependenciesList,
+              parentComponent,
             );
           }
-          pkgList = pkgList.concat(dlist);
+          if (dlist?.length) {
+            if (DEBUG_MODE) {
+              console.log(
+                "Found",
+                dlist.length,
+                "packages in gradle project",
+                sp.name,
+              );
+            }
+            pkgList = pkgList.concat(dlist);
+          }
         }
       }
-    } // for
+    } else {
+      for (const sp of allProjects) {
+        let gradleSubProjectDepArgs = [
+          sp.purl === parentComponent.purl
+            ? depTaskWithArgs[0]
+            : `:${sp.name}:${depTaskWithArgs[0]}`,
+        ];
+        gradleSubProjectDepArgs = gradleSubProjectDepArgs.concat(gradleDepArgs);
+
+        gradleSubProjectDepArgs.push("-q");
+        console.log(
+          "Executing",
+          gradleCmd,
+          gradleSubProjectDepArgs.join(" "),
+          "in",
+          path,
+        );
+        const sresult = spawnSync(gradleCmd, gradleSubProjectDepArgs, {
+          cwd: path,
+          encoding: "utf-8",
+          timeout: TIMEOUT_MS,
+          maxBuffer: MAX_BUFFER,
+        });
+        if (sresult.status !== 0 || sresult.error) {
+          if (options.failOnError || DEBUG_MODE) {
+            console.error(sresult.stdout, sresult.stderr);
+          }
+          options.failOnError && process.exit(1);
+        }
+        const sstdout = sresult.stdout;
+        if (sstdout) {
+          const cmdOutput = Buffer.from(sstdout).toString();
+          const parsedList = parseGradleDep(
+            cmdOutput,
+            sp.group || parentComponent.group,
+            sp.name,
+            sp.version?.length && sp.version !== "latest"
+              ? sp.version
+              : parentComponent.version,
+          );
+          const dlist = parsedList.pkgList;
+          if (parsedList.dependenciesList && parsedList.dependenciesList) {
+            dependencies = mergeDependencies(
+              dependencies,
+              parsedList.dependenciesList,
+              parentComponent,
+            );
+          }
+          if (dlist?.length) {
+            if (DEBUG_MODE) {
+              console.log(
+                "Found",
+                dlist.length,
+                "packages in gradle project",
+                sp.name,
+              );
+            }
+            pkgList = pkgList.concat(dlist);
+          }
+        }
+      } // for
+    }
     if (pkgList.length) {
       if (parentComponent.components?.length) {
         for (const subProj of parentComponent.components) {

--- a/index.js
+++ b/index.js
@@ -49,8 +49,8 @@ import {
   determineSbtVersion,
   encodeForPurl,
   executeGradleProperties,
-  extractJarArchive,
   executeParallelGradleProperties,
+  extractJarArchive,
   frameworksList,
   getAllFiles,
   getCppModules,
@@ -1488,8 +1488,13 @@ export async function createJavaBom(path, options) {
     // Get the sub-project properties and set the root dependencies
     if (allProjectsStr?.length) {
       if (process.env.GRADLE_MULTI_THREADED) {
-        const parallelPropTaskOut = executeParallelGradleProperties(path, null, allProjectsStr);
-        const splitPropTaskOut = splitOutputByGradleProjects(parallelPropTaskOut)
+        const parallelPropTaskOut = executeParallelGradleProperties(
+          path,
+          null,
+          allProjectsStr,
+        );
+        const splitPropTaskOut =
+          splitOutputByGradleProjects(parallelPropTaskOut);
         for (const [key, propTaskOut] of splitPropTaskOut.entries()) {
           const retMap = parseGradleProperties(propTaskOut);
           const rootSubProject = retMap.rootProject;
@@ -1514,7 +1519,8 @@ export async function createJavaBom(path, options) {
               null,
             ).toString();
             rootSubProjectObj["purl"] = rootSubProjectPurl;
-            rootSubProjectObj["bom-ref"] = decodeURIComponent(rootSubProjectPurl);
+            rootSubProjectObj["bom-ref"] =
+              decodeURIComponent(rootSubProjectPurl);
             if (!allProjectsAddedPurls.includes(rootSubProjectPurl)) {
               allProjects.push(rootSubProjectObj);
               rootDependsOn.push(rootSubProjectPurl);
@@ -1547,7 +1553,8 @@ export async function createJavaBom(path, options) {
               null,
             ).toString();
             rootSubProjectObj["purl"] = rootSubProjectPurl;
-            rootSubProjectObj["bom-ref"] = decodeURIComponent(rootSubProjectPurl);
+            rootSubProjectObj["bom-ref"] =
+              decodeURIComponent(rootSubProjectPurl);
             if (!allProjectsAddedPurls.includes(rootSubProjectPurl)) {
               allProjects.push(rootSubProjectObj);
               rootDependsOn.push(rootSubProjectPurl);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cyclonedx/cdxgen",
-  "version": "10.4.3",
+  "version": "10.4.3-SNAPSHOT",
   "description": "Creates CycloneDX Software Bill of Materials (SBOM) from source or container image",
   "homepage": "http://github.com/cyclonedx/cdxgen",
   "author": "Prabhu Subramanian <prabhu@appthreat.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cyclonedx/cdxgen",
-  "version": "10.4.3-SNAPSHOT",
+  "version": "10.4.3",
   "description": "Creates CycloneDX Software Bill of Materials (SBOM) from source or container image",
   "homepage": "http://github.com/cyclonedx/cdxgen",
   "author": "Prabhu Subramanian <prabhu@appthreat.com>",

--- a/utils.js
+++ b/utils.js
@@ -2262,15 +2262,15 @@ export function parseGradleProperties(rawOutput) {
  * @param {string} dir Directory to execute the command
  * @param {string} rootPath Root directory
  * @param {array} allProjectsStr List of all sub-projects (including the preceding `:`)
- * 
- * @returns {string} The combined output for all subprojects of the Gradle properties task 
+ *
+ * @returns {string} The combined output for all subprojects of the Gradle properties task
  */
 export function executeParallelGradleProperties(dir, rootPath, allProjectsStr) {
   let parallelPropTaskArgs = [];
   for (const spstr of allProjectsStr) {
-    parallelPropTaskArgs.push(spstr + ":properties")
+    parallelPropTaskArgs.push(`${spstr}:properties`);
   }
-        
+
   let gradlePropertiesArgs = [
     "--console",
     "plain",


### PR DESCRIPTION
Solution to https://github.com/CycloneDX/cdxgen/issues/907.

Generating sboms for larger Gradle projects with many sub-projects was quite slow. One of the reasons for this is that `cdxgen` was running the `dependencies` task individually for each sub-project in series. This is extremely slow as there's the added overhead of starting and stopping Gradle and other associated bootstrapping overhead. 

One solution to this slowness is to utilise Gradle's multi-threading support and run the `dependencies` tasks in parallel. In this PR we: 
- We pass in the necessary flags to enable multi-threading in Gradle
- Split the resulting output to individual sub-project dependency task output
- Feed the resulting output into the existing sbom generation logic. 

This achieves a significant performance improvement in large multi-project Gradle builds (personal tests show sbom generation time going down from ~15mins -> 6mins on large projects).
 
 
 This PR also parallelises the `properties` task, speeding up the sbom generation further.  This improvement further brought down the time to generate the sbom in the test project from the above-mentioned 6mins -> *drumroll* 1min6s !
 
 Overall, this PR should improve SBOM generation times on large multi-module Gradle projects by at least 50%!