### PR TITLE
[Gradle] Fixed incorrect PURLs & BOM-REFs

### DIFF
--- a/index.js
+++ b/index.js
@@ -1686,11 +1686,11 @@ export async function createJavaBom(path, options) {
               null,
             ).toString();
             rootSubProjectObj["purl"] = rootSubProjectPurl;
-            rootSubProjectObj["bom-ref"] =
-              decodeURIComponent(rootSubProjectPurl);
+            const rootSubProjectBomRef = decodeURIComponent(rootSubProjectPurl);
+            rootSubProjectObj["bom-ref"] = rootSubProjectBomRef;
             if (!allProjectsAddedPurls.includes(rootSubProjectPurl)) {
               allProjects.push(rootSubProjectObj);
-              rootDependsOn.push(rootSubProjectPurl);
+              rootDependsOn.push(rootSubProjectBomRef);
               allProjectsAddedPurls.push(rootSubProjectPurl);
             }
           }
@@ -1720,11 +1720,11 @@ export async function createJavaBom(path, options) {
               null,
             ).toString();
             rootSubProjectObj["purl"] = rootSubProjectPurl;
-            rootSubProjectObj["bom-ref"] =
-              decodeURIComponent(rootSubProjectPurl);
+            const rootSubProjectBomRef = decodeURIComponent(rootSubProjectPurl);
+            rootSubProjectObj["bom-ref"] = rootSubProjectBomRef;
             if (!allProjectsAddedPurls.includes(rootSubProjectPurl)) {
               allProjects.push(rootSubProjectObj);
-              rootDependsOn.push(rootSubProjectPurl);
+              rootDependsOn.push(rootSubProjectBomRef);
               allProjectsAddedPurls.push(rootSubProjectPurl);
             }
           }

--- a/utils.js
+++ b/utils.js
@@ -2608,7 +2608,7 @@ export function parseGradleDep(
               version = undefined;
             }
           }
-          let purlString = new PackageURL(
+          const purl = new PackageURL(
             "maven",
             group !== "project" ? group : rootProjectGroup,
             name,
@@ -2616,7 +2616,7 @@ export function parseGradleDep(
             { type: "jar" },
             null,
           ).toString();
-          purlString = decodeURIComponent(purlString);
+          const purlString = decodeURIComponent(purl);
           keys_cache[`${purlString}_${last_purl}`] = true;
           // Filter duplicates
           if (!deps_keys_cache[purlString]) {
@@ -2627,8 +2627,8 @@ export function parseGradleDep(
               version: version !== undefined ? version : rootProjectVersion,
               qualifiers: { type: "jar" },
             };
-            adep["purl"] = purlString;
-            adep["bom-ref"] = decodeURIComponent(purlString);
+            adep["purl"] = purl;
+            adep["bom-ref"] = purlString;
             if (scope) {
               adep["scope"] = scope;
             }


### PR DESCRIPTION
This PR fixes issues in the `purl` and `bom-ref` when your module names use characters other than letters or numbers.

I found that some of my modules (generated by expo) had names like 'expo-modules-core$android-annotation-processor', which were sometimes correctly percent encoded in the `purl` and sometimes they weren't. Same with the `bom-ref`, which actually caused cdxgen to output (only in debug):
```
===== WARNINGS =====
[
  'Invalid ref in dependencies.dependsOn pkg:maven/host.exp.exponent/expo-modules-core%24android-annotation-processor@1.1.1?type=jar',
  'Invalid ref in dependencies.dependsOn pkg:maven/host.exp.exponent/expo-modules-core%24android-annotation@1.1.1?type=jar'
]
```

I do wonder though why the incorrect `purl` wasn't a problem in the validation process...