### PR TITLE
Remove duplicates when resolving Gradle dependencies from Node

### DIFF
--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -6083,11 +6083,24 @@ export async function createMultiXBom(pathList, options) {
         ) {
           parentSubComponents.push(bomData.parentComponent);
         }
-        // Retain metadata.component.components
+        // Retain metadata.component.components, but add duplicates to the list of current components
+        // and removing them from metadata.component.components -- the components are merged later
         if (bomData.parentComponent.components?.length) {
-          parentSubComponents = parentSubComponents.concat(
-            bomData.parentComponent.components,
-          );
+          let bomSubComponents = bomData.parentComponent.components;
+          if (["true", "1"].includes(process.env.GRADLE_RESOLVE_FROM_NODE)) {
+            const allRefs = components.map((c) => c["bom-ref"]);
+            const duplicateComponents = bomSubComponents.filter((c) =>
+              allRefs.includes(c["bom-ref"]),
+            );
+            components = components.concat(duplicateComponents);
+            const duplicateComponentRefs = duplicateComponents.map(
+              (c) => c["bom-ref"],
+            );
+            bomSubComponents = bomSubComponents.filter(
+              (c) => !duplicateComponentRefs.includes(c["bom-ref"]),
+            );
+          }
+          parentSubComponents = parentSubComponents.concat(bomSubComponents);
           delete bomData.parentComponent.components;
         }
       }


### PR DESCRIPTION
A while back, I added a feature for Gradle-projects to resolve their dependencies from Node. Now, with the correct implementation of multi-language SBOMs, these dependencies were added twice. This fix removes any duplicates -- both components and dependencies by merging them into the existing ones.