### PR TITLE
Add missing variable defaultProps

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -2764,6 +2764,13 @@ export function parseGradleProperties(rawOutput) {
  * @returns {string} The combined output for all subprojects of the Gradle properties task
  */
 export function executeParallelGradleProperties(dir, rootPath, allProjectsStr) {
+  const defaultProps = {
+    rootProject: subProject,
+    projects: [],
+    metadata: {
+      version: "latest",
+    },
+  };
   let parallelPropTaskArgs = ["properties"];
   for (const spstr of allProjectsStr) {
     parallelPropTaskArgs.push(`${spstr}:properties`);


### PR DESCRIPTION
`defaultProps` definition was missing from the `executeParallelGradleProperties` method, causing SBOM gen to fail on some repos. This PR fixes it. 