### PR TITLE
feat: increase yargs terminal width

### DIFF
--- a/bin/cdxgen.js
+++ b/bin/cdxgen.js
@@ -281,7 +281,7 @@ const args = yargs(hideBin(process.argv))
   .alias("v", "version")
   .help("h")
   .alias("h", "help")
-  .wrap(yargs().terminalWidth()).argv;
+  .wrap(Math.min(120, yargs().terminalWidth())).argv;
 
 if (args.version) {
   const packageJsonAsString = fs.readFileSync(

--- a/bin/evinse.js
+++ b/bin/evinse.js
@@ -137,7 +137,7 @@ const args = yargs(hideBin(process.argv))
   .scriptName("evinse")
   .version()
   .help("h")
-  .wrap(yargs().terminalWidth()).argv;
+  .wrap(Math.min(120, yargs().terminalWidth())).argv;
 
 const evinseArt = `
 ███████╗██╗   ██╗██╗███╗   ██╗███████╗███████╗

--- a/bin/verify.js
+++ b/bin/verify.js
@@ -29,7 +29,7 @@ const args = yargs(hideBin(process.argv))
   .scriptName("cdx-verify")
   .version()
   .help("h")
-  .wrap(yargs().terminalWidth()).argv;
+  .wrap(Math.min(120, yargs().terminalWidth())).argv;
 
 if (args.version) {
   const packageJsonAsString = fs.readFileSync(

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -69,45 +69,59 @@ Commands:
   cdxgen completion  Generate bash/zsh completion
 
 Options:
-  -o, --output                 Output file. Default bom.json                                                                                                                   [default: "bom.json"]
-  -t, --type                   Project type. Please refer to https://cyclonedx.github.io/cdxgen/#/PROJECT_TYPES for supported languages/platforms.
-  -r, --recurse                Recurse mode suitable for mono-repos. Defaults to true. Pass --no-recurse to disable.                                                       [boolean] [default: true]
-  -p, --print                  Print the SBOM as a table with tree.                                                                                                                        [boolean]
-  -c, --resolve-class          Resolve class names for packages. jars only for now.                                                                                                        [boolean]
-      --deep                   Perform deep searches for components. Useful while scanning C/C++ apps, live OS and oci images.                                                             [boolean]
+  -o, --output                 Output file. Default bom.json                                       [default: "bom.json"]
+  -t, --type                   Project type. Please refer to https://cyclonedx.github.io/cdxgen/#/PROJECT_TYPES for supp
+                               orted languages/platforms.
+  -r, --recurse                Recurse mode suitable for mono-repos. Defaults to true. Pass --no-recurse to disable.
+                                                                                               [boolean] [default: true]
+  -p, --print                  Print the SBOM as a table with tree.                                            [boolean]
+  -c, --resolve-class          Resolve class names for packages. jars only for now.                            [boolean]
+      --deep                   Perform deep searches for components. Useful while scanning C/C++ apps, live OS and oci i
+                               mages.                                                                          [boolean]
       --server-url             Dependency track url. Eg: https://deptrack.cyclonedx.io
       --api-key                Dependency track api key
       --project-group          Dependency track project group
       --project-name           Dependency track project name. Default use the directory name
-      --project-version        Dependency track project version                                                                                                               [string] [default: ""]
-      --project-id             Dependency track project id. Either provide the id or the project name and version together                                                                  [string]
-      --parent-project-id      Dependency track parent project id                                                                                                                           [string]
-      --required-only          Include only the packages with required scope on the SBOM. Would set compositions.aggregate to incomplete unless --no-auto-compositions is passed.          [boolean]
-      --fail-on-error          Fail if any dependency extractor fails.                                                                                                                     [boolean]
-      --no-babel               Do not use babel to perform usage analysis for JavaScript/TypeScript projects.                                                                              [boolean]
-      --generate-key-and-sign  Generate an RSA public/private key pair and then sign the generated SBOM using JSON Web Signatures.                                                         [boolean]
-      --server                 Run cdxgen as a server                                                                                                                                      [boolean]
-      --server-host            Listen address                                                                                                                                 [default: "127.0.0.1"]
-      --server-port            Listen port                                                                                                                                         [default: "9090"]
-      --install-deps           Install dependencies automatically for some projects. Defaults to true but disabled for containers and oci scans. Use --no-install-deps to disable this feature.
-                                                                                                                                                                                           [boolean]
-      --validate               Validate the generated SBOM using json schema. Defaults to true. Pass --no-validate to disable.                                             [boolean] [default: true]
-      --evidence               Generate SBOM with evidence for supported languages.                                                                                       [boolean] [default: false]
-      --spec-version           CycloneDX Specification version to use. Defaults to 1.5                                                                                       [number] [default: 1.5]
-      --filter                 Filter components containing this word in purl or component.properties.value. Multiple values allowed.                                                        [array]
-      --only                   Include components only containing this word in purl. Useful to generate BOM with first party components alone. Multiple values allowed.                      [array]
-      --author                 The person(s) who created the BOM. Set this value if you're intending the modify the BOM and claim authorship.                  [array] [default: "OWASP Foundation"]
+      --project-version        Dependency track project version                                   [string] [default: ""]
+      --project-id             Dependency track project id. Either provide the id or the project name and version togeth
+                               er                                                                               [string]
+      --parent-project-id      Dependency track parent project id                                               [string]
+      --required-only          Include only the packages with required scope on the SBOM. Would set compositions.aggrega
+                               te to incomplete unless --no-auto-compositions is passed.                       [boolean]
+      --fail-on-error          Fail if any dependency extractor fails.                                         [boolean]
+      --no-babel               Do not use babel to perform usage analysis for JavaScript/TypeScript projects.  [boolean]
+      --generate-key-and-sign  Generate an RSA public/private key pair and then sign the generated SBOM using JSON Web S
+                               ignatures.                                                                      [boolean]
+      --server                 Run cdxgen as a server                                                          [boolean]
+      --server-host            Listen address                                                     [default: "127.0.0.1"]
+      --server-port            Listen port                                                             [default: "9090"]
+      --install-deps           Install dependencies automatically for some projects. Defaults to true but disabled for c
+                               ontainers and oci scans. Use --no-install-deps to disable this feature.         [boolean]
+      --validate               Validate the generated SBOM using json schema. Defaults to true. Pass --no-validate to di
+                               sable.                                                          [boolean] [default: true]
+      --evidence               Generate SBOM with evidence for supported languages.           [boolean] [default: false]
+      --spec-version           CycloneDX Specification version to use. Defaults to 1.5           [number] [default: 1.5]
+      --filter                 Filter components containing this word in purl or component.properties.value. Multiple va
+                               lues allowed.                                                                     [array]
+      --only                   Include components only containing this word in purl. Useful to generate BOM with first p
+                               arty components alone. Multiple values allowed.                                   [array]
+      --author                 The person(s) who created the BOM. Set this value if you're intending the modify the BOM
+                               and claim authorship.                               [array] [default: "OWASP Foundation"]
       --profile                BOM profile to use for generation. Default generic.
-                                                                             [choices: "appsec", "research", "operational", "threat-modeling", "license-compliance", "generic"] [default: "generic"]
-      --exclude                Additional glob pattern(s) to ignore                                                                                                                          [array]
-      --include-formulation    Generate formulation section using git metadata.                                                                                           [boolean] [default: false]
-      --include-crypto         Include crypto libraries found under formulation.                                                                                          [boolean] [default: false]
-      --standard               The list of standards which may consist of regulations, industry or organizational-specific standards, maturity models, best practices, or any other requirements whi
-                               ch can be evaluated against or attested to.
-                                                           [array] [choices: "asvs-4.0.3", "bsimm-v13", "masvs-2.0.0", "nist_ssdf-1.1", "pcissc-secure-slc-1.1", "scvs-1.0.0", "ssaf-DRAFT-2023-11"]
-      --auto-compositions      Automatically set compositions when the BOM was filtered. Defaults to true                                                                  [boolean] [default: true]
-  -h, --help                   Show help                                                                                                                                                   [boolean]
-  -v, --version                Show version number                                                                                                                                         [boolean]
+  [choices: "appsec", "research", "operational", "threat-modeling", "license-compliance", "generic"] [default: "generic"
+                                                                                                                       ]
+      --exclude                Additional glob pattern(s) to ignore                                              [array]
+      --include-formulation    Generate formulation section using git metadata.               [boolean] [default: false]
+      --include-crypto         Include crypto libraries found under formulation.              [boolean] [default: false]
+      --standard               The list of standards which may consist of regulations, industry or organizational-specif
+                               ic standards, maturity models, best practices, or any other requirements which can be eva
+                               luated against or attested to.
+  [array] [choices: "asvs-4.0.3", "bsimm-v13", "masvs-2.0.0", "nist_ssdf-1.1", "pcissc-secure-slc-1.1", "scvs-1.0.0", "s
+                                                                                                     saf-DRAFT-2023-11"]
+      --auto-compositions      Automatically set compositions when the BOM was filtered. Defaults to true
+                                                                                               [boolean] [default: true]
+  -h, --help                   Show help                                                                       [boolean]
+  -v, --version                Show version number                                                             [boolean]
 
 Examples:
   cdxgen -t java .  Generate a Java SBOM for the current directory


### PR DESCRIPTION
full terminal width rendered docs awkwardly.

pairing back to 120 chars (default is 80)