### PR TITLE
[Gradle] Don't use full multi-threading, SBOMs can be completely wrong

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -10072,9 +10072,12 @@ export function buildGradleCommandArguments(
   gradleSubCommands,
   gradleSubCommandArguments,
 ) {
-  let allGradleArguments = ["--console", "plain", "--build-cache"].concat(
-    gradleArguments,
-  );
+  let allGradleArguments = [
+    "--build-cache",
+    "--console",
+    "plain",
+    "--no-parallel",
+  ].concat(gradleArguments);
   for (const gradleSubCommand of gradleSubCommands) {
     allGradleArguments.push(gradleSubCommand);
     allGradleArguments = allGradleArguments.concat(gradleSubCommandArguments);


### PR DESCRIPTION
When using the feature `GRADLE_MULTI_THREADED` on large projects, the output of the dependency-tree can be mangled and there is no guarantee the same SBOM is generated between multiple runs!

To fix this, I added the parameter '--no-parallel' to the Gradle-command, which in my tests didn't show a significant difference in duration. The output SBOM however was consistent every time, although in one of the projects there is a difference with the non-multithreaded version in the versions of dependencies!
Unfortunately this is caused by Gradle itself -- manual inspection of the outputs of all commands shows, that Gradle is actually reporting different versions of dependencies for some modules in the project! I *assume* this is something similar to Maven: because there can only be 1 version of a JAR in the classpath, it gets corrected to specific version (by whatever kind of resolution). This would mean, that the current non-multithreaded version would actually be reporting false dependencies in some cases...