### PR TITLE
fix dart where no project is specified

### DIFF
--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -3959,7 +3959,7 @@ export async function createDartBom(path, options) {
   );
   let dependencies = [];
   let pkgList = [];
-  const parentComponent = determineParentComponent(options);
+  const parentComponent = createDefaultParentComponent(path, "pub", options);
   if (pubFiles.length) {
     for (const f of pubFiles) {
       if (DEBUG_MODE) {

--- a/lib/helpers/utils.js
+++ b/lib/helpers/utils.js
@@ -7442,7 +7442,7 @@ export async function parsePubLockData(pubLockData) {
       pkg._integrity = `sha256-${packageData.description?.sha256}`;
     }
 
-    const purlString = new PackageURL("dart", "", pkg.name, pkg.version)
+    const purlString = new PackageURL("pub", "", pkg.name, pkg.version)
       .toString()
       .replace(/%2F/g, "/");
     pkg["bom-ref"] = decodeURIComponent(purlString);

--- a/lib/helpers/utils.test.js
+++ b/lib/helpers/utils.test.js
@@ -2086,7 +2086,7 @@ test("parse pub lock", async () => {
     version: "2.11.0",
     _integrity:
       "sha256-947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c",
-    "bom-ref": "pkg:dart/async@2.11.0",
+    "bom-ref": "pkg:pub/async@2.11.0",
     scope: "required",
   });
   expect(root_list.length).toEqual(3);
@@ -2095,7 +2095,7 @@ test("parse pub lock", async () => {
     version: "3.0.2",
     _integrity:
       "sha256-99d63c60f00fac81249ce6410ee015d7b125c63d8278a30da81edf3317a1f6a0",
-    "bom-ref": "pkg:dart/flare_flutter@3.0.2",
+    "bom-ref": "pkg:pub/flare_flutter@3.0.2",
     scope: "required",
   });
   dep_list = parsePubYamlData(


### PR DESCRIPTION
Fix for https://github.com/CycloneDX/cdxgen/pull/1564

Fix: package type to pub
Fix: creating finding parentComponent to use default if no options passed

@malice00 i dont think I can manually rerun those tests