### PR TITLE
Clearer paths for new vs old snapshots.

### DIFF
--- a/.github/workflows/snapshot-tests.yml
+++ b/.github/workflows/snapshot-tests.yml
@@ -41,7 +41,7 @@ jobs:
            npm install -g "$cdxgen_tarball"
            python -m pip install --upgrade pip
            python -m pip install pytest
-           git clone https://github.com/appthreat/cdxgen-samples.git /home/runner/work/samples
+           git clone https://github.com/appthreat/cdxgen-samples.git /home/runner/work/original_snapshots
            python -m pip install custom-json-diff
            curl -s "https://get.sdkman.io" | bash
            source "/home/runner/.sdkman/bin/sdkman-init.sh"
@@ -57,30 +57,30 @@ jobs:
         env:
           SDKMAN_DIR: /home/runner/.sdkman
           CDXGEN_DEBUG_MODE: debug
-          CDXGEN_LOG: /home/runner/work/cdxgen-samples/generate.log
+          CDXGEN_LOG: /home/runner/work/new_snapshots/generate.log
         run: |
-          mkdir /home/runner/work/cdxgen-samples
+          mkdir /home/runner/work/new_snapshots
           python test/diff/generate.py
-          bash /home/runner/work/cdxgen-samples/sdkman_installs.sh
-          bash /home/runner/work/cdxgen-samples/cdxgen_commands.sh
+          bash /home/runner/work/new_snapshots/sdkman_installs.sh
+          bash /home/runner/work/new_snapshots/cdxgen_commands.sh
 
       - name: Upload shell scripts generated as artifact
         uses: actions/upload-artifact@v4
         with:
           name: scripts
-          path: /home/runner/work/cdxgen-samples/*.sh
+          path: /home/runner/work/new_snapshots/*.sh
 
       - name: Upload cdxgen boms
         uses: actions/upload-artifact@v4
         with:
           name: cdxgen_boms
           path: |
-            /home/runner/work/cdxgen-samples
+            /home/runner/work/new_snapshots
 
       - name: Test BOMs
         run: |
           python test/diff/diff_tests.py
-          if test -f /home/runner/work/cdxgen-samples/diffs.json; then
+          if test -f /home/runner/work/new_snapshots/diffs.json; then
             echo "status=FAILED" >> "$GITHUB_ENV"
           fi
 
@@ -90,8 +90,8 @@ jobs:
         with:
           name: diffs
           path: | 
-            /home/runner/work/cdxgen-samples/diffs.json
-            /home/runner/work/cdxgen-samples/*.html
+            /home/runner/work/new_snapshots/diffs.json
+            /home/runner/work/new_snapshots/*.html
 
       - name: Exit with error
         if: ${{ env.status == 'FAILED' }}

--- a/test/diff/diff_tests.py
+++ b/test/diff/diff_tests.py
@@ -14,8 +14,8 @@ failed_diffs = {}
 
 for i in repo_data:
     bom_file = f'{i["project"]}-bom.json'
-    bom_1 = f"/home/runner/work/samples/{bom_file}"
-    bom_2 = f"/home/runner/work/cdxgen-samples/{bom_file}"
+    bom_1 = f"/home/runner/work/original_snapshots/{bom_file}"
+    bom_2 = f"/home/runner/work/new_snapshots/{bom_file}"
     exclude = []
     include = ["properties", "evidence", "licenses"]
     options = Options(
@@ -26,7 +26,7 @@ for i in repo_data:
         exclude=exclude,
         file_1=bom_1,
         file_2=bom_2,
-        output=f'/home/runner/work/cdxgen-samples/{i["project"]}-diff.json'
+        output=f'/home/runner/work/new_snapshots/{i["project"]}-diff.json'
     )
     if not os.path.exists(bom_1):
         print(f'{bom_file} does not exist in cdxgen-samples repository.')
@@ -41,5 +41,5 @@ for i in repo_data:
         report_results(result, result_summary, options, j1, j2)
 
 if failed_diffs:
-    with open('/home/runner/work/cdxgen-samples/diffs.json', 'w') as f:
+    with open('/home/runner/work/new_snapshots/diffs.json', 'w') as f:
         json.dump(failed_diffs, f)

--- a/test/diff/generate.py
+++ b/test/diff/generate.py
@@ -30,7 +30,7 @@ def build_args():
         '-o',
         '--output-dir',
         type=Path,
-        default='/home/runner/work/cdxgen-samples',
+        default='/home/runner/work/new_snapshots',
         help='Path to output',
         dest='output_dir',
     )


### PR DESCRIPTION
Simply changes the directory that we clone our snapshot boms into and where we produce our new snapshot boms so that it is obvious which file in the diff is the original.