### PR TITLE
Enable CycloneDX 1.5 snapshots to be compared with 1.6.

### DIFF
--- a/.github/workflows/snapshot-tests.yml
+++ b/.github/workflows/snapshot-tests.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Test BOMs
         run: |
-          python test/diff/diff_tests.py
+          python test/diff/diff_tests.py --migrate-legacy
           if test -f /home/runner/work/new_snapshots/diffs.json; then
             echo "status=FAILED" >> "$GITHUB_ENV"
           fi


### PR DESCRIPTION
This PR adds a command-line option to handle the change to CycloneDX 1.6 for the snapshot tests. When the original snapshot is v1.5, the data will be migrated to v1.6 if the `--migrate-legacy` argument is given when running diff_tests.py.