### PR TITLE
[Gradle] Added deep-scanning of gradle modules

### DIFF
--- a/.github/workflows/repotests.yml
+++ b/.github/workflows/repotests.yml
@@ -249,6 +249,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: 'malice00/cdxgen-expo-test'
+          ref: 'android'
           path: 'repotests/expo-test'
       - uses: dtolnay/rust-toolchain@stable
       - name: setup sdkman

--- a/index.js
+++ b/index.js
@@ -1652,20 +1652,7 @@ export async function createJavaBom(path, options) {
         );
 
         for (const [key, propTaskOut] of splitPropTaskOut.entries()) {
-          let retMap = {};
-          // To optimize performance and reduce errors do not query for properties
-          // beyond the first level. Replicating behaviour from single-threaded Gradle generation.
-          if (key.includes(":")) {
-            retMap = {
-              rootProject: key,
-              projects: [],
-              metadata: {
-                version: "latest",
-              },
-            };
-          } else {
-            retMap = parseGradleProperties(propTaskOut);
-          }
+          const retMap = parseGradleProperties(propTaskOut);
           const rootSubProject = retMap.rootProject;
           if (rootSubProject) {
             const rootSubProjectObj = await buildObjectForGradleModule(

--- a/utils.js
+++ b/utils.js
@@ -2981,11 +2981,6 @@ export function executeGradleProperties(dir, subProject) {
       version: "latest",
     },
   };
-  // To optimize performance and reduce errors do not query for properties
-  // beyond the first level
-  if (subProject && subProject.match(/:/g).length >= 2) {
-    return defaultProps;
-  }
   const gradleCmd = getGradleCommand(dir, null);
   const gradleArguments = buildGradleCommandArguments(
     process.env.GRADLE_ARGS ? process.env.GRADLE_ARGS.split(" ") : [],


### PR DESCRIPTION
For performance-reasons, scanning of Gradle modules was disabled for modules deeper than the first level. This does however mean that your module information might be wrong. Performance obviously depends on the number of modules lower than first level, but using the multi-threaded version of the Gradle scanner makes this negligible.

Currently the optimization is just removed, I could however also add a switch (eg with an EnvVar) to (de-)activate it, although personally I think the scan should be complete and not use any (sometimes weird) defaults.

Also, for testing, I could maybe add fineract to the repotests...

Note: this fix builds on #1379!