### PR TITLE
Fix: Handle TAR_ENTRY_INVALID error

### DIFF
--- a/.github/workflows/dockertests.yml
+++ b/.github/workflows/dockertests.yml
@@ -64,6 +64,7 @@ jobs:
           bin/cdxgen.js /tmp/scanslim.tar -o bomresults/bom-scanarch.json --validate
           bin/cdxgen.js -t docker-compose test/data -o bomresults/bom-dc.json --validate
           bin/cdxgen.js -t operator repotests/grafana-operator -o bomresults/bom-op.json --validate
+          bin/cdxgen.js elasticsearch@sha256:3686a5757ed46c9dbcf00f6f71fce48ffc5413b193a80d1c46a21e7aad4c53ad -t docker  -o bomresults/bom-elastic.json --validate
           ls -ltr bomresults
 
   os-tests:

--- a/.github/workflows/dockertests.yml
+++ b/.github/workflows/dockertests.yml
@@ -65,6 +65,10 @@ jobs:
           bin/cdxgen.js -t docker-compose test/data -o bomresults/bom-dc.json --validate
           bin/cdxgen.js -t operator repotests/grafana-operator -o bomresults/bom-op.json --validate
           bin/cdxgen.js elasticsearch@sha256:3686a5757ed46c9dbcf00f6f71fce48ffc5413b193a80d1c46a21e7aad4c53ad -t docker  -o bomresults/bom-elastic.json --validate
+          echo "Test docker container image using a `.tar` file"
+          docker pull elasticsearch@sha256:3686a5757ed46c9dbcf00f6f71fce48ffc5413b193a80d1c46a21e7aad4c53ad
+          docker save -o /tmp/elastic.tar elasticsearch@sha256:3686a5757ed46c9dbcf00f6f71fce48ffc5413b193a80d1c46a21e7aad4c53ad
+          bin/cdxgen.js /tmp/elastic.tar -t docker -o bomresults/bom-elastic.tar.json --validate
           ls -ltr bomresults
 
   os-tests:

--- a/docker.js
+++ b/docker.js
@@ -740,7 +740,15 @@ export const extractTar = async (fullImageName, dir) => {
       );
       console.log(err);
     } else if (
-      !["TAR_BAD_ARCHIVE", "TAR_ENTRY_INFO", "TAR_ENTRY_INVALID", "TAR_ENTRY_ERROR", "TAR_ENTRY_UNSUPPORTED", "TAR_ABORT", "EACCES"].includes(err.code)
+      ![
+        "TAR_BAD_ARCHIVE",
+        "TAR_ENTRY_INFO",
+        "TAR_ENTRY_INVALID",
+        "TAR_ENTRY_ERROR",
+        "TAR_ENTRY_UNSUPPORTED",
+        "TAR_ABORT",
+        "EACCES",
+      ].includes(err.code)
     ) {
       console.log(
         `Error while extracting image ${fullImageName} to ${dir}. Please file this bug to the cdxgen repo. https://github.com/CycloneDX/cdxgen/issues`,
@@ -754,7 +762,7 @@ export const extractTar = async (fullImageName, dir) => {
       }
     } else if (["EACCES"].includes(err.code)) {
       console.log(err);
-    } else if (!["TAR_ENTRY_INFO", "TAR_ENTRY_INVALID"].includes(err.code)){
+    } else if (!["TAR_ENTRY_INFO", "TAR_ENTRY_INVALID"].includes(err.code)) {
       console.log(err);
     }
     return false;

--- a/docker.js
+++ b/docker.js
@@ -762,11 +762,11 @@ export const extractTar = async (fullImageName, dir) => {
       }
     } else if (["EACCES"].includes(err.code)) {
       console.log(err);
-    /*
-    * We do not display errors messages for errors:
-    * 1) TAR_ENTRY_INFO is an informative error indicating that an entry is being modified.
-    * 2) TAR_ENTRY_INVALID indicates that a given entry is not valid tar archive entry and will be skipped.
-    */
+      /*
+       * We do not display errors messages for errors:
+       * 1) TAR_ENTRY_INFO is an informative error indicating that an entry is being modified.
+       * 2) TAR_ENTRY_INVALID indicates that a given entry is not valid tar archive entry and will be skipped.
+       */
     } else if (!["TAR_ENTRY_INFO", "TAR_ENTRY_INVALID"].includes(err.code)) {
       console.log(err);
     }

--- a/docker.js
+++ b/docker.js
@@ -17,7 +17,7 @@ import {
   homedir,
   tmpdir,
 } from "node:os";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import process from "node:process";
 import stream from "node:stream/promises";
 import { parse } from "node:url";
@@ -713,6 +713,7 @@ export const extractTar = async (fullImageName, dir) => {
             path.includes("usr/share/zoneinfo/") ||
             path.includes("usr/share/doc/") ||
             path.includes("usr/share/i18n/") ||
+            basename(path).startsWith(".") ||
             path.includes("usr/share/licenses/device-mapper-libs") ||
             [
               "BlockDevice",
@@ -739,7 +740,7 @@ export const extractTar = async (fullImageName, dir) => {
       );
       console.log(err);
     } else if (
-      !["TAR_BAD_ARCHIVE", "TAR_ENTRY_INFO", "EACCES"].includes(err.code)
+      !["TAR_BAD_ARCHIVE", "TAR_ENTRY_INFO", "TAR_ENTRY_INVALID", "EACCES"].includes(err.code)
     ) {
       console.log(
         `Error while extracting image ${fullImageName} to ${dir}. Please file this bug to the cdxgen repo. https://github.com/CycloneDX/cdxgen/issues`,
@@ -753,7 +754,7 @@ export const extractTar = async (fullImageName, dir) => {
       }
     } else if (["EACCES"].includes(err.code)) {
       console.log(err);
-    } else {
+    } else if (!["TAR_ENTRY_INFO", "TAR_ENTRY_INVALID"].includes(err.code)){
       console.log(err);
     }
     return false;

--- a/docker.js
+++ b/docker.js
@@ -762,6 +762,11 @@ export const extractTar = async (fullImageName, dir) => {
       }
     } else if (["EACCES"].includes(err.code)) {
       console.log(err);
+    /*
+    * We do not display errors messages for errors:
+    * 1) TAR_ENTRY_INFO is an informative error indicating that an entry is being modified.
+    * 2) TAR_ENTRY_INVALID indicates that a given entry is not valid tar archive entry and will be skipped.
+    */
     } else if (!["TAR_ENTRY_INFO", "TAR_ENTRY_INVALID"].includes(err.code)) {
       console.log(err);
     }

--- a/docker.js
+++ b/docker.js
@@ -740,7 +740,7 @@ export const extractTar = async (fullImageName, dir) => {
       );
       console.log(err);
     } else if (
-      !["TAR_BAD_ARCHIVE", "TAR_ENTRY_INFO", "TAR_ENTRY_INVALID", "EACCES"].includes(err.code)
+      !["TAR_BAD_ARCHIVE", "TAR_ENTRY_INFO", "TAR_ENTRY_INVALID", "TAR_ENTRY_ERROR", "TAR_ENTRY_UNSUPPORTED", "TAR_ABORT", "EACCES"].includes(err.code)
     ) {
       console.log(
         `Error while extracting image ${fullImageName} to ${dir}. Please file this bug to the cdxgen repo. https://github.com/CycloneDX/cdxgen/issues`,

--- a/docker.test.js
+++ b/docker.test.js
@@ -111,19 +111,6 @@ test("parseImageName tests", () => {
     group: "shiftleft",
     name: "scan-java",
   });
-  expect(
-    parseImageName(
-      "docker.io/elasticsearch@sha256:3686a5757ed46c9dbcf00f6f71fce48ffc5413b193a80d1c46a21e7aad4c53ad",
-    ),
-  ).toEqual({
-    registry: "docker.io",
-    repo: "elasticsearch",
-    tag: "",
-    digest: "3686a5757ed46c9dbcf00f6f71fce48ffc5413b193a80d1c46a21e7aad4c53ad",
-    platform: "",
-    group: "",
-    name: "elasticsearch",
-  });
 }, 120000);
 
 test("docker getImage", async () => {

--- a/docker.test.js
+++ b/docker.test.js
@@ -124,7 +124,6 @@ test("parseImageName tests", () => {
     group: "",
     name: "elasticsearch",
   });
-  
 }, 120000);
 
 test("docker getImage", async () => {

--- a/docker.test.js
+++ b/docker.test.js
@@ -111,6 +111,20 @@ test("parseImageName tests", () => {
     group: "shiftleft",
     name: "scan-java",
   });
+  expect(
+    parseImageName(
+      "docker.io/elasticsearch@sha256:3686a5757ed46c9dbcf00f6f71fce48ffc5413b193a80d1c46a21e7aad4c53ad",
+    ),
+  ).toEqual({
+    registry: "docker.io",
+    repo: "elasticsearch",
+    tag: "",
+    digest: "3686a5757ed46c9dbcf00f6f71fce48ffc5413b193a80d1c46a21e7aad4c53ad",
+    platform: "",
+    group: "",
+    name: "elasticsearch",
+  });
+  
 }, 120000);
 
 test("docker getImage", async () => {


### PR DESCRIPTION
So far I receive error `Error: TAR_ENTRY_INVALID: checksum failure` instead of the `Error: TAR_ENTRY_INVALID: linkpath forbidden`.
in #572 
However, the changes should take into account both of these.

Also Handles: `TAR_ENTRY_ERROR`, `TAR_ENTRY_UNSUPPORTED` and `TAR_ABORT`