### PR TITLE
Adding The Installation Of Root Dependencies For Npm

### DIFF
--- a/index.js
+++ b/index.js
@@ -2071,14 +2071,25 @@ export async function createNodejsBom(path, options) {
     pkgJsonFile?.length === 1 &&
     options.installDeps
   ) {
-    console.log("Executing 'npm install' in", path);
-    const result = spawnSync("npm", ["install"], {
+    let pkgMgr = "npm";
+    const supPkgMgrs = ["npm", "yarn", "yarnpkg", "pnpm", "pnpx"];
+    const pkgData = JSON.parse(readFileSync(`${path}/package.json`, "utf8"));
+    const mgrData = pkgData.packageManager;
+    let mgr = "";
+    if (mgrData) {
+      mgr = mgrData.split("@")[0];
+    }
+    if (supPkgMgrs.includes(mgr)) {
+      pkgMgr = mgr;
+    }
+    console.log(`Executing '${pkgMgr} install' in`, path);
+    const result = spawnSync(pkgMgr, ["install"], {
       cwd: path,
       encoding: "utf-8",
     });
     if (result.status !== 0 || result.error) {
       console.error(
-        "NPM install has failed. Check if npm is installed and available in PATH.",
+        `${pkgMgr} install has failed. Check if ${pkgMgr} is installed and available in PATH.`,
       );
       console.log(result.error, result.stderr);
       options.failOnError && process.exit(1);

--- a/index.js
+++ b/index.js
@@ -2064,9 +2064,13 @@ export async function createNodejsBom(path, options) {
   const parentSubComponents = [];
   let ppurl = "";
   // Install deps for npm
-  let pkgJsonLockFile = getAllFiles(path, "package-lock.json", options);
-  let pkgJsonFile = getAllFiles(path, "package.json", options);
-  if (pkgJsonLockFile?.length === 0 && pkgJsonFile?.length === 1 && options.installDeps) {
+  const pkgJsonLockFile = getAllFiles(path, "package-lock.json", options);
+  const pkgJsonFile = getAllFiles(path, "package.json", options);
+  if (
+    pkgJsonLockFile?.length === 0 &&
+    pkgJsonFile?.length === 1 &&
+    options.installDeps
+  ) {
     console.log("Executing 'npm install' in", path);
     const result = spawnSync("npm", ["install"], {
       cwd: path,
@@ -2074,7 +2078,7 @@ export async function createNodejsBom(path, options) {
     });
     if (result.status !== 0 || result.error) {
       console.error(
-          "NPM install has failed. Check if npm is installed and available in PATH.",
+        "NPM install has failed. Check if npm is installed and available in PATH.",
       );
       console.log(result.error, result.stderr);
       options.failOnError && process.exit(1);

--- a/index.js
+++ b/index.js
@@ -2063,6 +2063,23 @@ export async function createNodejsBom(path, options) {
   let parentComponent = {};
   const parentSubComponents = [];
   let ppurl = "";
+  // Install deps for npm
+  let pkgJsonLockFile = getAllFiles(path, "package-lock.json", options);
+  let pkgJsonFile = getAllFiles(path, "package.json", options);
+  if (pkgJsonLockFile?.length === 0 && pkgJsonFile?.length === 1 && options.installDeps) {
+    console.log("Executing 'npm install' in", path);
+    const result = spawnSync("npm", ["install"], {
+      cwd: path,
+      encoding: "utf-8",
+    });
+    if (result.status !== 0 || result.error) {
+      console.error(
+          "NPM install has failed. Check if npm is installed and available in PATH.",
+      );
+      console.log(result.error, result.stderr);
+      options.failOnError && process.exit(1);
+    }
+  }
   // Docker mode requires special handling
   if (["docker", "oci", "container", "os"].includes(options.projectType)) {
     const pkgJsonFiles = getAllFiles(path, "**/package.json", options);

--- a/index.js
+++ b/index.js
@@ -2155,9 +2155,9 @@ export async function createNodejsBom(path, options) {
   const yarnLockFile = getAllFiles(path, "yarn.lock", options);
   const pnpmLockFile = getAllFiles(path, "pnpm-lock.yaml", options);
   if (
-    (pkgJsonLockFile?.length === 0 ||
-      yarnLockFile?.length === 0 ||
-      pnpmLockFile?.length === 0) &&
+    pkgJsonLockFile?.length === 0 &&
+    yarnLockFile?.length === 0 &&
+    pnpmLockFile?.length === 0 &&
     pkgJsonFile?.length === 1 &&
     options.installDeps
   ) {

--- a/index.js
+++ b/index.js
@@ -2097,7 +2097,7 @@ export async function createNodejsBom(path, options) {
     allImports = retData.allImports;
     allExports = retData.allExports;
   }
-  const yarnLockFiles = getAllFiles(
+  let yarnLockFiles = getAllFiles(
     path,
     `${options.multiProject ? "**/" : ""}yarn.lock`,
     options,
@@ -2115,7 +2115,7 @@ export async function createNodejsBom(path, options) {
   if (shrinkwrapFiles.length) {
     pkgLockFiles = pkgLockFiles.concat(shrinkwrapFiles);
   }
-  const pnpmLockFiles = getAllFiles(
+  let pnpmLockFiles = getAllFiles(
     path,
     `${options.multiProject ? "**/" : ""}pnpm-lock.yaml`,
     options,


### PR DESCRIPTION
## Problems

We are faced with the fact that cdxgen does not generate SBOM for a project where the `package.json` file exists at the root, but the `package-lock.json` file is missing. In this case, the `installDeps` dependency installation flag does not initiate the installation of dependencies.

## Decision

We have implemented the installation of dependencies with npm for the case when:
1) There is a `package.json` file in the root of the project.
2) The `package-lock.json` file is missing in the root of the project.
3) `installDeps` flag is set to true.