### PR TITLE
IncludeLicenses and gradleToMaven features

### DIFF
--- a/server.js
+++ b/server.js
@@ -92,6 +92,7 @@ const parseQueryString = (q, body, options = {}) => {
     "includeFormulation",
     "includeCrypto",
     "standard",
+    "includeLicenses"
   ];
 
   for (const param of queryParams) {
@@ -176,6 +177,11 @@ const start = (options) => {
     }
     console.log("Generating SBOM for", srcDir);
     let bomNSData = (await createBom(srcDir, reqOptions)) || {};
+    if (reqOptions?.includeLicenses === false) {
+      bomNSData.bomJson.components.forEach((component) => {
+        delete component.licenses;
+      });
+    }
     bomNSData = postProcess(bomNSData, reqOptions);
     if (reqOptions.serverUrl && reqOptions.apiKey) {
       console.log(


### PR DESCRIPTION
Added the includeLicenses /sbom query parameter that allows the exclusion of license information from the SBOM, resolving the issue of ODT inability to avoid fetching license information.
Added gradleToMaven /sbom query parameter, applying the "if it works, it's not stupid" methodology to avoid interacting with Gradle while still being able to generate an SBOM.