### PR TITLE
test: ensure all *.test.js files are being run

### DIFF
--- a/envcontext.test.js
+++ b/envcontext.test.js
@@ -12,7 +12,6 @@ import {
   getBranch,
   getOriginUrl,
   isNvmAvailable,
-  isNvmToolAvailable,
   isSdkmanAvailable,
   isSdkmanToolAvailable,
   listFiles,
@@ -45,6 +44,5 @@ test("sdkman tests", () => {
 test("nvm tests", () => {
   if (process.env?.SDKMAN_VERSION) {
     expect(isNvmAvailable()).toBeTruthy();
-    expect(isNvmToolAvailable("22")).toBeTruthy();
   }
 });

--- a/envcontext.test.js
+++ b/envcontext.test.js
@@ -12,6 +12,7 @@ import {
   getBranch,
   getOriginUrl,
   isNvmAvailable,
+  isNvmToolAvailable,
   isSdkmanAvailable,
   isSdkmanToolAvailable,
   listFiles,
@@ -44,5 +45,6 @@ test("sdkman tests", () => {
 test("nvm tests", () => {
   if (process.env?.SDKMAN_VERSION) {
     expect(isNvmAvailable()).toBeTruthy();
+    expect(isNvmToolAvailable("22")).toBeTruthy();
   }
 });

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "cdx-verify": "bin/verify.js"
   },
   "scripts": {
-    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --inject-globals false **/*.test.js",
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --inject-globals false --testPathIgnorePatterns envcontext.test.js",
     "watch": "node --experimental-vm-modules node_modules/jest/bin/jest.js --watch --inject-globals false",
     "lint:check": "biome check",
     "lint": "biome check --fix",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "cdx-verify": "bin/verify.js"
   },
   "scripts": {
-    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --inject-globals false docker.test.js utils.test.js display.test.js postgen.test.js",
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --inject-globals false **/*.test.js",
     "watch": "node --experimental-vm-modules node_modules/jest/bin/jest.js --watch --inject-globals false",
     "lint:check": "biome check",
     "lint": "biome check --fix",


### PR DESCRIPTION
Not sure if there is a reason that only a subset of *.test.js are being run...

I did find that parts of envcontext.test.js fails locally for me