### PR TITLE
[Gradle] Optimization for included/composite builds broke cdxgen on single module

### DIFF
--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -1965,46 +1965,45 @@ export async function createJavaBom(path, options) {
       options,
     )
   ) {
+    let includedBuilds = [];
     let allProjectsStr = [];
     if (process.env.GRADLE_INCLUDED_BUILDS) {
-      // Automatically add the colon prefix
-      allProjectsStr = process.env.GRADLE_INCLUDED_BUILDS.split(",").map((b) =>
+      includedBuilds = process.env.GRADLE_INCLUDED_BUILDS.split(",").map((b) =>
         !b.startsWith(":") ? `:${b}` : b,
       );
     }
     let parallelPropTaskOut = executeParallelGradleProperties(
       gradleRootPath,
-      [null],
+      [null].concat(includedBuilds),
       process.env.GRADLE_INCLUDED_BUILDS
         ? []
         : ["--init-script", GRADLE_INIT_SCRIPT],
     );
-    if (!process.env.GRADLE_INCLUDED_BUILDS) {
+    if (process.env.GRADLE_INCLUDED_BUILDS === undefined) {
       const outputLines = parallelPropTaskOut.split("\n");
       for (const [i, line] of outputLines.entries()) {
-        if (line.startsWith("Root project '")) {
+        if (line.startsWith("Root project '") || line.startsWith("Project '")) {
           break;
         }
         if (line.startsWith("<CDXGEN:includedBuild>")) {
           const includedBuild = line.split(">");
-          if (!allProjectsStr.includes(includedBuild[1].trim())) {
-            allProjectsStr.push(includedBuild[1].trim());
+          if (!includedBuilds.includes(includedBuild[1].trim())) {
+            includedBuilds.push(includedBuild[1].trim());
           }
         }
       }
-    }
-    if (allProjectsStr.length > 0) {
-      thoughtLog(
-        `Wait, this gradle project uses composite builds. I must carefully process these ${allProjectsStr.length} projects, in addition to the root.`,
-      );
-      if (DEBUG_MODE) {
-        console.log(`Composite builds: ${allProjectsStr.join(" ").trim()}.`);
+      if (includedBuilds.length > 0) {
+        thoughtLog(
+          `Wait, this gradle project uses composite builds. I must carefully process these ${includedBuilds.length} projects, in addition to the root.`,
+        );
+        if (DEBUG_MODE) {
+          console.log(`Composite builds: ${includedBuilds.join(" ").trim()}.`);
+        }
+        parallelPropTaskOut = parallelPropTaskOut.concat(
+          "\n",
+          executeParallelGradleProperties(gradleRootPath, includedBuilds),
+        );
       }
-      parallelPropTaskOut = parallelPropTaskOut.concat(
-        "\n",
-        executeParallelGradleProperties(gradleRootPath, allProjectsStr),
-      );
-      allProjectsStr = [];
     }
     const splitPropTaskOut = splitOutputByGradleProjects(parallelPropTaskOut, [
       "properties",
@@ -2017,7 +2016,7 @@ export async function createJavaBom(path, options) {
           rootProject,
           retMap.metadata,
         );
-        if (!key.startsWith(":")) {
+        if (!includedBuilds.includes(key)) {
           parentComponent = rootComponent;
         }
         gradleModules.set(key, rootComponent);


### PR DESCRIPTION
The previously implemented optimization on detecting included/composite builds broke cdxgen when run on a module instead of the root of the project. This PR fixes this and re-adds the optimization when the included/composite modules are entered directly from the cli.