### PR TITLE
Handling sub-components of the root component the same as all other components

### DIFF
--- a/index.js
+++ b/index.js
@@ -557,6 +557,11 @@ function addMetadata(parentComponent = {}, options = {}, context = {}) {
       }
     }
     if (parentComponent?.components) {
+      parentComponent.components = listComponents(
+        options,
+        {},
+        parentComponent.components,
+      );
       const parentFullName = componentToSimpleFullName(parentComponent);
       const subComponents = [];
       const addedSubComponents = {};


### PR DESCRIPTION
After adding the option to resolve Gradle modules from NPM packages and adding the new SBOM in Dependency-Track, I noticed the components didn't have licenses set. Checking the actual packages if they actually have licenses configured, I found that the licenses were removed on sub-components of the root component.

This PR fixes this issue and uses the same method(s) to convert the 'temporary' objects to their correct SBOM counterparts.

I just noticed this removes all code that fixed #479, but all tests are still running and my projects also work like before... If anybody has some Gradle projects they could run through it before we merge, that would be great!