### PR TITLE
[build] Extracted the rolling image into its own workflow

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -113,13 +113,6 @@ jobs:
             cdxgen-image:
               additional-image: cdxgen-debian-swift
 
-          - lang: rolling
-            distro: opensuse
-            base-image:
-              lang: lang
-            cdxgen-image:
-              skip-tags: true
-
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/build-rolling-image.yml
+++ b/.github/workflows/build-rolling-image.yml
@@ -1,0 +1,35 @@
+name: Build rolling image
+
+on:
+  schedule:
+  - cron: "0 8 * * *"
+  push:
+    branches:
+      - master
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  image:
+    if: github.repository == 'CycloneDX/cdxgen'
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/image-build.yml
+    with:
+      image: |
+        image: {
+          "lang": "rolling",
+          "distro": "opensuse",
+          "base-image": {
+            "lang": "lang"
+          },
+          "cdxgen-image": {
+            "skip-tags": true
+          }
+        }


### PR DESCRIPTION
The rolling image has been having some issues lately, because of changes in the OpenSuse repo. I extracted the rolling image into its own workflow so it doesn't abort the other builds when it fails.