### PR TITLE
Bump cjd version for bugfixes.

### DIFF
--- a/test/diff/requirements.txt
+++ b/test/diff/requirements.txt
@@ -1,1 +1,1 @@
-custom-json-diff~=2.0.0
+custom-json-diff~=2.1.0


### PR DESCRIPTION
This PR bumps the CJD version to 2.1.x, which included bugfixes for circumstances currently causing snapshot tests to fail when they should pass (e.g. #1426).