### PR TITLE
Duplicate properties

### DIFF
--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -5473,19 +5473,20 @@ export function trimComponents(components) {
     } else {
       const existingComponent = keyCache[key];
       // We need to retain any properties that differ
-      const compProps = existingComponent.properties || [];
-      const compPropsMap = {};
-      for (const aprop of compProps) {
-        compPropsMap[aprop.name] = aprop.value;
-      }
       if (comp.properties) {
-        for (const newprop of comp.properties) {
-          if (
-            !compPropsMap[newprop.name] ||
-            (newprop.value && compPropsMap[newprop.name] !== newprop.value)
-          ) {
-            compProps.push(newprop);
+        if (existingComponent.properties) {
+          for (const newprop of comp.properties) {
+            if (
+              !existingComponent.properties.find(
+                (prop) =>
+                  prop.name === newprop.name && prop.value === newprop.value,
+              )
+            ) {
+              existingComponent.properties.push(newprop);
+            }
           }
+        } else {
+          existingComponent.properties = comp.properties;
         }
       }
       // If the component is required in any of the child projects, then make it required
@@ -5494,11 +5495,6 @@ export function trimComponents(components) {
         comp?.scope === "required"
       ) {
         existingComponent.scope = "required";
-        keyCache[key] = existingComponent;
-      }
-      if (compProps.length) {
-        existingComponent.properties = compProps;
-        keyCache[key] = existingComponent;
       }
     }
   }

--- a/lib/helpers/utils.js
+++ b/lib/helpers/utils.js
@@ -2694,7 +2694,7 @@ export async function parseGradleDep(
         last_bomref = last_project_bomref;
         stack = [first_bomref];
       }
-      if (rline.includes(" - ")) {
+      if (rline.includes(" - ") && !rline.startsWith("Project ':")) {
         profileName = rline.split(" - ")[0];
         if (profileName.toLowerCase().includes("test")) {
           scope = "optional";


### PR DESCRIPTION
This fixes both the duplicate properties (#1401) and, for Gradle, the usage of a project name as a profile.

The issue for the duplicate properties was not in Gradle-specific code, so this could influence/fix issues with duplicate properties for other languages/tools as well!