### PR TITLE
fix(ci-deno): allow sqlite post-install scripts

### DIFF
--- a/ci/Dockerfile-deno
+++ b/ci/Dockerfile-deno
@@ -92,7 +92,7 @@ RUN set -e; \
     && python${PYTHON_VERSION} -m pip install --no-cache-dir --upgrade setuptools==77.0.3 wheel pip virtualenv \
     && python${PYTHON_VERSION} -m pip install --no-cache-dir --upgrade pipenv poetry blint atom-tools uv --target /opt/pypi \
     && curl -fsSL https://deno.land/x/install/install.sh | sh \
-    && deno install -g --allow-read --allow-env --allow-run --allow-sys=uid,systemMemoryInfo,gid,homedir --allow-write --allow-net -n cdxgen --node-modules-dir=auto "npm:@cyclonedx/cdxgen/cdxgen" \
+    && deno install -g --allow-read --allow-env --allow-run --allow-sys=uid,systemMemoryInfo,gid,homedir --allow-write --allow-net -n cdxgen --node-modules-dir=auto "npm:@cyclonedx/cdxgen/cdxgen" --allow-scripts=npm:sqlite3@5.1.7 \
     && deno install -g --allow-read --allow-env --allow-run --allow-sys=uid,systemMemoryInfo,gid,homedir --allow-write -n atom "npm:@appthreat/atom/atom" \
     && deno install -g --allow-read --allow-env --allow-run --allow-sys=uid,systemMemoryInfo,gid,homedir --allow-write -n astgen "npm:@appthreat/atom/astgen" \
     && deno install -g --allow-read --allow-env --allow-run --allow-sys=uid,systemMemoryInfo,gid,homedir --allow-write -n phpastgen "npm:@appthreat/atom/phpastgen" \


### PR DESCRIPTION
The deno image currently does not run as the sqlite bindings are not defined. 

Normally this would occur in the post install scripts.

Tiny change to ensure these run.