### PR TITLE
[Gradle] Fixed a problem with scoped NPM packages while resolving modules from NPM

### DIFF
--- a/.github/workflows/repotests.yml
+++ b/.github/workflows/repotests.yml
@@ -249,6 +249,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: 'malice00/cdxgen-expo-test'
+          ref: 'android'
           path: 'repotests/expo-test'
       - uses: dtolnay/rust-toolchain@stable
       - name: setup sdkman


### PR DESCRIPTION
When resolving the Gradle modules from NPM packages, there was an issue when the package was scoped. Because the package was referenced by its name, which in Gradle gets its scope added, the call to resolve dependencies used the wrong module-name.