### PR TITLE
build: use labels for changleog release section generation

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,26 @@
+changelog:
+  categories:
+    - title: 🚀 Features
+      labels:
+        - enhancement
+    - title: 🐛 Bug Fixes
+      labels:
+        - bug
+    - title: 🧼 Code Refactoring
+      labels:
+        - refactor
+    - title: 📚 Documentation
+      labels:
+        - documentation
+    - title: 🧪 Testing
+      labels:
+        - test
+    - title: 🏗️ Build System
+      labels:
+        - build
+    - title: 📦 Dependency Updates
+      labels:
+        - dependency
+    - title: Other Changes
+      labels:
+        - "*"


### PR DESCRIPTION
per https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes

Use the "standard" labels to group release notes into sections. closes #1311 

Would love to discuss if other label groups like lang:* etc are of interest, and if so, how would they appear in a changelog 🤔 

separately, we can discuss adopting something like https://github.com/fuxingloh/multi-labeler, which i've used in other projects (see [gitify-app/gitify](https://github.com/gitify-app/gitify)) to automatically apply labels based on a pretty powerful config file (for the purposes of ensuring all PRs are labels for release note bliss)