### PR TITLE
add all java archive files to trivy skip statement

### DIFF
--- a/binary.js
+++ b/binary.js
@@ -350,7 +350,7 @@ export function getOSPackages(src) {
       "--skip-java-db-update",
       "--offline-scan",
       "--skip-files",
-      "**/*.jar",
+      "**/*.jar,**/*.war,**/*.par,**/*.ear",
       "--no-progress",
       "--exit-code",
       "0",


### PR DESCRIPTION
**BUG**: Trivy casts error `Unable to initialize the Java DB: Java DB update failed: Java DB update error: '--skip-java-db-update'  cannot be specified on the first run` when running cdgxgen >= 10.4.3 with command `cdxgen --output backend_bom.json --type java --fail-on-error`
on docker images eclipse-temurin:21-jdk-alpine with Java applications packaged as .war. 

**FIX**: Disable Java scanning with Trivy for all Java archive files, not only .jar 

