### PR TITLE
fix: install setuptools and wheel before installing requirements

### DIFF
--- a/.github/workflows/snapshot-tests.yml
+++ b/.github/workflows/snapshot-tests.yml
@@ -38,6 +38,7 @@ jobs:
            sudo npm install -g "$cdxgen_tarball"
            git clone https://github.com/appthreat/cdxgen-samples.git original_snapshots
            python3.12 -m venv .venv
+           source .venv/bin/activate && pip install setuptools wheel
            source .venv/bin/activate && pip install -r test/diff/requirements.txt
 
       - name: Generate scripts


### PR DESCRIPTION
Fix the issue #1531 
By installing setuptools and wheel before installing requirements.txt