### PR TITLE
Added support for lifecycle and other args to server

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Options:
       --exclude                Additional glob pattern(s) to ignore                                              [array]
       --include-formulation    Generate formulation section with git metadata and build tools. Defaults to true. Invoke
                                with --no-include-formulation to disable.                       [boolean] [default: true]
-      --include-crypto         Include crypto libraries found under formulation.              [boolean] [default: false]
+      --include-crypto         Include crypto libraries as components.                        [boolean] [default: false]
       --standard               The list of standards which may consist of regulations, industry or organizational-specif
                                ic standards, maturity models, best practices, or any other requirements which can be eva
                                luated against or attested to.
@@ -463,6 +463,7 @@ Use the [CycloneDX CLI][cyclonedx-cli-github] tool for advanced use cases such a
 ## Including .NET Global Assembly Cache dependencies in the results
 
 Global Assembly Cache (GAC) dependencies must be made available in the build output of the project for cdxgen in order for it to inspect and include in the results. A cdxgen scan with the `--deep` flag will look for additional dependencies in the form of dll files. A simple way to have the dotnet build copy the GAC dependencies into the build directory is to place the file `Directory.Build.props` into the root of the project and ensure the contents include the following:
+
 ```
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 <ItemDefinitionGroup>

--- a/bin/cdxgen.js
+++ b/bin/cdxgen.js
@@ -253,7 +253,7 @@ const args = yargs(hideBin(process.argv))
   .option("include-crypto", {
     type: "boolean",
     default: false,
-    description: "Include crypto libraries found under formulation.",
+    description: "Include crypto libraries as components.",
   })
   .option("standard", {
     description:

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@cyclonedx/cdxgen",
-  "version": "10.8.8",
+  "version": "10.8.9",
   "exports": "./index.js",
   "compilerOptions": {
     "allowJs": true,

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -115,7 +115,7 @@ Options:
       --exclude                Additional glob pattern(s) to ignore                                              [array]
       --include-formulation    Generate formulation section with git metadata and build tools. Defaults to true. Invoke
                                with --no-include-formulation to disable.                       [boolean] [default: true]
-      --include-crypto         Include crypto libraries found under formulation.              [boolean] [default: false]
+      --include-crypto         Include crypto libraries as components.                        [boolean] [default: false]
       --standard               The list of standards which may consist of regulations, industry or organizational-specif
                                ic standards, maturity models, best practices, or any other requirements which can be eva
                                luated against or attested to.

--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@cyclonedx/cdxgen",
-  "version": "10.8.8",
+  "version": "10.8.9",
   "exports": "./index.js",
   "include": ["*.js", "bin/**", "data/**", "types/**"],
   "exclude": ["test/", "docs/", "contrib/", "ci/", "tools_config/"]

--- a/lib/server/openapi.yaml
+++ b/lib/server/openapi.yaml
@@ -134,6 +134,41 @@ paths:
           required: false
           schema:
             $ref: '#/components/schemas/CDXGEN/properties/gitBranch'
+        - name: lifecycle
+          in: query
+          required: false
+          schema:
+            $ref: '#/components/schemas/CDXGEN/properties/lifecycle'
+        - name: deep
+          in: query
+          required: false
+          schema:
+            $ref: '#/components/schemas/CDXGEN/properties/deep'
+        - name: profile
+          in: query
+          required: false
+          schema:
+            $ref: '#/components/schemas/CDXGEN/properties/profile'
+        - name: exclude
+          in: query
+          required: false
+          schema:
+            $ref: '#/components/schemas/CDXGEN/properties/exclude'
+        - name: includeFormulation
+          in: query
+          required: false
+          schema:
+            $ref: '#/components/schemas/CDXGEN/properties/includeFormulation'
+        - name: includeCrypto
+          in: query
+          required: false
+          schema:
+            $ref: '#/components/schemas/CDXGEN/properties/includeCrypto'
+        - name: standard
+          in: query
+          required: false
+          schema:
+            $ref: '#/components/schemas/CDXGEN/properties/standard'
       responses:
         '200':
           description: Successful operation
@@ -242,8 +277,33 @@ components:
         gitBranch:
           type: string
           description: Git branch used when cloning the repository. If not specified will use the default branch assigned to the repository
-
-
+        lifecycle:
+          type: string
+          description: Product lifecycle for the generated BOM. Choices are pre-build, build, post-build.
+        deep:
+          type: boolean
+          description: Perform deep searches for components. Useful while scanning C/C++ apps, live OS and oci images.
+          default: false
+        profile:
+          type: string
+          description: BOM profile to use for generation. Default generic. Choices are appsec, research, license-compliance
+          default: generic
+        exclude:
+          type: array
+          items:
+            type: string
+          description: Additional glob pattern(s) to ignore
+        includeFormulation:
+          type: boolean
+          description: Generate formulation section with git metadata and build tools. Use with caution, since there is a risk of exposure of sensitive data such as secrets.
+          default: false
+        includeCrypto:
+          type: boolean
+          description: Include crypto libraries as components.
+          default: false
+        standard:
+          type: string
+          description: The list of standards which may consist of regulations, industry or organizational-specific standards, maturity models, best practices, or any other requirements which can be evaluated against or attested to. Choices are asvs-4.0.3, bsimm-v13, masvs-2.0.0, nist_ssdf-1.1, pcissc-secure-slc-1.1, scvs-1.0.0, ssaf-DRAFT-2023-11
     CycloneDXSBOM:
       type: object
       externalDocs:

--- a/lib/server/openapi.yaml
+++ b/lib/server/openapi.yaml
@@ -286,7 +286,7 @@ components:
           default: false
         profile:
           type: string
-          description: BOM profile to use for generation. Default generic. Choices are appsec, research, license-compliance
+          description: BOM profile to use for generation. Default generic. Choices are appsec, research.
           default: generic
         exclude:
           type: array

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cyclonedx/cdxgen",
-  "version": "10.8.8",
+  "version": "10.8.9",
   "description": "Creates CycloneDX Software Bill of Materials (SBOM) from source or container image",
   "homepage": "http://github.com/cyclonedx/cdxgen",
   "author": "Prabhu Subramanian <prabhu@appthreat.com>",

--- a/server.js
+++ b/server.js
@@ -123,7 +123,6 @@ const applyProfileOptions = (options) => {
     case "appsec":
       options.deep = true;
       break;
-    case "threat-modeling":
     case "research":
       options.deep = true;
       options.evidence = true;

--- a/server.js
+++ b/server.js
@@ -85,19 +85,53 @@ const parseQueryString = (q, body, options = {}) => {
     "only",
     "autoCompositions",
     "gitBranch",
-    "active",
+    "lifecycle",
+    "deep",
+    "profile",
+    "exclude",
+    "includeFormulation",
+    "includeCrypto",
+    "standard",
   ];
 
   for (const param of queryParams) {
     if (q[param]) {
-      options[param] = q[param];
+      let value = q[param];
+      // Convert string to boolean
+      if (value === "true") {
+        value = true;
+      } else if (value === "false") {
+        value = false;
+      }
+      options[param] = value;
     }
   }
 
   options.projectType = options.type?.split(",");
   delete options.type;
-
+  if (options.lifecycle === "pre-build") {
+    options.installDeps = false;
+  }
+  if (options.profile) {
+    applyProfileOptions(options);
+  }
   return options;
+};
+
+const applyProfileOptions = (options) => {
+  switch (options.profile) {
+    case "appsec":
+      options.deep = true;
+      break;
+    case "threat-modeling":
+    case "research":
+      options.deep = true;
+      options.evidence = true;
+      options.includeCrypto = true;
+      break;
+    default:
+      break;
+  }
 };
 
 const configureServer = (cdxgenServer) => {
@@ -143,9 +177,7 @@ const start = (options) => {
     }
     console.log("Generating SBOM for", srcDir);
     let bomNSData = (await createBom(srcDir, reqOptions)) || {};
-    if (reqOptions.requiredOnly || reqOptions["filter"] || reqOptions["only"]) {
-      bomNSData = postProcess(bomNSData, reqOptions);
-    }
+    bomNSData = postProcess(bomNSData, reqOptions);
     if (reqOptions.serverUrl && reqOptions.apiKey) {
       console.log("Publishing SBOM to Dependency Track");
       const response = await submitBom(reqOptions, bomNSData.bomJson);

--- a/types/server.d.ts.map
+++ b/types/server.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"server.d.ts","sourceRoot":"","sources":["../server.js"],"names":[],"mappings":"AAsGA,yDAKC;AAED,0CAsEC"}
+{"version":3,"file":"server.d.ts","sourceRoot":"","sources":["../server.js"],"names":[],"mappings":"AAwIA,yDAKC;AAED,0CAoEC"}

--- a/types/server.d.ts.map
+++ b/types/server.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"server.d.ts","sourceRoot":"","sources":["../server.js"],"names":[],"mappings":"AAwIA,yDAKC;AAED,0CAoEC"}
+{"version":3,"file":"server.d.ts","sourceRoot":"","sources":["../server.js"],"names":[],"mappings":"AAuIA,yDAKC;AAED,0CAoEC"}


### PR DESCRIPTION
Both of these query parameters are valid:

```
lifecycle=pre-build
installDeps=false
```

Tested with:

```
curl "http://127.0.0.1:9090/sbom?path=/Volumes/Work/sandbox/server-lifecycle&type=python&lifecycle=pre-build" > bom.json
curl "http://127.0.0.1:9090/sbom?path=/Volumes/Work/sandbox/server-lifecycle&type=python&installDeps=false" > bom.json
```
