### PR TITLE
Fix: `nvm tests` in `envcontext.test.js`

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Sections include:
 ## Installing
 
 ```shell
-npm install -g @cyclonedx/cdxgen@10.9.8
+npm install -g @cyclonedx/cdxgen@10.9.9
 ```
 
 If you are a [Homebrew][homebrew-homepage] user, you can also install [cdxgen][homebrew-cdxgen] via:
@@ -403,7 +403,7 @@ To generate test public/private key pairs, you can run cdxgen by passing the arg
 Use the bundled `cdx-verify` command, which supports verifying a single signature added at the bom level.
 
 ```shell
-npm install -g @cyclonedx/cdxgen@10.9.8
+npm install -g @cyclonedx/cdxgen@10.9.9
 cdx-verify -i bom.json --public-key public.key
 ```
 

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@cyclonedx/cdxgen",
-  "version": "10.9.8",
+  "version": "10.9.9",
   "exports": "./index.js",
   "compilerOptions": {
     "allowJs": true,

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -21,7 +21,7 @@ flowchart LR
 ## Installing
 
 ```shell
-sudo npm install -g @cyclonedx/cdxgen@10.9.8
+sudo npm install -g @cyclonedx/cdxgen@10.9.9
 ```
 
 If you are a [Homebrew](https://brew.sh/) user, you can also install [cdxgen](https://formulae.brew.sh/formula/cdxgen) via:

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,7 @@ cdxgen is available as an npm package, container image, and single application e
 ## Installation
 
 ```shell
-sudo npm install -g @cyclonedx/cdxgen@10.9.8
+sudo npm install -g @cyclonedx/cdxgen@10.9.9
 ```
 
 If you are a [Homebrew](https://brew.sh/) user, you can also install [cdxgen](https://formulae.brew.sh/formula/cdxgen) via:
@@ -63,7 +63,7 @@ cdxgen -t c -o bom.json
 ## Installation
 
 ```shell
-sudo npm install -g @cyclonedx/cdxgen@10.9.8
+sudo npm install -g @cyclonedx/cdxgen@10.9.9
 ```
 
 ## Usage
@@ -237,7 +237,7 @@ To generate test public/private key pairs, you can run cdxgen by passing the arg
 Use the bundled `cdx-verify` command, which supports verifying a single signature added at the bom level.
 
 ```shell
-npm install -g @cyclonedx/cdxgen@10.9.8
+npm install -g @cyclonedx/cdxgen@10.9.9
 cdx-verify -i bom.json --public-key public.key
 ```
 

--- a/envcontext.test.js
+++ b/envcontext.test.js
@@ -55,7 +55,6 @@ test("nvm tests", () => {
           shell: process.env.SHELL || true,
         },
       );
-      console.log(removeNode14.stdout);
 
       // expected to be run in CircleCi, where node version is 22.8.0
       // as defined in our Dockerfile

--- a/envcontext.test.js
+++ b/envcontext.test.js
@@ -65,7 +65,7 @@ test("nvm tests", () => {
       expect(getOrInstallNvmTool(14)).toBeTruthy();
       expect(getNvmToolDirectory(14)).toBeTruthy();
     } else {
-      // if this test is failing it would be due to isNvmAvailable()
+      // if this test is failing it would be due to an error in isNvmAvailable()
       expect(getNvmToolDirectory(22)).toBeFalsy();
       expect(getOrInstallNvmTool(14)).toBeFalsy();
     }

--- a/envcontext.test.js
+++ b/envcontext.test.js
@@ -41,10 +41,3 @@ test("sdkman tests", () => {
     expect(isSdkmanToolAvailable("java", "22.0.1-tem")).toBeTruthy();
   }
 });
-
-test("nvm tests", () => {
-  if (process.env?.SDKMAN_VERSION) {
-    expect(isNvmAvailable()).toBeTruthy();
-    expect(isNvmToolAvailable("22")).toBeTruthy();
-  }
-});

--- a/envcontext.test.js
+++ b/envcontext.test.js
@@ -1,6 +1,6 @@
+import { spawnSync } from "node:child_process";
 import process from "node:process";
 import { expect, test } from "@jest/globals";
-
 import {
   collectDotnetInfo,
   collectGccInfo,
@@ -10,7 +10,10 @@ import {
   collectPythonInfo,
   collectRustInfo,
   getBranch,
+  getNvmToolDirectory,
+  getOrInstallNvmTool,
   getOriginUrl,
+  isNvmAvailable,
   isSdkmanAvailable,
   isSdkmanToolAvailable,
   listFiles,
@@ -37,5 +40,35 @@ test("sdkman tests", () => {
   if (process.env?.SDKMAN_VERSION) {
     expect(isSdkmanAvailable()).toBeTruthy();
     expect(isSdkmanToolAvailable("java", "22.0.1-tem")).toBeTruthy();
+  }
+});
+
+test("nvm tests", () => {
+  if (process.env?.NVM_DIR) {
+    if (isNvmAvailable()) {
+      // try to remove nodejs 14 before testing below
+      const removeNode14 = spawnSync(
+        process.env.SHELL || "bash",
+        ["-i", "-c", `"nvm uninstall 14"`],
+        {
+          encoding: "utf-8",
+          shell: process.env.SHELL || true,
+        },
+      );
+      console.log(removeNode14.stdout);
+
+      // expected to be run in CircleCi, where node version is 22.8.0
+      // as defined in our Dockerfile
+      expect(getNvmToolDirectory(22)).toBeTruthy();
+      expect(getNvmToolDirectory(14)).toBeFalsy();
+
+      // now we install nvm tool for a specific verison
+      expect(getOrInstallNvmTool(14)).toBeTruthy();
+      expect(getNvmToolDirectory(14)).toBeTruthy();
+    } else {
+      // if this test is failing it would be due to isNvmAvailable()
+      expect(getNvmToolDirectory(22)).toBeFalsy();
+      expect(getOrInstallNvmTool(14)).toBeFalsy();
+    }
   }
 });

--- a/envcontext.test.js
+++ b/envcontext.test.js
@@ -11,8 +11,6 @@ import {
   collectRustInfo,
   getBranch,
   getOriginUrl,
-  isNvmAvailable,
-  isNvmToolAvailable,
   isSdkmanAvailable,
   isSdkmanToolAvailable,
   listFiles,

--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@cyclonedx/cdxgen",
-  "version": "10.9.8",
+  "version": "10.9.9",
   "exports": "./index.js",
   "include": ["*.js", "bin/**", "data/**", "types/**"],
   "exclude": ["test/", "docs/", "contrib/", "ci/", "tools_config/"]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cyclonedx/cdxgen",
-  "version": "10.9.8",
+  "version": "10.9.9",
   "description": "Creates CycloneDX Software Bill of Materials (SBOM) from source or container image",
   "homepage": "http://github.com/cyclonedx/cdxgen",
   "author": "Prabhu Subramanian <prabhu@appthreat.com>",

--- a/pregen.js
+++ b/pregen.js
@@ -1,10 +1,9 @@
-import { spawn, spawnSync } from "node:child_process";
+import { spawnSync } from "node:child_process";
 import { mkdtempSync, readdirSync } from "node:fs";
 import { arch, platform, tmpdir } from "node:os";
 import { delimiter, join } from "node:path";
 import {
   SDKMAN_TOOL_ALIASES,
-  getNvmToolDirectory,
   getOrInstallNvmTool,
   installSdkmanTool,
   isNvmAvailable,
@@ -228,10 +227,10 @@ export function doNpmInstall(filePath, nvmNodePath) {
     // There was some problem with NpmInstall
     if (DEBUG_MODE) {
       if (console.stdout) {
-        console.log(result.stdout);
+        console.log(resultNpmInstall.stdout);
       }
       if (console.stderr) {
-        console.log(result.stderr);
+        console.log(resultNpmInstall.stderr);
       }
     }
   }

--- a/pregen.js
+++ b/pregen.js
@@ -184,7 +184,7 @@ export function tryLoadNvmAndInstallTool(nodeVersion) {
       fi
       `;
 
-  const spawnedShell = spawnSync(process.env.SHELL || "bash", ["-c", command], {
+  const result = spawnSync(process.env.SHELL || "bash", ["-c", command], {
     encoding: "utf-8",
     shell: process.env.SHELL || true,
   });


### PR DESCRIPTION
Fix `nvm tests` in `envcontext.test.js`.
It should test the following functions:
1) `getNvmToolDirectory`
2) `getOrInstallNvmTool`
4) `isNvmAvailable`

there are some issues here as CircleCI does not actually have `nvm` but does have `NVM_DIR` in `env`.