### PR TITLE
Run some GitHub action jobs only on main repository

### DIFF
--- a/.github/workflows/app-release.yml
+++ b/.github/workflows/app-release.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   pkg:
+    if: github.repository == 'CycloneDX/cdxgen'
     # use ubuntu-20.04 due to avoid glic errors
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -4,6 +4,7 @@ on: [workflow_dispatch]
 
 jobs:
   build:
+    if: github.repository == 'CycloneDX/cdxgen'
     # use ubuntu-20.04 due to avoid glic errors
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/binary-builds.yml
+++ b/.github/workflows/binary-builds.yml
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
   sae-builds:
+    if: github.repository == 'CycloneDX/cdxgen'
     strategy:
       matrix:
         os: [windows-latest]

--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -14,6 +14,7 @@ env:
 
 jobs:
   pkg:
+    if: github.repository == 'CycloneDX/cdxgen'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -51,6 +52,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   containers:
+    if: github.repository == 'CycloneDX/cdxgen'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -124,6 +126,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   containers-deno:
+    if: github.repository == 'CycloneDX/cdxgen'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -175,6 +178,7 @@ jobs:
         cache-from: type=gha,scope=cdxgen-deno
         cache-to: type=gha,mode=max,scope=cdxgen-deno
   containers-ppc64:
+    if: github.repository == 'CycloneDX/cdxgen'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -226,6 +230,7 @@ jobs:
         cache-from: type=gha,scope=cdxgen-ppc64
         cache-to: type=gha,mode=max,scope=cdxgen-ppc64
   containers-bun:
+    if: github.repository == 'CycloneDX/cdxgen'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/nydus-demo.yml
+++ b/.github/workflows/nydus-demo.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
 jobs:
   build:
+    if: github.repository == 'CycloneDX/cdxgen'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Fixes https://github.com/CycloneDX/cdxgen/issues/1437.

All GitHub actions that are not triggered by `pull_request` event should not be run on forks.