### PR TITLE
Update snapshot tests to integrate new custom-json-diff functionality.

### DIFF
--- a/.github/workflows/snapshot-tests.yml
+++ b/.github/workflows/snapshot-tests.yml
@@ -30,11 +30,17 @@ jobs:
         with:
           python-version: 3.12
 
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.2.0
+
       -  name: Atom, cdxgen, sdkman, custom-json-diff installs
+         shell: bash
+         env:
+           SHELL: bash
          run: |
-           corepack enable
-           cdxgen_version=$(corepack pnpm pack | tail -1)
-           corepack pnpm install -g "$cdxgen_version"
+           cdxgen_version=$(pnpm pack | tail -1)
+           npm install -g "$cdxgen_version"
            python -m pip install --upgrade pip
            python -m pip install pytest
            git clone https://github.com/appthreat/cdxgen-samples.git /home/runner/work/samples

--- a/.github/workflows/snapshot-tests.yml
+++ b/.github/workflows/snapshot-tests.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   pull_request:
     branches:
-      - main
+      - master
 
 
 concurrency:
@@ -38,10 +38,8 @@ jobs:
            python -m pip install --upgrade pip
            python -m pip install pytest
            git clone https://github.com/appthreat/cdxgen-samples.git /home/runner/work/samples
-           git clone https://github.com/appthreat/custom-json-diff.git /home/runner/work/custom-json-diff
-           cd /home/runner/work/custom-json-diff
-           python -m pip install .
-           corepack pnpm install -g @appthreat/atom
+           python -m pip install custom-json-diff
+           npm install -g @appthreat/atom
            curl -s "https://get.sdkman.io" | bash
            source "/home/runner/.sdkman/bin/sdkman-init.sh"
 
@@ -87,8 +85,9 @@ jobs:
         if: ${{ env.status == 'FAILED' }}
         uses: actions/upload-artifact@v4
         with:
-            name: diff
-            path: /home/runner/work/cdxgen-samples/diffs.json
+            path: | 
+              /home/runner/work/cdxgen-samples/diffs.json
+              /home/runner/work/cdxgen-samples/*.html
 
       - name: Exit with error
         if: ${{ env.status == 'FAILED' }}

--- a/.github/workflows/snapshot-tests.yml
+++ b/.github/workflows/snapshot-tests.yml
@@ -31,21 +31,18 @@ jobs:
           python-version: 3.12
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9.2.0
 
-      -  name: Atom, cdxgen, sdkman, custom-json-diff installs
+      -  name: cdxgen, sdkman, custom-json-diff installs
          shell: bash
          env:
            SHELL: bash
          run: |
-           cdxgen_version=$(pnpm pack | tail -1)
-           npm install -g "$cdxgen_version"
+           cdxgen_tarball=$(pnpm pack | tail -1)
+           npm install -g "$cdxgen_tarball"
            python -m pip install --upgrade pip
            python -m pip install pytest
            git clone https://github.com/appthreat/cdxgen-samples.git /home/runner/work/samples
            python -m pip install custom-json-diff
-           npm install -g @appthreat/atom
            curl -s "https://get.sdkman.io" | bash
            source "/home/runner/.sdkman/bin/sdkman-init.sh"
 
@@ -91,9 +88,10 @@ jobs:
         if: ${{ env.status == 'FAILED' }}
         uses: actions/upload-artifact@v4
         with:
-            path: | 
-              /home/runner/work/cdxgen-samples/diffs.json
-              /home/runner/work/cdxgen-samples/*.html
+          name: diffs
+          path: | 
+            /home/runner/work/cdxgen-samples/diffs.json
+            /home/runner/work/cdxgen-samples/*.html
 
       - name: Exit with error
         if: ${{ env.status == 'FAILED' }}

--- a/test/diff/diff_tests.py
+++ b/test/diff/diff_tests.py
@@ -17,7 +17,7 @@ for i in repo_data:
     bom_1 = f"/home/runner/work/samples/{bom_file}"
     bom_2 = f"/home/runner/work/cdxgen-samples/{bom_file}"
     exclude = []
-    include = []
+    include = ["properties", "evidence", "licenses"]
     options = Options(
         allow_new_versions=True,
         allow_new_data=True,

--- a/test/diff/diff_tests.py
+++ b/test/diff/diff_tests.py
@@ -1,34 +1,45 @@
 import csv
 import json
 import os
-from pathlib import Path
 
-from custom_json_diff.custom_diff import compare_dicts, get_diffs
+from custom_json_diff.custom_diff import compare_dicts, perform_bom_diff, report_results
+from custom_json_diff.custom_diff_classes import Options
+
 
 with open('/home/runner/work/cdxgen/cdxgen/test/diff/repos.csv', 'r', encoding='utf-8') as f:
     reader = csv.DictReader(f)
     repo_data = list(reader)
 
-Failed = False
 failed_diffs = {}
 
 for i in repo_data:
     bom_file = f'{i["project"]}-bom.json'
-    bom_1 = Path("/home/runner/work/samples", bom_file)
-    bom_2 = Path("/home/runner/work/cdxgen-samples", bom_file)
+    bom_1 = f"/home/runner/work/samples/{bom_file}"
+    bom_2 = f"/home/runner/work/cdxgen-samples/{bom_file}"
+    exclude = []
+    include = []
+    options = Options(
+        allow_new_versions=True,
+        allow_new_data=True,
+        bom_diff=True,
+        include=include,
+        exclude=exclude,
+        file_1=bom_1,
+        file_2=bom_2,
+        output=f'/home/runner/work/cdxgen-samples/{i["project"]}-diff.json'
+    )
     if not os.path.exists(bom_1):
         print(f'{bom_file} does not exist in cdxgen-samples repository.')
         failed_diffs[i["project"]] = f'{bom_file} does not exist in cdxgen-samples repository.'
         continue
-    result, j1, j2 = compare_dicts(bom_1, bom_2, preset="cdxgen")
-    if result == 0:
-        print(f'{i["project"]} BOM passed.')
-    else:
-        print(f'{i["project"]} BOM failed.')
-        Failed = True
-        diffs = get_diffs(bom_1, bom_2, j1, j2)
-        failed_diffs[i["project"]] = diffs
+    result, j1, j2 = compare_dicts(options)
+
+    if result != 0:
+        print(f"{i['project']} failed.")
+        result_summary = perform_bom_diff(j1, j2)
+        failed_diffs[i["project"]] = result_summary
+        report_results(result, result_summary, options, j1, j2)
 
 if failed_diffs:
     with open('/home/runner/work/cdxgen-samples/diffs.json', 'w') as f:
-        json.dump(failed_diffs, f, indent=2)
+        json.dump(failed_diffs, f)

--- a/test/diff/repos.csv
+++ b/test/diff/repos.csv
@@ -1,5 +1,5 @@
 project,link,language,pre_build_cmd,build_cmd,commit
-"netty","https://github.com/netty/netty.git","java","sdk use java 8.0.392-zulu","","7ad2b91515b3affaeadb4b2975cd6d2a8342c403"
+"netty","https://github.com/netty/netty.git","java","sdk use java 8.0.392-zulu","","ffee1746f85cb3e0d74801abe77ab30f49221185"
 "django-goat","https://github.com/red-and-black/DjangoGoat.git","python","","python -m venv venv; source venv/bin/activate && pip install -r requirements_app.txt","5e6aaa6d0497bf24abd179304e6ca51295a8091d"
 "java-sec-code","https://github.com/JoyChou93/java-sec-code.git","java","sdk use java 8.0.392-zulu","mvn -B clean compile -DskipTests=true","457d703e8f89bff657c6c51151ada71ebd09a1c6"
 "rasa","https://github.com/RasaHQ/rasa.git","python","pipx install poetry","","7807b19ad5fffab73ca1a04dc710f812115a9288"


### PR DESCRIPTION
# Changes
- I have ugraded the functionality in custom-json-diff to better handle bom diffing
- Handles [version issue](https://github.com/CycloneDX/cdxgen/discussions/1099#discussioncomment-9549267)
- Produces an HTML report in addition to the JSON
- Comparison is of defined bom objects which allows for better control for different use cases


## Notes on the current configuration of the tests
- Will pass if the newly generated bom has the same components or dependencies at equal or greater versions. This also means that purl and bom-ref will not be used in the comparison given they will not be the same in such a scenario.
- Will pass if the snapshot bom has empty fields and the newly generated bom has populated these fields
- Includes licenses, properties, and evidence in comparison but not hashes


@prabhu @setchy I have tested with the snapshots, updated the ones which required updating (properties expanded for a couple) and there's one thing I need to check on. 

Change of scope from optional to required for bouncy castles dependencies for netty. The [netty pom](https://github.com/netty/netty/blob/7ad2b91515b3affaeadb4b2975cd6d2a8342c403/pom.xml) indicates these are optional. Thoughts?

```
{
  "bom-ref": "pkg:maven/org.bouncycastle/bcpkix-jdk15on@1.69?type=jar",
  "description": "The Bouncy Castle Java APIs for CMS, PKCS, EAC, TSP, CMP, CRMF, OCSP, and certificate generation. This jar contains APIs for JDK 1.5 and up. The APIs can be used in conjunction with a JCE/JCA provider such as the one provided with the Bouncy Castle Cryptography APIs.",
  "name": "bcpkix-jdk15on",
  "purl": "pkg:maven/org.bouncycastle/bcpkix-jdk15on@1.69?type=jar",
  "scope": "optional",
  "type": "framework",
  "version": "1.69"
}
``` 
```
{
  "bom-ref": "pkg:maven/org.bouncycastle/bcpkix-jdk15on@1.69?type=jar",
  "description": "The Bouncy Castle Java APIs for CMS, PKCS, EAC, TSP, CMP, CRMF, OCSP, and certificate generation. This jar contains APIs for JDK 1.5 and up. The APIs can be used in conjunction with a JCE/JCA provider such as the one provided with the Bouncy Castle Cryptography APIs.",
  "name": "bcpkix-jdk15on",
  "purl": "pkg:maven/org.bouncycastle/bcpkix-jdk15on@1.69?type=jar",
  "scope": "required",
  "type": "framework",
  "version": "1.69"
}
``` 
```
<dependency>
  <groupId>org.bouncycastle</groupId>
  <artifactId>bcpkix-jdk15on</artifactId>
  <version>1.69</version>
  <scope>compile</scope>
  <optional>true</optional>
</dependency>

<!--
  Completely optional and only needed for OCSP stapling to construct and
  parse OCSP requests and responses.
-->
<dependency>
  <groupId>org.bouncycastle</groupId>
  <artifactId>bcprov-jdk15on</artifactId>
  <version>1.69</version>
  <scope>compile</scope>
  <optional>true</optional>
</dependency>

<!--
  Completely optional and only needed for ALPN.
-->
<dependency>
  <groupId>org.bouncycastle</groupId>
  <artifactId>bctls-jdk15on</artifactId>
  <version>1.69</version>
  <scope>compile</scope>
  <optional>true</optional>
</dependency>
``` 

Closes #1112 