### PR TITLE
Add 10MB buffer for parallel Gradle properties task output 

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -2861,6 +2861,7 @@ export function executeGradleProperties(dir, rootPath, subProject) {
     cwd: dir,
     encoding: "utf-8",
     shell: isWin,
+    maxBuffer: 10 * 1024 * 1024,
   });
   if (result.status !== 0 || result.error) {
     if (result.stderr) {


### PR DESCRIPTION
Currently there's no maxBuffer set for running the parallel properties task, and this results in the buffer size defaulting to 1MB, causing some output to be cut-off, especially for large projects. This PR sets the buffer size to 10MB to fix this problem.

cc: @prabhu 