### PR TITLE
Add support for build arguments in FROM instruction

### DIFF
--- a/test/data/Dockerfile
+++ b/test/data/Dockerfile
@@ -16,5 +16,24 @@ FROM hello-world:latest@sha256:1234567890abcdef
 # reusing previous build stage as new stage
 FROM HELLO as WORLD
 
+# image statement with base image name from build arg
+ARG BASE_IMAGE=docker.io/hello-world@sha256:1234567890abcdef
+FROM $BASE_IMAGE
+
+# image statement with base image name from build arg with curly braces
+ARG BASE_IMAGE=docker.io/hello-world:latest@sha256:1234567890abcdef
+FROM ${BASE_IMAGE}
+
+# image statement with multiple build args
+ARG IMAGE_REGISTRY=docker.io
+ARG IMAGE_NAME=hello-world
+ARG IMAGE_TAG="latest"
+ARG IMAGE_PATH=$IMAGE_NAME:$IMAGE_TAG
+FROM $IMAGE_REGISTRY/$IMAGE_PATH
+
+# image statement with base image name from build arg without default
+ARG BASE_IMAGE_WITHOUT_DEFAULT
+FROM $BASE_IMAGE_WITHOUT_DEFAULT
+
 # Commented out image statement
 # FROM hello-world

--- a/utils.test.js
+++ b/utils.test.js
@@ -4047,7 +4047,7 @@ test("parse containerfiles / dockerfiles", () => {
   const dep_list = parseContainerFile(
     readFileSync("./test/data/Dockerfile", { encoding: "utf-8" }),
   );
-  expect(dep_list.length).toEqual(4);
+  expect(dep_list.length).toEqual(7);
   expect(dep_list[0]).toEqual({
     image: "hello-world",
   });
@@ -4059,6 +4059,15 @@ test("parse containerfiles / dockerfiles", () => {
   });
   expect(dep_list[3]).toEqual({
     image: "hello-world:latest@sha256:1234567890abcdef",
+  });
+  expect(dep_list[4]).toEqual({
+    image: "docker.io/hello-world@sha256:1234567890abcdef",
+  });
+  expect(dep_list[5]).toEqual({
+    image: "docker.io/hello-world:latest@sha256:1234567890abcdef",
+  });
+  expect(dep_list[6]).toEqual({
+    image: "docker.io/hello-world:latest",
   });
 });
 


### PR DESCRIPTION
[`FROM` instructions support variables that are declared by any `ARG` instructions that occur before the first `FROM`.](https://docs.docker.com/reference/dockerfile/#understand-how-arg-and-from-interact)

I've added envsubst-a-like behaviour for image name parsing using default values of the `ARG` instructions.