### PR TITLE
Add if conditional to ignore irrelevant tasks

### DIFF
--- a/test/gradle-dep-parallel.out
+++ b/test/gradle-dep-parallel.out
@@ -1,4 +1,7 @@
-
+> Task :buildSrc:classes UP-TO-DATE
+> Task :buildSrc:jar UP-TO-DATE
+> Task :buildSrc:check UP-TO-DATE
+> Task :buildSrc:build UP-TO-DATE
 > Task :dependencies
 
 ------------------------------------------------------------

--- a/test/gradle-prop-parallel.out
+++ b/test/gradle-prop-parallel.out
@@ -1,4 +1,7 @@
-
+> Task :buildSrc:classes UP-TO-DATE
+> Task :buildSrc:jar UP-TO-DATE
+> Task :buildSrc:check UP-TO-DATE
+> Task :buildSrc:build UP-TO-DATE
 > Task :properties
 
 ------------------------------------------------------------

--- a/utils.js
+++ b/utils.js
@@ -9219,8 +9219,6 @@ export function splitOutputByGradleProjects(rawOutput) {
     if (
       line.startsWith("> Task :") &&
       !regexForPropertiesOrDependencies.test(line)
-      // !line.includes(":properties") &&
-      // !line.includes(":dependencies")
     ) {
       continue;
     }

--- a/utils.js
+++ b/utils.js
@@ -9207,7 +9207,8 @@ export function splitOutputByGradleProjects(rawOutput) {
   let subProjectOut = "";
   const outSplitByLine = rawOutput.split("\n");
   let currentProjectName = "";
-  const regexForPropertiesOrDependencies = /.*:(dependencies|properties)(?=\s|$)/;
+  const regexForPropertiesOrDependencies =
+    /.*:(dependencies|properties)(?=\s|$)/;
   for (const [i, line] of outSplitByLine.entries()) {
     //filter out everything before first task output
     if (!line.startsWith("> Task :") && subProjectOut === "") {
@@ -9227,21 +9228,21 @@ export function splitOutputByGradleProjects(rawOutput) {
     if (line.startsWith("Root project '") || line.startsWith("Project ':")) {
       currentProjectName = line.split("'")[1];
       currentProjectName = currentProjectName.replace(":", "");
-     outputSplitBySubprojects.set(currentProjectName, "");
-   }
-   // if previous subProject has ended, push to array and reset subProject string
-   if (line.startsWith("> Task :") && subProjectOut !== "") {
-     outputSplitBySubprojects.set(currentProjectName, subProjectOut);
-     subProjectOut = "";
-   }
-   //if in subproject block, keep appending to string
-   subProjectOut += `${line}\n`;
-   //if end of last dependencies output block, push to array
-   if (i === outSplitByLine.length - 1) {
-     outputSplitBySubprojects.set(currentProjectName, subProjectOut);
-   }
- }
- return outputSplitBySubprojects;
+      outputSplitBySubprojects.set(currentProjectName, "");
+    }
+    // if previous subProject has ended, push to array and reset subProject string
+    if (line.startsWith("> Task :") && subProjectOut !== "") {
+      outputSplitBySubprojects.set(currentProjectName, subProjectOut);
+      subProjectOut = "";
+    }
+    //if in subproject block, keep appending to string
+    subProjectOut += `${line}\n`;
+    //if end of last dependencies output block, push to array
+    if (i === outSplitByLine.length - 1) {
+      outputSplitBySubprojects.set(currentProjectName, subProjectOut);
+    }
+  }
+  return outputSplitBySubprojects;
 }
 /**
  * Method to return the maven command to use.

--- a/utils.js
+++ b/utils.js
@@ -9214,9 +9214,11 @@ export function splitOutputByGradleProjects(rawOutput) {
     }
 
     //ignore output of irrelevant tasks
-    if (line.startsWith("> Task :") 
-      && !line.includes(":properties") 
-      && !line.includes(":dependencies")) {
+    if (
+      line.startsWith("> Task :") &&
+      !line.includes(":properties") &&
+      !line.includes(":dependencies")
+    ) {
       continue;
     }
 
@@ -9226,7 +9228,7 @@ export function splitOutputByGradleProjects(rawOutput) {
       outputSplitBySubprojects.set(currentProjectName, "");
     }
     // if previous subProject has ended, push to array and reset subProject string
-    if (line.startsWith("> Task :") && subProjectOut !== "") {   
+    if (line.startsWith("> Task :") && subProjectOut !== "") {
       outputSplitBySubprojects.set(currentProjectName, subProjectOut);
       subProjectOut = "";
     }

--- a/utils.js
+++ b/utils.js
@@ -9208,8 +9208,15 @@ export function splitOutputByGradleProjects(rawOutput) {
   const outSplitByLine = rawOutput.split("\n");
   let currentProjectName = "";
   for (const [i, line] of outSplitByLine.entries()) {
-    //filter out everything before first dependencies task output
+    //filter out everything before first task output
     if (!line.startsWith("> Task :") && subProjectOut === "") {
+      continue;
+    }
+
+    //ignore output of irrelevant tasks
+    if (line.startsWith("> Task :") 
+      && !line.includes(":properties") 
+      && !line.includes(":dependencies")) {
       continue;
     }
 
@@ -9219,7 +9226,7 @@ export function splitOutputByGradleProjects(rawOutput) {
       outputSplitBySubprojects.set(currentProjectName, "");
     }
     // if previous subProject has ended, push to array and reset subProject string
-    if (line.startsWith("> Task :") && subProjectOut !== "") {
+    if (line.startsWith("> Task :") && subProjectOut !== "") {   
       outputSplitBySubprojects.set(currentProjectName, subProjectOut);
       subProjectOut = "";
     }

--- a/utils.js
+++ b/utils.js
@@ -9207,6 +9207,7 @@ export function splitOutputByGradleProjects(rawOutput) {
   let subProjectOut = "";
   const outSplitByLine = rawOutput.split("\n");
   let currentProjectName = "";
+  const regexForPropertiesOrDependencies = /.*:(dependencies|properties)(?=\s|$)/;
   for (const [i, line] of outSplitByLine.entries()) {
     //filter out everything before first task output
     if (!line.startsWith("> Task :") && subProjectOut === "") {
@@ -9216,8 +9217,9 @@ export function splitOutputByGradleProjects(rawOutput) {
     //ignore output of irrelevant tasks
     if (
       line.startsWith("> Task :") &&
-      !line.includes(":properties") &&
-      !line.includes(":dependencies")
+      !regexForPropertiesOrDependencies.test(line)
+      // !line.includes(":properties") &&
+      // !line.includes(":dependencies")
     ) {
       continue;
     }
@@ -9225,22 +9227,21 @@ export function splitOutputByGradleProjects(rawOutput) {
     if (line.startsWith("Root project '") || line.startsWith("Project ':")) {
       currentProjectName = line.split("'")[1];
       currentProjectName = currentProjectName.replace(":", "");
-      outputSplitBySubprojects.set(currentProjectName, "");
-    }
-    // if previous subProject has ended, push to array and reset subProject string
-    if (line.startsWith("> Task :") && subProjectOut !== "") {
-      outputSplitBySubprojects.set(currentProjectName, subProjectOut);
-      subProjectOut = "";
-    }
-    //if in subproject block, keep appending to string
-    subProjectOut += `${line}\n`;
-
-    //if end of last dependencies output block, push to array
-    if (i === outSplitByLine.length - 1) {
-      outputSplitBySubprojects.set(currentProjectName, subProjectOut);
-    }
-  }
-  return outputSplitBySubprojects;
+     outputSplitBySubprojects.set(currentProjectName, "");
+   }
+   // if previous subProject has ended, push to array and reset subProject string
+   if (line.startsWith("> Task :") && subProjectOut !== "") {
+     outputSplitBySubprojects.set(currentProjectName, subProjectOut);
+     subProjectOut = "";
+   }
+   //if in subproject block, keep appending to string
+   subProjectOut += `${line}\n`;
+   //if end of last dependencies output block, push to array
+   if (i === outSplitByLine.length - 1) {
+     outputSplitBySubprojects.set(currentProjectName, subProjectOut);
+   }
+ }
+ return outputSplitBySubprojects;
 }
 /**
  * Method to return the maven command to use.


### PR DESCRIPTION
Some Gradle projects have additional tasks that run when running `properties` or `dependencies` tasks in parallel. These tasks were being captured and causing sbom gen to break on some gradle projects when using the multi-threaded mode. [Gradle composite builds](https://docs.gradle.org/current/userguide/composite_builds.html) are a good example of when this might occur. 
This PR fixes it by ignoring irrelevant tasks's outputs when building the output map split by sub-projects.

cc: @prabhu 
