### PR TITLE
Make sure composer.lock dependency package version is a string

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -7871,7 +7871,7 @@ export function parseComposerLock(pkgLockFile, rootRequires) {
             "composer",
             group,
             name,
-            pkg.version,
+            pkg.version?.toString(),
             null,
             null,
           ).toString();
@@ -7880,7 +7880,7 @@ export function parseComposerLock(pkgLockFile, rootRequires) {
             name: name,
             purl,
             "bom-ref": decodeURIComponent(purl),
-            version: pkg.version,
+            version: pkg.version?.toString(),
             repository: pkg.source,
             license: pkg.license,
             description: pkg.description,


### PR DESCRIPTION
`composer.lock` files may have a dependency package version as a number instead of a string (see: https://github.com/google/osv-scanner/issues/1138).
In that case `new PackageURL(...)` throws the following error: `Error: Invalid purl: "versions" argument must be a string.`

By forcing the number to be interpreted as a string (with `.toString()`), the error disappears. The same string conversion is done for the version generated in the SBOM as it should also be a string.