### PR TITLE
Ignore uncommented lines in gradle build scripts

### DIFF
--- a/lib/helpers/package_specific/gradleutils.js
+++ b/lib/helpers/package_specific/gradleutils.js
@@ -13,8 +13,23 @@ export function analyzeBuildSettings(buildFile, buildContent) {
   }
   const data = buildContent || readFileSync(buildFile, "utf-8");
   let pluginManagementMode = false;
+  let multilineCommentMode = false;
+
   for (let aline of data.split("\n")) {
     aline = aline.replaceAll("\r", "").trim();
+
+    if (aline.startsWith("/*")) {
+      multilineCommentMode = true;
+    }
+    if (multilineCommentMode) {
+      if (aline.endsWith("*/")) {
+        multilineCommentMode = false;
+      }
+      continue;
+    }
+    if (aline.startsWith("//")) {
+      continue;
+    }
     if (aline.includes("pluginManagement {")) {
       pluginManagementMode = true;
     }

--- a/lib/helpers/package_specific/gradleutils.test.js
+++ b/lib/helpers/package_specific/gradleutils.test.js
@@ -63,3 +63,40 @@ includeBuild 'my-utils'`,
     ),
   ).toBeUndefined();
 });
+
+test("analyzeBuildSettings comment tests", () => {
+  expect(
+    analyzeBuildSettings(
+      undefined,
+      `// includeBuild("my-app")
+      includeBuild("my-utils")`,
+    ),
+  ).toEqual({
+    includedBuilds: [":my-utils"],
+  });
+
+  expect(
+    analyzeBuildSettings(
+      undefined,
+      `/*
+        includeBuild("my-app")
+      */
+      includeBuild("my-utils")`,
+    ),
+  ).toEqual({
+    includedBuilds: [":my-utils"],
+  });
+
+  expect(
+    analyzeBuildSettings(
+      undefined,
+      `includeBuild("my-app")
+      // includeBuild("my-utils")
+      /*
+        includeBuild("my-other-utils")
+      */`,
+    ),
+  ).toEqual({
+    includedBuilds: [":my-app"],
+  });
+});


### PR DESCRIPTION
The changes in #1658 were prone to errors if users had commented-out blocks of build logic in their Gradle scripts, e.g. for toggling composite builds. 
The impact and implications have been outlined [here](https://github.com/CycloneDX/cdxgen/pull/1658#issuecomment-2801821782).
This PR attempts to skip any lines that start with `//` or are surrounded by `/* ... */` and adds tests for the skipping behaviour. 