### PR TITLE
Use PackageURL.fromString to properly parse npm targetName

### DIFF
--- a/lib/helpers/utils.js
+++ b/lib/helpers/utils.js
@@ -1192,13 +1192,12 @@ export async function parsePkgLock(pkgLockFile, options = {}) {
           }`
         : author;
     if (node === rootNode) {
-      purlString = new PackageURL(
-        "npm",
-        options.projectGroup || "",
-        "project-name" in options ? options.projectName : node.packageName,
-        options.projectVersion || node.version,
-        null,
-        null,
+      const projectGroup = options.projectGroup;
+      const projectName =
+        "project-name" in options ? options.projectName : node.packageName;
+      const projectVersion = options.projectVersion || node.version;
+      purlString = PackageURL.fromString(
+        `pkg:npm/${projectGroup ? `${encodeURIComponent(projectGroup).replace(/%2F/g, "/")}/` : ""}${encodeURIComponent(projectName).replace(/%2F/g, "/")}@${projectVersion}`,
       )
         .toString()
         .replace(/%2F/g, "/");
@@ -1213,13 +1212,8 @@ export async function parsePkgLock(pkgLockFile, options = {}) {
         "bom-ref": decodeURIComponent(purlString),
       };
     } else {
-      purlString = new PackageURL(
-        "npm",
-        "",
-        node.packageName,
-        node.version,
-        null,
-        null,
+      purlString = PackageURL.fromString(
+        `pkg:npm/${encodeURIComponent(node.packageName).replace(/%2F/g, "/")}@${node.version}`,
       )
         .toString()
         .replace(/%2F/g, "/");
@@ -1558,7 +1552,9 @@ export async function parsePkgLock(pkgLockFile, options = {}) {
         continue;
       }
       const depPurlString = decodeURIComponent(
-        new PackageURL("npm", "", targetName, targetVersion, null, null)
+        PackageURL.fromString(
+          `pkg:npm/${encodeURIComponent(targetName).replace(/%2F/g, "/")}@${targetVersion}`,
+        )
           .toString()
           .replace(/%2F/g, "/"),
       );
@@ -1945,13 +1941,8 @@ export async function parseYarnLock(yarnLockFile) {
           // Handle case where the dependency name is really an alias.
           // Eg: legacy-swc-helpers "npm:@swc/helpers@=0.4.14". Here the dgroupname=@swc/helpers
 
-          const depPurlString = new PackageURL(
-            "npm",
-            null,
-            dgroupnameToUse,
-            resolvedVersion,
-            null,
-            null,
+          const depPurlString = PackageURL.fromString(
+            `pkg:npm/${encodeURIComponent(dgroupnameToUse).replace(/%2F/g, "/")}@${resolvedVersion}`,
           ).toString();
           deplist.add(decodeURIComponent(depPurlString));
         }
@@ -2556,13 +2547,8 @@ export async function parsePnpmLock(
         if (vers?.includes("(")) {
           vers = vers.split("(")[0];
         }
-        const opurlString = new PackageURL(
-          "npm",
-          "",
-          opkgName,
-          vers,
-          null,
-          null,
+        const opurlString = PackageURL.fromString(
+          `pkg:npm/${encodeURIComponent(opkgName).replace(/%2F/g, "/")}@${vers}`,
         ).toString();
         const obomRef = decodeURIComponent(opurlString);
         if (possibleOptionalDeps[obomRef] === undefined) {
@@ -2700,13 +2686,8 @@ export async function parsePnpmLock(
                 .replace(/^\//, "");
               vers = overrideVersion;
             }
-            const dpurlString = new PackageURL(
-              "npm",
-              "",
-              dpkgName,
-              vers,
-              null,
-              null,
+            const dpurlString = PackageURL.fromString(
+              `pkg:npm/${encodeURIComponent(dpkgName).replace(/%2F/g, "/")}@${vers}`,
             ).toString();
             const dbomRef = decodeURIComponent(dpurlString);
             deplist.push(dbomRef);


### PR DESCRIPTION
Use `PackageURL.fromString` to properly parse npm `targetName`.

Noticed this when running locally and it picked up a new version of `PackageURL` that validates than `name` cannot contain special characters like `@babel/core`. This allows for parsing the `namespace` and `name` components