### PR TITLE
docs: add project types

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,60 +21,8 @@ Most SBOM tools are like simple barcode scanners. For easy applications, they ca
 
 ## Supported languages and package format
 
-| Language/Platform               | Package format                                                                                                      | Transitive dependencies                                                                           | Evidence |
-| ------------------------------- | ------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- | -------- |
-| Node.js                         | npm-shrinkwrap.json, package-lock.json, pnpm-lock.yaml, yarn.lock, rush.js, bower.json, .min.js                     | Yes except .min.js                                                                                | Yes      |
-| Java                            | maven (pom.xml [1]), gradle (build.gradle, .kts), scala (sbt), bazel                                                | Yes unless pom.xml is manually parsed due to unavailability of maven or errors                    | Yes      |
-| Android                         | apk, aab                                                                                                            |                                                                                                   |
-| PHP                             | composer.lock                                                                                                       | Yes                                                                                               | Yes      |
-| Python                          | pyproject.toml, setup.py, requirements.txt [2], Pipfile.lock, poetry.lock, pdm.lock, bdist_wheel, .whl, .egg-info   | Yes using the automatic pip install/freeze. When disabled, only with Pipfile.lock and poetry.lock | Yes      |
-| Go                              | binary, go.mod, go.sum, Gopkg.lock                                                                                  | Yes except binary                                                                                 | Yes      |
-| Ruby                            | Gemfile.lock, gemspec                                                                                               | Only for Gemfile.lock                                                                             |          |
-| Rust                            | binary, Cargo.toml, Cargo.lock                                                                                      | Only for Cargo.lock                                                                               |          |
-| .Net                            | .csproj, .vbproj, .fsproj, packages.config, project.assets.json [3], packages.lock.json, .nupkg, paket.lock, binary | Only for project.assets.json, packages.lock.json, paket.lock                                      |          |
-| Dart                            | pubspec.lock, pubspec.yaml                                                                                          | Only for pubspec.lock                                                                             |          |
-| Haskell                         | cabal.project.freeze                                                                                                | Yes                                                                                               |          |
-| Elixir                          | mix.lock                                                                                                            | Yes                                                                                               |          |
-| C/C++/Objective C/C++11         | conan.lock, conanfile.txt, \*.cmake, CMakeLists.txt, meson.build, codebase without package managers!                | Yes only for conan.lock. Best effort basis for cmake without version numbers.                     | Yes      |
-| Clojure                         | Clojure CLI (deps.edn), Leiningen (project.clj)                                                                     | Yes unless the files are parsed manually due to lack of clojure cli or leiningen command          |          |
-| Swift                           | Package.resolved, Package.swift (swiftpm)                                                                           | Yes                                                                                               |          |
-| Docker / oci image              | All supported languages. Linux OS packages with plugins [4]                                                         | Best effort based on lock files                                                                   | Yes      |
-| GitHub Actions                  | .github/workflows/\*.yml                                                                                            | N/A                                                                                               | Yes      |
-| Linux                           | All supported languages. Linux OS packages with plugins [5]                                                         | Best effort based on lock files                                                                   | Yes      |
-| Windows                         | All supported languages. OS packages with best effort [5]                                                           | Best effort based on lock files                                                                   | Yes      |
-| Jenkins Plugins                 | .hpi files                                                                                                          |                                                                                                   | Yes      |
-| Helm Charts                     | .yaml                                                                                                               | N/A                                                                                               |          |
-| Skaffold                        | .yaml                                                                                                               | N/A                                                                                               |          |
-| kustomization                   | .yaml                                                                                                               | N/A                                                                                               |          |
-| Tekton tasks                    | .yaml                                                                                                               | N/A                                                                                               |          |
-| Kubernetes                      | .yaml                                                                                                               | N/A                                                                                               |          |
-| Maven Cache                     | $HOME/.m2/repository/\*\*/\*.jar                                                                                    | N/A                                                                                               |          |
-| SBT Cache                       | $HOME/.ivy2/cache/\*\*/\*.jar                                                                                       | N/A                                                                                               |          |
-| Gradle Cache                    | $HOME/caches/modules-2/files-2.1/\*\*/\*.jar                                                                        | N/A                                                                                               |          |
-| Helm Index                      | $HOME/.cache/helm/repository/\*\*/\*.yaml                                                                           | N/A                                                                                               |          |
-| Docker compose                  | docker-compose\*.yml. Images would also be scanned.                                                                 | N/A                                                                                               |          |
-| Dockerfile                      | `*Dockerfile*` Images would also be scanned.                                                                        | N/A                                                                                               |          |
-| Containerfile                   | `*Containerfile*`. Images would also be scanned.                                                                    | N/A                                                                                               |          |
-| Bitbucket Pipelines             | `bitbucket-pipelines.yml` images and pipes would also be scanned.                                                   | N/A                                                                                               |          |
-| Google CloudBuild configuration | cloudbuild.yaml                                                                                                     | N/A                                                                                               |          |
-| OpenAPI                         | openapi\*.json, openapi\*.yaml                                                                                      | N/A                                                                                               |          |
+See our [Supported Project Types](https://cyclonedx.github.io/cdxgen/#/PROJECT_TYPES) documentation
 
-NOTE:
-
-- Apache maven 3.x is required for parsing pom.xml
-- gradle or gradlew is required to parse gradle projects
-- sbt is required for parsing scala sbt projects. Only scala 2.10 + sbt 0.13.6+ and 2.12 + sbt 1.0+ are currently supported.
-  - Alternatively, create a lock file using sbt-dependency-lock [plugin](https://github.com/stringbean/sbt-dependency-lock)
-
-Footnotes:
-
-- [1] - For multi-module applications, the BOM file could include components not included in the packaged war or ear file.
-- [2] - Pip freeze is automatically performed to improve precision. Requires virtual environment.
-- [3] - Perform dotnet or nuget restore to generate project.assets.json. Without this file, cdxgen would not include indirect dependencies.
-- [4] - See the section on plugins
-- [5] - Powered by osquery. See the section on plugins
-
-<img src="./docs/cdxgen-tree.jpg" alt="cdxgen tree" width="256">
 
 ### Automatic usage detection
 

--- a/docs/PROJECT_TYPES.md
+++ b/docs/PROJECT_TYPES.md
@@ -8,34 +8,53 @@ The following **Project Types** are supported:
 
 _Note: there are multiple project types / aliases that will produce the same output_ 
 
-## Supported Types
+## Supported languages and package formats
 
-| BOM Generated | Project Types |
-| - | - |
-| Java | `java`, `groovy`, `kotlin`, `scala`, `jvm`, `gradle`, `mvn`, `maven`, `sbt`|
-| Android | `android`, `apk`, `aab`|
-| JAR | `jar` |
-| JAR (Gradle Cache) | `gradle-index`, `gradle-cache` |
-| JAR (SBT Cache) | `sbt-index`, `sbt-cache` |
-| JAR (Maven Cache) | `maven-index`, `maven-cache`, `maven-repo` |
-| Node.js | `npm`, `pnpm`, `nodejs`, `js`, `javascript`, `typescript`, `ts`, `tsx` |
-| Python | `python`, `py`, `pypi` |
-| Golang | `go`, `golang` |
-| Rust | `rust`, `rust-lang`, `cargo` |
-| PHP | `ruby`, `gems` |
-| .NET (#C) | `csharp`, `netcore`, `dotnet`, `vb` |
-| Dart | `dart`, `flutter`, `pub` |
-| Haskell | `haskell`, `hackage`, `cabal` |
-| Elixir | `elixir`, `hex`, `mix` | 
-| C++ | `c`, `cpp`, `c++`, `conan` |
-| Clojure | `clojure`, `edn`, `clj`, `leiningen` |
-| GitHub | `github`, `actions` |
+| Language/Platform | Project Types | Package Formats | Supported Evidence | Supports Transitives |
+| - | - | - | - | - |
+| Node.js | `npm`, `pnpm`, `nodejs`, `js`, `javascript`, `typescript`, `ts`, `tsx` | `npm-shrinkwrap.json`, `package-lock.json`, `pnpm-lock.yaml`, `yarn.lock`, `rush.js`, `bower.json`, `.min.js` | Yes, except for `.min.` | ✅
+| Java | `java`, `groovy`, `kotlin`, `scala`, `jvm`, `gradle`, `mvn`, `maven`, `sbt`| `pom.xml` [1], `build.gradle`, `.kts`, `sbt`, `bazel` | Yes, unless `pom.xml` is manually parsed due to unavailability of maven or errors) | ✅|
+| Android | `android`, `apk`, `aab`| `apk`, `aab` | - | - |
+| JAR | `jar` | `.jar` | - | - |
+| JAR (Gradle Cache) | `gradle-index`, `gradle-cache` | `$HOME/caches/modules-2/files-2.1/\*\*/\*.jar` | - | - |
+| JAR (SBT Cache) | `sbt-index`, `sbt-cache` | `$HOME/.ivy2/cache/\*\*/\*.jar ` | - | - |
+| JAR (Maven Cache) | `maven-index`, `maven-cache`, `maven-repo` | `$HOME/.m2/repository/\*\*/\*.jar` | - | - |
+| Python | `python`, `py`, `pypi` | `pyproject.toml`, `setup.py`, `requirements.txt` [2], `Pipfile.lock`, `poetry.lock`, `pdm.lock`, `bdist_wheel`, `.whl`, `.egg-info` | Yes using the automatic pip install/freeze. When disabled, only with `Pipfile.lock` and `poetry.lock` |   ✅   | 
+| Golang | `go`, `golang` | `binary`, `go.mod`, `go.sum`, `Gopkg.lock` | Yes except binary                                                                                 | ✅       |
+| Rust | `rust`, `rust-lang`, `cargo` | `binary`, `Cargo.toml`, `Cargo.lock`                                                                                      | Only for `Cargo.lock`                                                                              |    -     |
+| Ruby | `ruby`, `gems` | `Gemfile.lock`, `gemspec`                                                                                               | Only for `Gemfile.lock`                                                                             |     -     |
+| .NET (#C) | `csharp`, `netcore`, `dotnet`, `vb` | `.csproj`, `.vbproj`, `.fsproj`, `packages.config`, `project.assets.json` [3], `packages.lock.json`, `.nupkg`, `paket.lock`, `binary` | Only for `project.assets.json`, `packages.lock.json`, `paket.lock`                                      |    -      |
+| Dart | `dart`, `flutter`, `pub` | `pubspec.lock`, `pubspec.yaml`                                                                                          | Only for `pubspec.lock`                                                                             |  -        |
+| Haskell | `haskell`, `hackage`, `cabal` | `cabal.project.freeze`                                                                                                | Yes                                                                                               |          |
+| Elixir | `elixir`, `hex`, `mix` | `mix.lock`                                                                                                            | Yes                                                                                               |  -         |
+| C++ | `c`, `cpp`, `c++`, `conan` | `conan.lock`, `conanfile.txt`, `\*.cmake`, `CMakeLists.txt`, `meson.build`, codebase without package managers!                | Yes only for `conan.lock`. Best effort basis for `cmake` without version numbers.                     | ✅       |
+| Clojure | `clojure`, `edn`, `clj`, `leiningen` | `deps.edn`, `projects.clj` | Yes unless the files are parsed manually due to lack of clojure cli or leiningen command          |      -    |
+| GitHub Actions | `github`, `actions` | `.github/workflows/\*.yml`                                                                                            | n/a                                                                                               | ✅       |
 | Operation System (OS) | `os`, `osquery`, `windows`, `linux`, `mac`, `macos`, `darwin` |
-| Jenkins | `jenkins` |
-| Helm | `helm`, `charts` |
-| Helm (Cache) | `helm-index`, `helm-repo` |
-| Container | `universal`, `containerfile`, `docker-compose`, `dockerfile`, `swarm`, `tekton`, `kustomize`, `operator`, `skaffold`, `kubernetes`, `openshift`, `yaml-manifest` |
-| Cloud Build (GCP) | `cloudbuild` |
-| Swift (iOS) | `swift` |
+| Jenkins Plugins | `jenkins` | `.hpi files`                                                                                                          |       -                                                                                            | ✅         |
+| Helm | `helm`, `charts` | `.yaml`                                                                                                               | n/a                                                                                               |          |
+| Helm (Cache) | `helm-index`, `helm-repo` | `$HOME/.cache/helm/repository/\*\*/\*.yaml` | - | - |
+| Container | `universal`, `containerfile`, `docker-compose`, `dockerfile`, `swarm`, `tekton`, `kustomize`, `operator`, `skaffold`, `kubernetes`, `openshift`, `yaml-manifest` | `.yaml`, `docker-compose\*.yml`, `*Dockerfile*`, `*Containerfile*`, `bitbucket-pipelines.yml`                                                                                                               | n/a                                                                                           |    -      |
+| Google Cloud Build | `cloudbuild` | `cloudbuild.yaml` | n/a | - |
+| Swift (iOS) | `swift` | `Package.resolved`, `Package.swift` (swiftpm)                                                                           | Yes                                                                                               |     -     |
 | Binary | `binary`, `blint` |
+| Open API | Open API Specification, Swagger | `openapi\*.json`, `openapi\*.yaml`| n/a | - |
 
+
+
+*_NOTE:_*
+
+> - Apache maven 3.x is required for parsing pom.xml
+> - gradle or gradlew is required to parse gradle projects
+> - sbt is required for parsing scala sbt projects. Only scala 2.10 + sbt 0.13.6+ and 2.12 + sbt 1.0+ are currently supported.
+>    - Alternatively, create a lock file using sbt-dependency-lock [plugin](https://github.com/stringbean/sbt-dependency-lock)
+
+*_Footnotes:_*
+
+- [1] - For multi-module applications, the BOM file could include components not included in the packaged war or ear file.
+- [2] - Pip freeze is automatically performed to improve precision. Requires virtual environment.
+- [3] - Perform dotnet or nuget restore to generate project.assets.json. Without this file, cdxgen would not include indirect dependencies.
+- [4] - See the section on plugins
+- [5] - Powered by osquery. See the section on plugins
+
+<img src="./cdxgen-tree.jpg" alt="cdxgen tree" width="256">

--- a/docs/PROJECT_TYPES.md
+++ b/docs/PROJECT_TYPES.md
@@ -1,0 +1,41 @@
+# Project Types
+
+## Overview
+
+The following **Project Types** are supported:
+- When in `CLI` mode, passed as `t` or `--type` flag
+- When in `Server` mode, passed as `projectType` parameter.
+
+_Note: there are multiple project types / aliases that will produce the same output_ 
+
+## Supported Types
+
+| BOM Generated | Project Types |
+| - | - |
+| Java | `java`, `groovy`, `kotlin`, `scala`, `jvm`, `gradle`, `mvn`, `maven`, `sbt`|
+| Android | `android`, `apk`, `aab`|
+| JAR | `jar` |
+| JAR (Gradle Cache) | `gradle-index`, `gradle-cache` |
+| JAR (SBT Cache) | `sbt-index`, `sbt-cache` |
+| JAR (Maven Cache) | `maven-index`, `maven-cache`, `maven-repo` |
+| Node.js | `npm`, `pnpm`, `nodejs`, `js`, `javascript`, `typescript`, `ts`, `tsx` |
+| Python | `python`, `py`, `pypi` |
+| Golang | `go`, `golang` |
+| Rust | `rust`, `rust-lang`, `cargo` |
+| PHP | `ruby`, `gems` |
+| .NET (#C) | `csharp`, `netcore`, `dotnet`, `vb` |
+| Dart | `dart`, `flutter`, `pub` |
+| Haskell | `haskell`, `hackage`, `cabal` |
+| Elixir | `elixir`, `hex`, `mix` | 
+| C++ | `c`, `cpp`, `c++`, `conan` |
+| Clojure | `clojure`, `edn`, `clj`, `leiningen` |
+| GitHub | `github`, `actions` |
+| Operation System (OS) | `os`, `osquery`, `windows`, `linux`, `mac`, `macos`, `darwin` |
+| Jenkins | `jenkins` |
+| Helm | `helm`, `charts` |
+| Helm (Cache) | `helm-index`, `helm-repo` |
+| Container | `universal`, `containerfile`, `docker-compose`, `dockerfile`, `swarm`, `tekton`, `kustomize`, `operator`, `skaffold`, `kubernetes`, `openshift`, `yaml-manifest` |
+| Cloud Build (GCP) | `cloudbuild` |
+| Swift (iOS) | `swift` |
+| Binary | `binary`, `blint` |
+

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -1,6 +1,7 @@
 - [Home](/)
 - [CLI Usage](CLI.md)
 - [Server Usage](SERVER.md)
+- [Supported Project Types](PROJECT_TYPES.md)
 - [Configuration](ENV.md)
 - [Advanced Usage](ADVANCED.md)
 - [Tutorials - Java](LESSON1.md)


### PR DESCRIPTION
Add a new page to the website which documents supported `project types`.  

Migrate content from `README.md` into docs/ to reduce duplication.