### PR TITLE
fixed null error in utils.js

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -7379,6 +7379,9 @@ export function parseCsProjAssetsData(csProjData, assetsJsonFile) {
   // extract name, operator, version from .NET package representation
   // like "NLog >= 4.5.0"
   function extractNameOperatorVersion(inputStr) {
+    if (!inputStr) {
+      return null;
+    }
     const extractNameOperatorVersion = /([\w.-]+)\s*([><=!]+)\s*([\d.]+)/;
     const match = inputStr.match(extractNameOperatorVersion);
 


### PR DESCRIPTION
When I test cdxgen on [SteamTools](https://github.com/BeyondDimension/SteamTools) repo on C# I get "TypeError: Cannot read properties of null (reading 'match')" on
    const match = inputStr.match(extractNameOperatorVersion);
line 7383
