### PR TITLE
Fix Index Boundary Error in parseCmakeLikeFile

### DIFF
--- a/lib/helpers/utils.js
+++ b/lib/helpers/utils.js
@@ -11680,7 +11680,8 @@ export function parseCmakeLikeFile(cmakeListFile, pkgType, options = {}) {
           .split(")")[0]
           .split(",")
           .filter((v) => v.length > 1);
-        const parentName = tmpB[0].replace(":", "");
+        const parentName =
+          tmpB.length > 0 ? tmpB[0].replace(":", "").trim() : "";
         let parentVersion = undefined;
         // In case of meson.build we can find the version number after the word version
         // thanks to our replaces and splits

--- a/lib/helpers/utils.js
+++ b/lib/helpers/utils.js
@@ -10814,11 +10814,6 @@ export function getPipFrozenTree(
             "Install suitable version of python or set the environment variable PYTHON_CMD.",
           );
         }
-        if (!result.stderr) {
-          console.log(
-            "Ensure the virtualenv package is installed using pip. `python -m pip install virtualenv`",
-          );
-        }
       }
     } else {
       if (DEBUG_MODE) {


### PR DESCRIPTION
# Changes
- Avoids triggering an exception for referencing an invalid index in `parseCmakeLikeFile`.
- Removes message indicating to the user that they need to install virtualenv (regardless of whether virtual environment creation failed). We are using _venv_ which is a subset of virtualenv that has been part of the Python standard library since Python 3.3.