### PR TITLE
[Gradle] SBOM generation didn't work on Windows

### DIFF
--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -2129,32 +2129,36 @@ export async function createJavaBom(path, options) {
       process.env.GRADLE_ARGS_DEPENDENCIES
         ? process.env.GRADLE_ARGS_DEPENDENCIES.split(" ")
         : [],
+      gradleCmd.length,
     );
-    if (DEBUG_MODE) {
-      console.log(
-        "Executing",
-        gradleCmd,
-        `${gradleArguments.join(" ").substring(0, 150)} ...`,
-        "in",
-        gradleRootPath,
-      );
-    }
-    thoughtLog(
-      `Let's invoke '${basename(gradleCmd)}' with the arguments '${gradleArguments.join(" ").substring(0, 100)} ...'.`,
-    );
-    const sresult = spawnSync(gradleCmd, gradleArguments, {
-      cwd: gradleRootPath,
-      encoding: "utf-8",
-      timeout: TIMEOUT_MS,
-      maxBuffer: MAX_BUFFER,
-    });
-    if (sresult.status !== 0 || sresult.error) {
-      if (options.failOnError || DEBUG_MODE) {
-        console.error(sresult.stdout, sresult.stderr);
+    const allOutputs = [];
+    for (const gradleArg of gradleArguments) {
+      if (DEBUG_MODE) {
+        console.log(
+          `Executing ${gradleCmd} with arguments ${gradleArg.join(" ").substring(0, 150)}... in ${gradleRootPath}`,
+        );
       }
-      options.failOnError && process.exit(1);
+      thoughtLog(
+        `Let's invoke '${basename(gradleCmd)}' with the arguments '${gradleArguments.join(" ").substring(0, 100)} ...'.`,
+      );
+      const sresult = spawnSync(gradleCmd, gradleArg, {
+        cwd: gradleRootPath,
+        encoding: "utf-8",
+        shell: isWin,
+        timeout: TIMEOUT_MS,
+        maxBuffer: MAX_BUFFER,
+      });
+      if (sresult.status !== 0 || sresult.error) {
+        if (options.failOnError || DEBUG_MODE) {
+          console.error(sresult.stdout, sresult.stderr);
+        }
+        options.failOnError && process.exit(1);
+      }
+      if (sresult.stdout !== null) {
+        allOutputs.push(sresult.stdout);
+      }
     }
-    const sstdout = sresult.stdout;
+    const sstdout = allOutputs.join("\n");
     if (sstdout) {
       const cmdOutput = Buffer.from(sstdout).toString();
       const perProjectOutput = splitOutputByGradleProjects(cmdOutput, [

--- a/lib/helpers/utils.js
+++ b/lib/helpers/utils.js
@@ -4011,61 +4011,68 @@ export function executeParallelGradleProperties(dir, allProjectsStr) {
     process.env.GRADLE_ARGS_PROPERTIES
       ? process.env.GRADLE_ARGS_PROPERTIES.split(" ")
       : [],
+    gradleCmd.length,
   );
-  if (DEBUG_MODE) {
-    console.log(
-      `Executing ${gradleCmd} with arguments ${gradleArgs.join(" ").substring(0, 150)}... in ${dir}`,
-    );
-  }
-  const result = spawnSync(gradleCmd, gradleArgs, {
-    cwd: dir,
-    encoding: "utf-8",
-    shell: isWin,
-    maxBuffer: MAX_BUFFER,
-  });
-  if (result.status !== 0 || result.error) {
-    if (process.env?.CDXGEN_IN_CONTAINER === "true") {
-      thoughtLog(
-        "Gradle build has failed. Perhaps the user is using the wrong container image?",
-      );
-    } else {
-      thoughtLog(
-        "Gradle build has failed. I recommend using Java container images.",
+  const allOutputs = [];
+  for (const gradleArg of gradleArgs) {
+    if (DEBUG_MODE) {
+      console.log(
+        `Executing ${gradleCmd} with arguments ${gradleArg.join(" ").substring(0, 150)}... in ${dir}`,
       );
     }
-    if (result.stderr) {
-      console.group("*** GRADLE BUILD ERRORS ***");
-      console.error(result.stdout, result.stderr);
-      console.groupEnd();
-      console.log(
-        "1. Check if the correct version of java and gradle are installed and available in PATH. For example, some project might require Java 11 with gradle 7.\n cdxgen container image bundles Java 23 with gradle 8 which might be incompatible.",
-      );
-      console.log(
-        "2. Try running cdxgen with the custom JDK11-based image `ghcr.io/cyclonedx/cdxgen-java11:v11`.",
-      );
-      if (result.stderr?.includes("not get unknown property")) {
-        console.log(
-          "3. Check if the SBOM is generated for the correct root project for your application.",
+    const result = spawnSync(gradleCmd, gradleArg, {
+      cwd: dir,
+      encoding: "utf-8",
+      shell: isWin,
+      maxBuffer: MAX_BUFFER,
+    });
+    if (result.status !== 0 || result.error) {
+      if (process.env?.CDXGEN_IN_CONTAINER === "true") {
+        thoughtLog(
+          "Gradle build has failed. Perhaps the user is using the wrong container image?",
         );
-      } else if (
-        result.stderr?.includes(
-          "In version catalog libs, import of external catalog file failed",
-        )
-      ) {
-        console.log(
-          "3. Catalog file is required for gradle dependency resolution to succeed.",
-        );
-      } else if (result.stderr?.includes("Unrecognized option")) {
-        console.log(
-          "3. Try removing the unrecognized options to improve compatibility with a range of Java versions. Refer to the error message above.",
+      } else {
+        thoughtLog(
+          "Gradle build has failed. I recommend using Java container images.",
         );
       }
-      if (result.stderr.includes("does not exist")) {
-        return "";
+      if (result.stderr) {
+        console.group("*** GRADLE BUILD ERRORS ***");
+        console.error(result.stdout, result.stderr);
+        console.groupEnd();
+        console.log(
+          "1. Check if the correct version of java and gradle are installed and available in PATH. For example, some project might require Java 11 with gradle 7.\n cdxgen container image bundles Java 23 with gradle 8 which might be incompatible.",
+        );
+        console.log(
+          "2. Try running cdxgen with the custom JDK11-based image `ghcr.io/cyclonedx/cdxgen-java11:v11`.",
+        );
+        if (result.stderr?.includes("not get unknown property")) {
+          console.log(
+            "3. Check if the SBOM is generated for the correct root project for your application.",
+          );
+        } else if (
+          result.stderr?.includes(
+            "In version catalog libs, import of external catalog file failed",
+          )
+        ) {
+          console.log(
+            "3. Catalog file is required for gradle dependency resolution to succeed.",
+          );
+        } else if (result.stderr?.includes("Unrecognized option")) {
+          console.log(
+            "3. Try removing the unrecognized options to improve compatibility with a range of Java versions. Refer to the error message above.",
+          );
+        }
+        if (result.stderr.includes("does not exist")) {
+          return "";
+        }
       }
     }
+    if (result.stdout !== null) {
+      allOutputs.push(result.stdout);
+    }
   }
-  const stdout = result.stdout;
+  const stdout = allOutputs.join("\n");
   if (stdout) {
     return Buffer.from(stdout).toString();
   }
@@ -12119,25 +12126,49 @@ export function getMillCommand(srcPath) {
  * @param {string[]} gradleArguments The general gradle arguments, which must only be added once
  * @param {string[]} gradleSubCommands The sub-commands that are to be executed by gradle
  * @param {string[]} gradleSubCommandArguments The arguments specific to the sub-command(s), which much be added PER sub-command
+ * @param {int} gradleCommandLength The length of the full gradle-command
  *
- * @returns {string[]} Array of arguments to be added to the gradle command
+ * @returns {string[]} Array of arrays of arguments to be added to the gradle command
  */
 export function buildGradleCommandArguments(
   gradleArguments,
   gradleSubCommands,
   gradleSubCommandArguments,
+  gradleCommandLength,
 ) {
-  let allGradleArguments = [
+  const mainGradleArguments = [
     "--build-cache",
     "--console",
     "plain",
     "--no-parallel",
   ].concat(gradleArguments);
+  const maxCliArgsLength = isWin
+    ? 7500 - gradleCommandLength - mainGradleArguments.join(" ").length - 2
+    : -1;
+  if (DEBUG_MODE && maxCliArgsLength !== -1) {
+    console.log(
+      "Running on Windows with a very long command -- splitting into multiple commands",
+    );
+  }
+  const splitArgs = [];
+  let allGradleArguments = [].concat(mainGradleArguments);
+  let remainingLength = maxCliArgsLength;
   for (const gradleSubCommand of gradleSubCommands) {
+    const subCommandLength =
+      [gradleSubCommand, ...gradleSubCommandArguments].join(" ").length + 1;
+    if (maxCliArgsLength !== -1 && remainingLength - subCommandLength < 0) {
+      splitArgs.push(allGradleArguments);
+      allGradleArguments = [].concat(mainGradleArguments);
+      remainingLength = maxCliArgsLength;
+    }
     allGradleArguments.push(gradleSubCommand);
     allGradleArguments = allGradleArguments.concat(gradleSubCommandArguments);
+    remainingLength -= subCommandLength;
   }
-  return allGradleArguments;
+  if (allGradleArguments.length !== mainGradleArguments.length) {
+    splitArgs.push(allGradleArguments);
+  }
+  return splitArgs;
 }
 
 /**


### PR DESCRIPTION
cdxgen didn't generate SBOM for Gradle on Windows. This PR fixes this.

Since Windows also has a maximum character count in the CLI, this was also fixed. This unfortunately means that generating a gradle SBOM on Windows could be slower, because we potentially have to run multiple commands instead of just the one!