### PR TITLE
Allow Conan references with user and channel in conan.lock files

### DIFF
--- a/test/data/conan.with_custom_pkg_user_channel.lock
+++ b/test/data/conan.with_custom_pkg_user_channel.lock
@@ -1,0 +1,55 @@
+{
+ "graph_lock": {
+  "nodes": {
+   "0": {
+    "options": "libcurl:shared=False\nlibcurl:with_brotli=False\nlibcurl:with_c_ares=False\nlibcurl:with_ca_bundle=auto\nlibcurl:with_ca_fallback=False\nlibcurl:with_ca_path=auto\nlibcurl:with_cookies=True\nlibcurl:with_crypto_auth=True\nlibcurl:with_dict=True\nlibcurl:with_docs=False\nlibcurl:with_file=True\nlibcurl:with_ftp=True\nlibcurl:with_gopher=True\nlibcurl:with_http=True\nlibcurl:with_imap=True\nlibcurl:with_ipv6=True\nlibcurl:with_largemaxwritesize=False\nlibcurl:with_ldap=False\nlibcurl:with_libidn=False\nlibcurl:with_libpsl=False\nlibcurl:with_librtmp=False\nlibcurl:with_libssh2=False\nlibcurl:with_mqtt=True\nlibcurl:with_nghttp2=False\nlibcurl:with_ntlm=True\nlibcurl:with_ntlm_wb=True\nlibcurl:with_pop3=True\nlibcurl:with_proxy=True\nlibcurl:with_rtsp=True\nlibcurl:with_smb=True\nlibcurl:with_smtp=True\nlibcurl:with_ssl=openssl\nlibcurl:with_symbol_hiding=False\nlibcurl:with_telnet=True\nlibcurl:with_tftp=True\nlibcurl:with_threaded_resolver=True\nlibcurl:with_unix_sockets=True\nlibcurl:with_verbose_debug=True\nlibcurl:with_verbose_strings=True\nlibcurl:with_zlib=True\nlibcurl:with_zstd=False\nopenssl:386=False\nopenssl:capieng_dialog=False\nopenssl:enable_capieng=False\nopenssl:enable_weak_ssl_ciphers=False\nopenssl:no_aria=False\nopenssl:no_asm=False\nopenssl:no_async=False\nopenssl:no_bf=False\nopenssl:no_blake2=False\nopenssl:no_camellia=False\nopenssl:no_cast=False\nopenssl:no_chacha=False\nopenssl:no_cms=False\nopenssl:no_comp=False\nopenssl:no_ct=False\nopenssl:no_deprecated=False\nopenssl:no_des=False\nopenssl:no_dgram=False\nopenssl:no_dh=False\nopenssl:no_dsa=False\nopenssl:no_dso=False\nopenssl:no_ec=False\nopenssl:no_ecdh=False\nopenssl:no_ecdsa=False\nopenssl:no_engine=False\nopenssl:no_filenames=False\nopenssl:no_fips=False\nopenssl:no_gost=False\nopenssl:no_idea=False\nopenssl:no_legacy=False\nopenssl:no_md2=True\nopenssl:no_md4=False\nopenssl:no_mdc2=False\nopenssl:no_module=False\nopenssl:no_ocsp=False\nopenssl:no_pinshared=False\nopenssl:no_rc2=False\nopenssl:no_rc4=False\nopenssl:no_rc5=False\nopenssl:no_rfc3779=False\nopenssl:no_rmd160=False\nopenssl:no_seed=False\nopenssl:no_sm2=False\nopenssl:no_sm3=False\nopenssl:no_sm4=False\nopenssl:no_sock=False\nopenssl:no_srp=False\nopenssl:no_srtp=False\nopenssl:no_sse2=False\nopenssl:no_ssl=False\nopenssl:no_ssl3=False\nopenssl:no_stdio=False\nopenssl:no_threads=False\nopenssl:no_tls1=False\nopenssl:no_ts=False\nopenssl:no_whirlpool=False\nopenssl:no_zlib=False\nopenssl:openssldir=None\nopenssl:shared=False\nzlib:shared=False",
+    "requires": [
+     "1"
+    ],
+    "build_requires": [
+     "4"
+    ],
+    "path": "conanfile.txt",
+    "context": "host"
+   },
+   "1": {
+    "ref": "libcurl/8.1.2@internal/stable#25215c550633ef0224152bc2c0556698",
+    "options": "shared=False\nwith_brotli=False\nwith_c_ares=False\nwith_ca_bundle=auto\nwith_ca_fallback=False\nwith_ca_path=auto\nwith_cookies=True\nwith_crypto_auth=True\nwith_dict=True\nwith_docs=False\nwith_file=True\nwith_ftp=True\nwith_gopher=True\nwith_http=True\nwith_imap=True\nwith_ipv6=True\nwith_largemaxwritesize=False\nwith_ldap=False\nwith_libidn=False\nwith_libpsl=False\nwith_librtmp=False\nwith_libssh2=False\nwith_mqtt=True\nwith_nghttp2=False\nwith_ntlm=True\nwith_ntlm_wb=True\nwith_pop3=True\nwith_proxy=True\nwith_rtsp=True\nwith_smb=True\nwith_smtp=True\nwith_ssl=openssl\nwith_symbol_hiding=False\nwith_telnet=True\nwith_tftp=True\nwith_threaded_resolver=True\nwith_unix_sockets=True\nwith_verbose_debug=True\nwith_verbose_strings=True\nwith_zlib=True\nwith_zstd=False\nopenssl:386=False\nopenssl:capieng_dialog=False\nopenssl:enable_capieng=False\nopenssl:enable_weak_ssl_ciphers=False\nopenssl:no_aria=False\nopenssl:no_asm=False\nopenssl:no_async=False\nopenssl:no_bf=False\nopenssl:no_blake2=False\nopenssl:no_camellia=False\nopenssl:no_cast=False\nopenssl:no_chacha=False\nopenssl:no_cms=False\nopenssl:no_comp=False\nopenssl:no_ct=False\nopenssl:no_deprecated=False\nopenssl:no_des=False\nopenssl:no_dgram=False\nopenssl:no_dh=False\nopenssl:no_dsa=False\nopenssl:no_dso=False\nopenssl:no_ec=False\nopenssl:no_ecdh=False\nopenssl:no_ecdsa=False\nopenssl:no_engine=False\nopenssl:no_filenames=False\nopenssl:no_fips=False\nopenssl:no_gost=False\nopenssl:no_idea=False\nopenssl:no_legacy=False\nopenssl:no_md2=True\nopenssl:no_md4=False\nopenssl:no_mdc2=False\nopenssl:no_module=False\nopenssl:no_ocsp=False\nopenssl:no_pinshared=False\nopenssl:no_rc2=False\nopenssl:no_rc4=False\nopenssl:no_rc5=False\nopenssl:no_rfc3779=False\nopenssl:no_rmd160=False\nopenssl:no_seed=False\nopenssl:no_sm2=False\nopenssl:no_sm3=False\nopenssl:no_sm4=False\nopenssl:no_sock=False\nopenssl:no_srp=False\nopenssl:no_srtp=False\nopenssl:no_sse2=False\nopenssl:no_ssl=False\nopenssl:no_ssl3=False\nopenssl:no_stdio=False\nopenssl:no_threads=False\nopenssl:no_tls1=False\nopenssl:no_ts=False\nopenssl:no_whirlpool=False\nopenssl:no_zlib=False\nopenssl:openssldir=None\nopenssl:shared=False\nzlib:shared=False",
+    "package_id": "5e2e9ff4c7478ced557b78f984fac0ae12c7c499",
+    "prev": "efd8a682b248f16445c0fc2e177f5ee6",
+    "requires": [
+     "2",
+     "3"
+    ],
+    "context": "host"
+   },
+   "2": {
+    "ref": "openssl/3.1.0@internal/stable#c9c6ab43aa40bafacf8b37c5948cdb1f",
+    "options": "386=False\ncapieng_dialog=False\nenable_capieng=False\nenable_weak_ssl_ciphers=False\nno_aria=False\nno_asm=False\nno_async=False\nno_bf=False\nno_blake2=False\nno_camellia=False\nno_cast=False\nno_chacha=False\nno_cms=False\nno_comp=False\nno_ct=False\nno_deprecated=False\nno_des=False\nno_dgram=False\nno_dh=False\nno_dsa=False\nno_dso=False\nno_ec=False\nno_ecdh=False\nno_ecdsa=False\nno_engine=False\nno_filenames=False\nno_fips=False\nno_gost=False\nno_idea=False\nno_legacy=False\nno_md2=True\nno_md4=False\nno_mdc2=False\nno_module=False\nno_ocsp=False\nno_pinshared=False\nno_rc2=False\nno_rc4=False\nno_rc5=False\nno_rfc3779=False\nno_rmd160=False\nno_seed=False\nno_sm2=False\nno_sm3=False\nno_sm4=False\nno_sock=False\nno_srp=False\nno_srtp=False\nno_sse2=False\nno_ssl=False\nno_ssl3=False\nno_stdio=False\nno_threads=False\nno_tls1=False\nno_ts=False\nno_whirlpool=False\nno_zlib=False\nopenssldir=None\nshared=False\nzlib:shared=False",
+    "package_id": "73e13514e79f4e5c082cf3505874df8af370579c",
+    "prev": "3713842f921d291615eb48fbcff8b3f4",
+    "requires": [
+     "3"
+    ],
+    "context": "host"
+   },
+   "3": {
+    "ref": "zlib/1.2.13@internal/stable#aee6a56ff7927dc7261c55eb2db4fc5b",
+    "options": "shared=False",
+    "package_id": "9057732059ea44a47760900cb5e4855d2bea8714",
+    "prev": "eab8bb81b803d46d87c1345d191c8ada",
+    "context": "host"
+   },
+   "4": {
+    "ref": "fmt/10.0.0@internal/stable#79e7cc169695bc058fb606f20df6bb10",
+    "options": "header_only=False\nshared=False\nwith_fmt_alias=False\nwith_os_api=True",
+    "package_id": "bed2451fe8e6a2dd1b2f8bac3c035717ff9ddfa8",
+    "prev": "abbe46a75c51ba913fc6608a9df2f437",
+    "context": "host"
+   }
+  },
+  "revisions_enabled": true
+ },
+ "version": "0.4",
+ "profile_host": "[settings]\narch=x86_64\narch_build=x86_64\nbuild_type=Debug\ncompiler=Visual Studio\ncompiler.runtime=MDd\ncompiler.version=16\nos=Windows\nos_build=Windows\n[options]\n[build_requires]\n[env]\n"
+}

--- a/test/data/conanfile.with_custom_pkg_user_channel.txt
+++ b/test/data/conanfile.with_custom_pkg_user_channel.txt
@@ -1,0 +1,8 @@
+[requires]
+libcurl/8.1.2@internal/stable
+
+[build_requires]
+fmt/10.0.0@internal/stable
+
+[generators]
+cmake

--- a/utils.test.js
+++ b/utils.test.js
@@ -33,6 +33,7 @@ import {
   parseCmakeDotFile,
   parseCmakeLikeFile,
   parseComposerLock,
+  mapConanPkgRefToPurlStringAndNameAndVersion,
   parseConanData,
   parseConanLockData,
   parseContainerFile,
@@ -1552,14 +1553,128 @@ test("parse conan data", () => {
   dep_list = parseConanData(
     readFileSync("./test/data/cmakes/conanfile1.txt", { encoding: "utf-8" }),
   );
-  expect(dep_list.length).toEqual(42);
+  expect(dep_list.length).toEqual(43);
   expect(dep_list[0]).toEqual({
-    "bom-ref":
-      "pkg:conan/7-Zip@19.00?revision=bb67aa9bc0da3feddc68ca9f334f4c8b",
+    "bom-ref": "pkg:conan/7-Zip@19.00?channel=stable&rrev=bb67aa9bc0da3feddc68ca9f334f4c8b&user=iw",
     name: "7-Zip",
-    purl: "pkg:conan/7-Zip@19.00?revision=bb67aa9bc0da3feddc68ca9f334f4c8b",
+    purl: "pkg:conan/7-Zip@19.00?channel=stable&rrev=bb67aa9bc0da3feddc68ca9f334f4c8b&user=iw",
     scope: "required",
     version: "19.00",
+  });
+});
+
+test("conan package reference mapper to pURL", () => {
+  const checkParseResult = function(inputPkgRef, expectedPurl) {
+    const [purl, name, version] = mapConanPkgRefToPurlStringAndNameAndVersion(inputPkgRef);
+    expect(purl).toEqual(expectedPurl);
+    
+    const expectedPurlPrefix = `pkg:conan/${name}@${version}`;
+    expect(purl.substring(0, expectedPurlPrefix.length)).toEqual(expectedPurlPrefix);
+  };
+
+  checkParseResult(
+    "testpkg",
+    "pkg:conan/testpkg@latest"
+  );
+
+  checkParseResult(
+    "testpkg/1.2.3",
+    "pkg:conan/testpkg@1.2.3"
+  );
+
+  checkParseResult(
+    "testpkg/1.2.3#recipe_revision",
+    "pkg:conan/testpkg@1.2.3?rrev=recipe_revision"
+  );
+
+  checkParseResult(
+    "testpkg/1.2.3@someuser/somechannel",
+    "pkg:conan/testpkg@1.2.3?channel=somechannel&user=someuser"
+  );
+
+  checkParseResult(
+    "testpkg/1.2.3@someuser/somechannel#recipe_revision",
+    "pkg:conan/testpkg@1.2.3?channel=somechannel&rrev=recipe_revision&user=someuser"
+  );
+
+  checkParseResult(
+    "testpkg/1.2.3@someuser/somechannel#recipe_revision:package_id#package_revision",
+    "pkg:conan/testpkg@1.2.3" +
+      "?channel=somechannel" +
+      "&prev=package_revision" +
+      "&rrev=recipe_revision" +
+      "&user=someuser"
+  );
+
+  const expectParseError = function(pkgRef) {
+    const result = mapConanPkgRefToPurlStringAndNameAndVersion(pkgRef);
+    expect(result[0]).toBe(null);
+    expect(result[1]).toBe(null);
+    expect(result[2]).toBe(null);
+  }
+
+  expectParseError("testpkg/"); // empty version
+  expectParseError("testpkg/1.2.3@"); // empty user
+  expectParseError("testpkg/1.2.3@someuser"); // pkg ref is not allowed to stop here
+  expectParseError("testpkg/1.2.3@someuser/"); // empty channel
+  expectParseError("testpkg/1.2.3@someuser/somechannel#"); // empty recipe revision
+  expectParseError("testpkg/1.2.3@someuser/somechannel#recipe_revision:"); // empty package id
+  expectParseError("testpkg/1.2.3@someuser/somechannel#recipe_revision:package_id"); // pkg ref is not allowed to stop here
+  expectParseError("testpkg/1.2.3@someuser/somechannel#recipe_revision:package_id#"); // empty package revision
+  expectParseError("testpkg/1.2.3/unexpected"); // unexpected pkg ref segment separator
+  expectParseError("testpkg/1.2.3@someuser/somechannel/unexpected"); // unexpected pkg ref segment separator
+  expectParseError("testpkg/1.2.3@someuser/somechannel#recipe_revision/unexpected"); // unexpected pkg ref segment separator
+  expectParseError("testpkg/1.2.3@someuser/somechannel#recipe_revision:package_id/unexpected"); // unexpected pkg ref segment separator
+  expectParseError("testpkg/1.2.3@someuser/somechannel#recipe_revision:package_id#package_revision/unexpected");   // unexpected pkg ref segment separator
+});
+
+test("parse conan data where packages use custom user/channel", () => {
+  let dep_list = parseConanLockData(
+    readFileSync("./test/data/conan.with_custom_pkg_user_channel.lock", { encoding: "utf-8" }),
+  );
+  expect(dep_list.length).toEqual(4);
+  expect(dep_list[0]).toEqual({
+    name: "libcurl",
+    version: "8.1.2",
+    "bom-ref": "pkg:conan/libcurl@8.1.2?channel=stable&rrev=25215c550633ef0224152bc2c0556698&user=internal",
+    purl: "pkg:conan/libcurl@8.1.2?channel=stable&rrev=25215c550633ef0224152bc2c0556698&user=internal"
+  });
+  expect(dep_list[1]).toEqual({
+    name: "openssl",
+    version: "3.1.0",
+    "bom-ref": "pkg:conan/openssl@3.1.0?channel=stable&rrev=c9c6ab43aa40bafacf8b37c5948cdb1f&user=internal",
+    purl: "pkg:conan/openssl@3.1.0?channel=stable&rrev=c9c6ab43aa40bafacf8b37c5948cdb1f&user=internal"
+  });
+  expect(dep_list[2]).toEqual({
+    name: "zlib",
+    version: "1.2.13",
+    "bom-ref": "pkg:conan/zlib@1.2.13?channel=stable&rrev=aee6a56ff7927dc7261c55eb2db4fc5b&user=internal",
+    purl: "pkg:conan/zlib@1.2.13?channel=stable&rrev=aee6a56ff7927dc7261c55eb2db4fc5b&user=internal"
+  });
+  expect(dep_list[3]).toEqual({
+    name: "fmt",
+    version: "10.0.0",
+    purl: "pkg:conan/fmt@10.0.0?channel=stable&rrev=79e7cc169695bc058fb606f20df6bb10&user=internal",
+    "bom-ref": "pkg:conan/fmt@10.0.0?channel=stable&rrev=79e7cc169695bc058fb606f20df6bb10&user=internal"
+  });
+
+  dep_list = parseConanData(
+    readFileSync("./test/data/conanfile.with_custom_pkg_user_channel.txt", { encoding: "utf-8" }),
+  );
+  expect(dep_list.length).toEqual(2);
+  expect(dep_list[0]).toEqual({
+    name: "libcurl",
+    version: "8.1.2",
+    "bom-ref": "pkg:conan/libcurl@8.1.2?channel=stable&user=internal",
+    purl: "pkg:conan/libcurl@8.1.2?channel=stable&user=internal",
+    scope: "required"
+  });
+  expect(dep_list[1]).toEqual({
+    name: "fmt",
+    version: "10.0.0",
+    purl: "pkg:conan/fmt@10.0.0?channel=stable&user=internal",
+    "bom-ref": "pkg:conan/fmt@10.0.0?channel=stable&user=internal",
+    scope: "optional"
   });
 });
 


### PR DESCRIPTION
# Problem Statement

When `cdxgen` parses `conan.lock` files, it fails to detect Conan packages whose [reference](https://docs.conan.io/1/cheatsheet.html#package-terminology) specifies [user and channel attributes](https://docs.conan.io/1/reference/conanfile/attributes.html#user-channel). 

Consider the following `conan.lock` file, where the listed package's reference does not specify *user and channel*. This sample is similar to a [conan.lock](https://github.com/CycloneDX/cdxgen/blob/be4e4f424a984fc96cd63173d14cd13098dd2865/test/data/conan.lock#L15) already present in test data. When running `cdxgen -t cpp .`, the created `bom.json` reflects the package accurately:

```json
/* excerpt from conan.lock */
{
 "graph_lock": {
  "nodes": {
   "0": { /* ... */ },
   "1": {
    "ref": "libcurl/8.1.2#3ddeb44d32deb27b1e0b027ad1c0e673",
    /* ... */
   }
  }
 }
}
```

```json
/* excerpt from bom.json */
{
    "components": [
      {
        "group": "",
        "name": "libcurl",
        "version": "8.1.2",
        "purl": "pkg:conan/libcurl@8.1.2",
        "type": "library",
        "bom-ref": "pkg:conan/libcurl@8.1.2"
      }
    ]
}
```

However, any packages with *user and channel* specified in the `conan.lock` file (note the `@internal/stable`) are not found in the resulting `bom.json`:

```json
/* excerpt from conan.lock */
{
 "graph_lock": {
  "nodes": {
   "0": { /* ... */ },
   "1": {
    "ref": "libcurl/8.1.2@internal/stable#0528972de6fa5f9c3ec7958fb8875338",
    /* ... */
   }
  }
 }
}
```

```json
/* excerpt from bom.json */
{
    "components": []
}
```

# Summary of Changes

1. Adds function `mapConanPkgRefToPurlStringAndNameAndVersion` to `utils.js` (+ a new test `conan package reference mapper to pURL` in `utils.test.js`) capable of parsing Conan references and transforming them to a pURL string.
2. Removes in-place Conan reference parsing logic in `parseConanLockData` and replaces it with a call to `mapConanPkgRefToPurlStringAndNameAndVersion`.
3. Removes in-place Conan reference parsing logic in `parseConanData` and replaces it with a call to `mapConanPkgRefToPurlStringAndNameAndVersion`.
4. Adds new test `parse conan data where packages use custom user/channel` to verify behavior of the above on added test files `conanfile.with_custom_pkg_user_channel.txt` and `conan.with_custom_pkg_user_channel.lock`.
5. Changes pURL format to comply with the latest revision of [Package URL Type definitions](https://github.com/package-url/purl-spec/blob/b33dda1cf4515efa8eabbbe8e9b140950805f845/PURL-TYPES.rst#conan) for Conan by renaming a currently generated specifier `revision` to `rrev`.
6. Allows including specifiers `user`, `channel`, `prev` in the Conan pURL when their counterparts are present in the parsed Conan reference.
7. Adjusts the `parse conan data` test from `utils.test.js` to:
   * Expect 43 instead of 42 results. The test file [conanfile1.txt](https://github.com/CycloneDX/cdxgen/blob/be4e4f424a984fc96cd63173d14cd13098dd2865/test/data/cmakes/conanfile1.txt) actually contains 43 package references, the entry `libx264/cci.20220602@iw/stable#018d183cfa8ac8c55af9f4406d6d40e4` appears not to have been recognized by the original parsing logic.
   * Expect the `channel`, `user` and `rrev` specifiers for the verified package, which are newly added by the new parsing logic.
