### PR TITLE
chore: fix exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,10 @@
     }
   ],
   "type": "module",
-  "exports": "./lib/cli/index.js",
+  "exports": {
+    "import": "./lib/cli/index.js",
+    "types": "./types/lib/cli/index.d.ts"
+  },
   "types": "./types/lib/cli/index.d.ts",
   "bin": {
     "cdxgen": "bin/cdxgen.js",


### PR DESCRIPTION
Fixes this typescript error:
```
Could not find a declaration file for module '@cyclonedx/cdxgen'. '.../node_modules/@cyclonedx/cdxgen/lib/cli/index.js' implicitly has an 'any' type.
  There are types at '.../node_modules/@cyclonedx/cdxgen/types/lib/cli/index.d.ts', but this result could not be resolved when respecting package.json "exports". The '@cyclonedx/cdxgen' library may need to update its package.json or typings.ts(7016)
```

We were not exporting types 🤷🏼 