### PR TITLE
Switch to llama.cpp for gguf conversion

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -156,6 +156,7 @@ RUN set -e; \
     && curl -L --output /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-${GOBIN_VERSION} \
     && chmod +x /usr/local/bin/bazel \
     && useradd -ms /bin/bash cyclonedx \
+    && npm install --global corepack@latest \
     && npm install --unsafe-perm -g node-gyp @microsoft/rush --omit=dev \
     && npx node-gyp install \
     && pecl channel-update pecl.php.net \

--- a/ci/Dockerfile-secure
+++ b/ci/Dockerfile-secure
@@ -166,6 +166,7 @@ RUN set -e; \
     && useradd -ms /bin/bash cyclonedx \
     && mv /root/.bashrc /home/cyclonedx/.bashrc \
     && chown -R cyclonedx:cyclonedx /home/cyclonedx/.bashrc \
+    && npm install --global corepack@latest \
     && npm install --unsafe-perm -g node-gyp @microsoft/rush --omit=dev \
     && npx node-gyp install \
     && pecl channel-update pecl.php.net \

--- a/ci/base-images/debian/install.sh
+++ b/ci/base-images/debian/install.sh
@@ -35,4 +35,5 @@ if [ x"${SKIP_NODEJS}" != "xyes" ]; then
   chmod +x /root/.nvm/nvm.sh
   source /root/.nvm/nvm.sh
   nvm install ${NODE_VERSION}
+  npm install --global corepack@latest
 fi

--- a/contrib/fine-tuning/Modelfile
+++ b/contrib/fine-tuning/Modelfile
@@ -1,4 +1,4 @@
-FROM CycloneDX/cdx1-gguf
+FROM ./cdx1-gguf-q8_0.gguf
 
 PARAMETER num_ctx 16384
 PARAMETER temperature 0.05

--- a/contrib/fine-tuning/Modelfile
+++ b/contrib/fine-tuning/Modelfile
@@ -5,7 +5,7 @@ PARAMETER temperature 0.05
 PARAMETER top_k 10
 PARAMETER top_p 0.5
 
-SYSTEM """You are cdxgen, a CycloneDX and an xBOM expert."""
+SYSTEM """You are cdxgen, an expert in CycloneDX and xBOM."""
 
 LICENSE """
 apache-2.0

--- a/contrib/fine-tuning/README.md
+++ b/contrib/fine-tuning/README.md
@@ -32,7 +32,7 @@ lms load CycloneDX/cdx1-mlx --exact --gpu max --identifier cdx1-test --context-l
 System prompt:
 
 ```text
-You are cdxgen, an xBOM and CycloneDX expert.
+You are cdxgen, an expert in CycloneDX and xBOM.
 ```
 
 ### gguf testing with ollama
@@ -60,7 +60,7 @@ ollama show cdx1-gguf
     top_p          0.5
 
   System
-    You are cdxgen, a CycloneDX and an xBOM expert.
+    You are cdxgen, an expert in CycloneDX and xBOM.
 
   License
     apache-2.0

--- a/contrib/fine-tuning/convert-gguf.sh
+++ b/contrib/fine-tuning/convert-gguf.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -e
+# Path to the latest llama.cpp compiled with all packages installed under conda
+# git clone https://github.com/ggerganov/llama.cpp.git
+# cd llama.cpp
+# conda create --name llama.cpp python=3.12
+# conda activate llama.cpp
+# python -m pip install -r requirements.txt
+# cmake .
+TUNING_TOOL=mlx
+HF_ORG=CycloneDX
+TOOL_BASE_MODEL=cdx1
+LLAMA_CPP_PATH=/Volumes/Work/sandbox/llama.cpp
+cd $LLAMA_CPP_PATH
+CDXGEN_FT_PATH=/Volumes/Work/CycloneDX/cdxgen/contrib/fine-tuning
+GGUF_MODEL_Q8_0=${HF_ORG}/${TOOL_BASE_MODEL}-gguf-Q8_0-GGUF
+FUSED_MODEL=${CDXGEN_FT_PATH}/${HF_ORG}/${TOOL_BASE_MODEL}-${TUNING_TOOL}
+
+rm -rf ${GGUF_MODEL_Q8_0}
+mkdir -p ${GGUF_MODEL_Q8_0}
+python convert_hf_to_gguf.py --outtype q8_0 --outfile ${CDXGEN_FT_PATH}/${HF_ORG}/${TOOL_BASE_MODEL}-gguf-Q8_0-GGUF/${TOOL_BASE_MODEL}-gguf-q8_0.gguf --model-name ${GGUF_MODEL_Q8_0} ${FUSED_MODEL}
+
+cp ${CDXGEN_FT_PATH}/Modelfile ${GGUF_MODEL_Q8_0}/
+# cp ${FUSED_MODEL}/*.json ${FUSED_MODEL}/merges.txt ${GGUF_MODEL_Q8_0}/
+
+### Testing with ollama
+# cd ${GGUF_MODEL_Q8_0}
+# ollama create cdx1-gguf -f Modelfile
+# ollama show cdx1-gguf
+# ollama run cdx1-gguf 
+
+export HF_HUB_ENABLE_HF_TRANSFER=0
+huggingface-cli whoami
+huggingface-cli upload --quiet --repo-type model ${GGUF_MODEL_Q8_0} ./${GGUF_MODEL_Q8_0} .

--- a/contrib/fine-tuning/upload-hf.sh
+++ b/contrib/fine-tuning/upload-hf.sh
@@ -5,7 +5,6 @@ HF_ORG=CycloneDX
 TUNING_TOOL=mlx
 TOOL_BASE_MODEL=cdx1
 FUSED_MODEL=${HF_ORG}/${TOOL_BASE_MODEL}-${TUNING_TOOL}
-FUSED_GGUF_MODEL=${HF_ORG}/${TOOL_BASE_MODEL}-gguf
 QUANT_MODEL_8BIT=${HF_ORG}/${TOOL_BASE_MODEL}-${TUNING_TOOL}-8bit
 QUANT_MODEL_6BIT=${HF_ORG}/${TOOL_BASE_MODEL}-${TUNING_TOOL}-6bit
 QUANT_MODEL_4BIT=${HF_ORG}/${TOOL_BASE_MODEL}-${TUNING_TOOL}-4bit
@@ -22,4 +21,3 @@ huggingface-cli upload --quiet --repo-type model ${QUANT_MODEL_6BIT} ./${QUANT_M
 huggingface-cli upload --quiet --repo-type model ${QUANT_MODEL_4BIT} ./${QUANT_MODEL_4BIT} .
 
 huggingface-cli upload --quiet --repo-type model ${FUSED_MODEL} ./${FUSED_MODEL} .
-huggingface-cli upload --quiet --repo-type model ${FUSED_GGUF_MODEL} ./${FUSED_GGUF_MODEL} .


### PR DESCRIPTION
Switched to llama.cpp master for gguf conversion and Q8_0 quantization. Works on my machine.

```
❯ ollama create cdx1-gguf -f Modelfile
gathering model components
copying file sha256:39ef2abdaad48bdbd1a8466c85b14a9646caf8049ec62e2b8d6383c56e035dc9 100%
parsing GGUF
using existing layer sha256:39ef2abdaad48bdbd1a8466c85b14a9646caf8049ec62e2b8d6383c56e035dc9
using autodetected template chatml
using existing layer sha256:a9f47bf267b28cae24d9d2b7e1d9204045da3b72568e4dcf5f66968e9d1fdf18
using existing layer sha256:de1eea7f14a061696a1490b000e7c36b45bb768c07a236acc828c69580770887
creating new layer sha256:6ee123ab45fc93d2d4223e606e0866d49b943b3826853a5db46fed97cdc50001
writing manifest
success
```

```
❯ ollama show cdx1-gguf
  Model
    architecture        llama
    parameters          14.7B
    context length      16384
    embedding length    5120
    quantization        Q8_0

  Parameters
    num_ctx        16384
    stop           "<|im_start|>"
    stop           "<|im_end|>"
    temperature    0.05
    top_k          10
    top_p          0.5

  System
    You are cdxgen, a CycloneDX and an xBOM expert.

  License
    apache-2.0
```

```
❯ ollama run cdx1-gguf
>>> tell me about cdxgen
cdxgen is a command-line tool that generates BOMs in various formats including JSON, XML, YAML, and CycloneDX. It supports multiple programming languages and frameworks.

>>>
```
