### PR TITLE
search only for Bazel workspace and module files

### DIFF
--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -1837,7 +1837,7 @@ export async function createJavaBom(path, options) {
   // NOTE: This can match BUILD files used by perl, so could lead to errors in some projects
   const bazelFiles = getAllFiles(
     path,
-    `${options.multiProject ? "**/" : ""}BUILD{,.bazel}`,
+    `${options.multiProject ? "**/" : ""}{WORKSPACE{,.bazel},MODULE.bazel}`,
     options,
   );
   if (


### PR DESCRIPTION
As described in the issue https://github.com/CycloneDX/cdxgen/issues/1370 the newest release of cdxgen will match on non-bazel projects f.ex when finding `build.gradle` files. Changing the search to look for `WORKSPACE`, `WORKSPACE.bazel` and `MODULE.bazel` files.