### PR TITLE
Build Ruby in a builder

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -53,9 +53,41 @@ jobs:
       continue-on-error: true
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  containers-ruby-builder:
+    if: github.repository == 'CycloneDX/cdxgen'
+    runs-on: ["self-hosted", "metal", "amd64"]
+    permissions:
+      contents: write
+      packages: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Setup docker cache dir
+        run: |
+          mkdir -p /tmp/ruby-builder-cache
+      - name: Build and push Docker images
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ci/base-images/al9/Dockerfile.ruby-builder
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ghcr.io/cyclonedx/cdxgen-ruby-builder:master
+          cache-from: type=local,src=/tmp/ruby-builder-cache
+          cache-to: type=local,dest=/tmp/ruby-builder-cache,mode=max
   containers:
     if: github.repository == 'CycloneDX/cdxgen'
-    runs-on: ["self-hosted", "ubuntu", "amd64"]
+    runs-on: ["self-hosted", "metal", "amd64"]
+    needs: [containers-ruby-builder]
     permissions:
       contents: write
       packages: write
@@ -110,7 +142,8 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   containers-secure:
     if: github.repository == 'CycloneDX/cdxgen'
-    runs-on: ["self-hosted", "ubuntu", "amd64"]
+    runs-on: ["self-hosted", "metal", "amd64"]
+    needs: [containers-ruby-builder]
     permissions:
       contents: write
       packages: write
@@ -160,6 +193,7 @@ jobs:
   containers-deno:
     if: github.repository == 'CycloneDX/cdxgen'
     runs-on: ubuntu-latest
+    needs: [containers-ruby-builder]
     permissions:
       contents: read
       packages: write

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM almalinux:9.5-minimal
+FROM ghcr.io/cyclonedx/cdxgen-ruby-builder:master
 
 LABEL maintainer="cyclonedx" \
       org.opencontainers.image.authors="Prabhu Subramanian <prabhu@appthreat.com>" \
@@ -61,12 +61,8 @@ ENV GOPATH=/opt/app-root/go \
     SDKMAN_DIR=/root/.sdkman \
     SDKMAN_CANDIDATES_DIR=/root/.sdkman/candidates \
     DOTNET_CLI_TELEMETRY_OPTOUT=1 \
-    MALLOC_CONF="dirty_decay_ms:2000,narenas:2,background_thread:true" \
-    RUBY_CONFIGURE_OPTS="--with-jemalloc --enable-yjit" \
-    RUBYOPT="--yjit" \
-    RUBY_BUILD_BUILD_PATH="/tmp/rbenv" \
-    RUBY_BUILD_HTTP_CLIENT=curl
-ENV PATH=${PATH}:/root/.nvm/versions/node/v${NODE_VERSION}/bin:${JAVA_HOME}/bin:${MAVEN_HOME}/bin:${GRADLE_HOME}/bin:${SCALA_HOME}/bin:${SBT_HOME}/bin:${GOPATH}/bin:/usr/local/go/bin:/usr/local/bin/:/root/.local/bin:/root/.cargo/bin:/opt/pypi/bin:/root/.rbenv/bin:/root/.rbenv/versions/3.4.2/bin:
+    RBENV_ROOT=/opt/.rbenv
+ENV PATH=${PATH}:/root/.nvm/versions/node/v${NODE_VERSION}/bin:${JAVA_HOME}/bin:${MAVEN_HOME}/bin:${GRADLE_HOME}/bin:${SCALA_HOME}/bin:${SBT_HOME}/bin:${GOPATH}/bin:/usr/local/go/bin:/usr/local/bin/:/root/.local/bin:/root/.cargo/bin:/opt/pypi/bin:/opt/.rbenv/bin:/opt/.rbenv/versions/3.4.3/bin:
 
 COPY . /opt/cdxgen
 
@@ -88,8 +84,8 @@ RUN set -e; \
         python${PYTHON_VERSION} python${PYTHON_VERSION}-devel python${PYTHON_VERSION}-pip glibc-common glibc-all-langpacks \
         openssl-devel libffi-devel libyaml zlib-devel \
         pcre2 which tar gzip zip unzip bzip2 sudo ncurses ncurses-devel sqlite-devel gnupg2 dotnet-sdk-9.0 \
-    && microdnf install -y epel-release \
-    && microdnf install --enablerepo=crb -y libyaml-devel jemalloc-devel \
+    && ruby --version \
+    && which ruby \
     && alternatives --install /usr/bin/python3 python /usr/bin/python${PYTHON_VERSION} 10 \
     && alternatives --install /usr/bin/python3 python3 /usr/bin/python${PYTHON_VERSION} 10 \
     && /usr/bin/python${PYTHON_VERSION} --version \
@@ -105,17 +101,6 @@ RUN set -e; \
     && source /root/.nvm/nvm.sh \
     && nvm install ${NODE_VERSION} \
     && node --version \
-    && git clone https://github.com/rbenv/rbenv.git --depth=1 ~/.rbenv \
-    && echo 'export PATH="$HOME/.rbenv/bin:$PATH"' >> ~/.bashrc \
-    && echo 'eval "$(~/.rbenv/bin/rbenv init - bash)"' >> ~/.bashrc \
-    && source ~/.bashrc \
-    && mkdir -p "$(rbenv root)/plugins" \
-    && git clone https://github.com/rbenv/ruby-build.git --depth=1 "$(rbenv root)/plugins/ruby-build" \
-    && rbenv install ${RUBY_VERSION} -- --disable-install-doc \
-    && rbenv global ${RUBY_VERSION} \
-    && ruby --version \
-    && which ruby \
-    && rm -rf /root/.rbenv/cache $RUBY_BUILD_BUILD_PATH \
     && curl -s "https://get.sdkman.io" | bash \
     && echo -e "sdkman_auto_answer=true\nsdkman_selfupdate_feature=false\nsdkman_auto_env=true\nsdkman_curl_connect_timeout=20\nsdkman_curl_max_time=0" >> $HOME/.sdkman/etc/config \
     && source "$HOME/.sdkman/bin/sdkman-init.sh" \

--- a/ci/Dockerfile-deno
+++ b/ci/Dockerfile-deno
@@ -1,4 +1,4 @@
-FROM almalinux:9.5-minimal
+FROM ghcr.io/cyclonedx/cdxgen-ruby-builder:master
 
 LABEL maintainer="cyclonedx" \
       org.opencontainers.image.authors="Prabhu Subramanian <prabhu@appthreat.com>" \
@@ -59,12 +59,8 @@ ENV GOPATH=/opt/app-root/go \
     SDKMAN_CANDIDATES_DIR=/root/.sdkman/candidates \
     PYTHONPATH=/opt/pypi:${PYTHONPATH} \
     DOTNET_CLI_TELEMETRY_OPTOUT=1 \
-    MALLOC_CONF="dirty_decay_ms:2000,narenas:2,background_thread:true" \
-    RUBY_CONFIGURE_OPTS="--with-jemalloc --enable-yjit" \
-    RUBYOPT="--yjit" \
-    RUBY_BUILD_BUILD_PATH="/tmp/rbenv" \
-    RUBY_BUILD_HTTP_CLIENT=curl
-ENV PATH=${PATH}:${JAVA_HOME}/bin:${MAVEN_HOME}/bin:${GRADLE_HOME}/bin:${SCALA_HOME}/bin:${SBT_HOME}/bin:${GOPATH}/bin:/usr/local/go/bin:/usr/local/bin/:/root/.local/bin:/root/.deno/bin:/root/.cargo/bin:/opt/pypi/bin:/root/.rbenv/bin:/root/.rbenv/versions/3.4.2/bin:
+    RBENV_ROOT=/opt/.rbenv
+ENV PATH=${PATH}:${JAVA_HOME}/bin:${MAVEN_HOME}/bin:${GRADLE_HOME}/bin:${SCALA_HOME}/bin:${SBT_HOME}/bin:${GOPATH}/bin:/usr/local/go/bin:/usr/local/bin/:/root/.local/bin:/root/.deno/bin:/root/.cargo/bin:/opt/pypi/bin:/opt/.rbenv/bin:/opt/.rbenv/versions/3.4.3/bin:
 
 RUN set -e; \
     ARCH_NAME="$(rpm --eval '%{_arch}')"; \
@@ -84,8 +80,8 @@ RUN set -e; \
         python${PYTHON_VERSION} python${PYTHON_VERSION}-devel python${PYTHON_VERSION}-pip glibc-common glibc-all-langpacks \
         openssl-devel libffi-devel libyaml zlib-devel \
         pcre2 which tar gzip zip unzip bzip2 sudo ncurses ncurses-devel sqlite-devel gnupg2 dotnet-sdk-9.0 \
-    && microdnf install -y epel-release \
-    && microdnf install --enablerepo=crb -y libyaml-devel jemalloc-devel \
+    && ruby --version \
+    && which ruby \
     && alternatives --install /usr/bin/python3 python /usr/bin/python${PYTHON_VERSION} 10 \
     && alternatives --install /usr/bin/python3 python3 /usr/bin/python${PYTHON_VERSION} 10 \
     && python${PYTHON_VERSION} --version \
@@ -105,17 +101,6 @@ RUN set -e; \
     && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
     && cargo --version \
     && rustc --version \
-    && git clone https://github.com/rbenv/rbenv.git --depth=1 ~/.rbenv \
-    && echo 'export PATH="$HOME/.rbenv/bin:$PATH"' >> ~/.bashrc \
-    && echo 'eval "$(~/.rbenv/bin/rbenv init - bash)"' >> ~/.bashrc \
-    && source ~/.bashrc \
-    && mkdir -p "$(rbenv root)/plugins" \
-    && git clone https://github.com/rbenv/ruby-build.git --depth=1 "$(rbenv root)/plugins/ruby-build" \
-    && rbenv install ${RUBY_VERSION} -- --disable-install-doc \
-    && rbenv global ${RUBY_VERSION} \
-    && ruby --version \
-    && which ruby \
-    && rm -rf /root/.rbenv/cache $RUBY_BUILD_BUILD_PATH \
     && curl -s "https://get.sdkman.io" | bash \
     && echo -e "sdkman_auto_answer=true\nsdkman_selfupdate_feature=false\nsdkman_auto_env=true" >> $HOME/.sdkman/etc/config \
     && source "$HOME/.sdkman/bin/sdkman-init.sh" \

--- a/ci/Dockerfile-secure
+++ b/ci/Dockerfile-secure
@@ -1,4 +1,4 @@
-FROM almalinux:9.5-minimal
+FROM ghcr.io/cyclonedx/cdxgen-ruby-builder:master
 
 LABEL maintainer="cyclonedx" \
       org.opencontainers.image.authors="Prabhu Subramanian <prabhu@appthreat.com>" \
@@ -66,13 +66,8 @@ ENV GOPATH=/opt/app-root/go \
     CDXGEN_TEMP_DIR=/tmp/cdxgen-temp \
     SDKMAN_DIR=/opt/.sdkman \
     SDKMAN_CANDIDATES_DIR=/opt/.sdkman/candidates \
-    MALLOC_CONF="dirty_decay_ms:2000,narenas:2,background_thread:true" \
-    RUBY_CONFIGURE_OPTS="--with-jemalloc --enable-yjit" \
-    RUBYOPT="--yjit" \
-    RUBY_BUILD_BUILD_PATH="/tmp/rbenv" \
-    RUBY_BUILD_HTTP_CLIENT=curl \
     RBENV_ROOT=/opt/.rbenv
-ENV PATH=${PATH}:/opt/bin:/opt/.nvm/versions/node/v${NODE_VERSION}/bin:${JAVA_HOME}/bin:${MAVEN_HOME}/bin:${GRADLE_HOME}/bin:${SCALA_HOME}/bin:${SBT_HOME}/bin:${GOPATH}/bin:/usr/local/go/bin:/usr/local/bin/:/opt/.local/bin:/opt/pypi/bin:/opt/.rbenv/bin:/opt/.rbenv/versions/3.4.2/bin:
+ENV PATH=${PATH}:/opt/bin:/opt/.nvm/versions/node/v${NODE_VERSION}/bin:${JAVA_HOME}/bin:${MAVEN_HOME}/bin:${GRADLE_HOME}/bin:${SCALA_HOME}/bin:${SBT_HOME}/bin:${GOPATH}/bin:/usr/local/go/bin:/usr/local/bin/:/opt/.local/bin:/opt/pypi/bin:/opt/.rbenv/bin:/opt/.rbenv/versions/3.4.3/bin:
 
 COPY . /opt/cdxgen
 
@@ -94,8 +89,8 @@ RUN set -e; \
         python${PYTHON_VERSION} python${PYTHON_VERSION}-devel python${PYTHON_VERSION}-pip glibc-common glibc-all-langpacks \
         openssl-devel libffi-devel libyaml zlib-devel \
         pcre2 which tar gzip zip unzip bzip2 sudo ncurses ncurses-devel sqlite-devel gnupg2 dotnet-sdk-9.0 rust cargo \
-    && microdnf install -y epel-release \
-    && microdnf install --enablerepo=crb -y libyaml-devel jemalloc-devel \
+    && ruby --version \
+    && which ruby \
     && alternatives --install /usr/bin/python3 python /usr/bin/python${PYTHON_VERSION} 10 \
     && alternatives --install /usr/bin/python3 python3 /usr/bin/python${PYTHON_VERSION} 10 \
     && /usr/bin/python${PYTHON_VERSION} --version \
@@ -111,19 +106,6 @@ RUN set -e; \
     && source ${NVM_DIR}/nvm.sh \
     && nvm install ${NODE_VERSION} \
     && node --version \
-    && git clone https://github.com/rbenv/rbenv.git --depth=1 /opt/.rbenv \
-    && echo 'export PATH="/opt/.rbenv/bin:$PATH"' >> ~/.bashrc \
-    && echo 'eval "$(/opt/.rbenv/bin/rbenv init - bash)"' >> ~/.bashrc \
-    && echo 'export RBENV_ROOT=/opt/.rbenv' >> ~/.bashrc \
-    && echo 'export NVM_DIR=/opt/.nvm' >> ~/.bashrc \
-    && source ~/.bashrc \
-    && mkdir -p "/opt/.rbenv/plugins" \
-    && git clone https://github.com/rbenv/ruby-build.git --depth=1 "/opt/.rbenv/plugins/ruby-build" \
-    && rbenv install ${RUBY_VERSION} -- --disable-install-doc \
-    && rbenv global ${RUBY_VERSION} \
-    && rm -rf /opt/.rbenv/cache $RUBY_BUILD_BUILD_PATH \
-    && ruby --version \
-    && which ruby \
     && curl -s "https://get.sdkman.io" | bash \
     && echo -e "sdkman_auto_answer=true\nsdkman_selfupdate_feature=false\nsdkman_auto_env=true\nsdkman_curl_connect_timeout=20\nsdkman_curl_max_time=0" >> /opt/.sdkman/etc/config \
     && source "/opt/.sdkman/bin/sdkman-init.sh" \

--- a/ci/base-images/al9/Dockerfile.ruby-builder
+++ b/ci/base-images/al9/Dockerfile.ruby-builder
@@ -1,0 +1,39 @@
+FROM almalinux:9.5-minimal AS ruby-builder
+
+LABEL maintainer="cyclonedx" \
+      org.opencontainers.image.authors="Prabhu Subramanian <prabhu@appthreat.com>" \
+      org.opencontainers.image.source="https://github.com/cyclonedx/cdxgen" \
+      org.opencontainers.image.url="https://github.com/cyclonedx/cdxgen" \
+      org.opencontainers.image.version="11.3.x" \
+      org.opencontainers.image.vendor="cyclonedx" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.title="cdxgen" \
+      org.opencontainers.image.description="Base Ruby builder. Do not use directly."
+
+ARG RUBY_VERSION=3.4.3
+
+ENV RUBY_VERSION=$RUBY_VERSION \
+    RBENV_ROOT=/opt/.rbenv \
+    MAKEFLAGS="-j$(nproc --ignore=2)" \
+    PATH=/opt/bin:/opt/vendor/bin:${PATH}:/usr/local/bin/:/root/.local/bin:/root/.rbenv/bin:/root/.rbenv/versions/3.4.3/bin:
+
+RUN microdnf install -y \
+          gcc gcc-c++ make autoconf automake bison libtool \
+          wget git-core bash glibc-common glibc-all-langpacks \
+          openssl-devel readline-devel zlib-devel \
+          ncurses-devel libffi-devel pcre2-devel rust \
+    && microdnf clean all \
+    && microdnf install -y epel-release \
+    && microdnf install --enablerepo=crb -y libyaml-devel \
+    && git clone https://github.com/rbenv/rbenv.git --depth=1 /opt/.rbenv \
+    && echo 'export PATH="/opt/.rbenv/bin:$PATH"' >> ~/.bashrc \
+    && echo 'eval "$(/opt/.rbenv/bin/rbenv init - bash)"' >> ~/.bashrc \
+    && echo 'export RBENV_ROOT=/opt/.rbenv' >> ~/.bashrc \
+    && echo 'export NVM_DIR=/opt/.nvm' >> ~/.bashrc \
+    && source ~/.bashrc \
+    && mkdir -p "/opt/.rbenv/plugins" \
+    && git clone https://github.com/rbenv/ruby-build.git --depth=1 "/opt/.rbenv/plugins/ruby-build" \
+    && rbenv install ${RUBY_VERSION} -- --disable-install-doc \
+    && rbenv global ${RUBY_VERSION} \
+    && rm -rf /opt/.rbenv/cache \
+    && ruby --version

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   "bugs": {
     "url": "https://github.com/cyclonedx/cdxgen/issues"
   },
-  "packageManager": "pnpm@10.10.0",
+  "packageManager": "pnpm@10.11.0",
   "lint-staged": {
     "*": "biome check --fix --no-errors-on-unmatched"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,7 +75,7 @@ importers:
         version: 2.3.0
       semver:
         specifier: ^7.7.1
-        version: 7.7.1
+        version: 7.7.2
       ssri:
         specifier: ^12.0.0
         version: 12.0.0
@@ -903,8 +903,8 @@ packages:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
 
-  caniuse-lite@1.0.30001717:
-    resolution: {integrity: sha512-auPpttCq6BDEG8ZAuHJIplGw6GODhjw+/11e7IjpnYCxZcW/ONgPs0KVBJ0d1bY3e2+7PRe5RCLyP+PfwVgkYw==}
+  caniuse-lite@1.0.30001718:
+    resolution: {integrity: sha512-AflseV1ahcSunK53NfEs9gFWgOEmzr0f+kaMFA4xiLZlr9Hzt7HxcSpIFcnNCUkz6R6dWKa54rUz3HUmI3nVcw==}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -1112,8 +1112,8 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
-  electron-to-chromium@1.5.151:
-    resolution: {integrity: sha512-Rl6uugut2l9sLojjS4H4SAr3A4IgACMLgpuEMPYCVcKydzfyPrn5absNRju38IhQOf/NwjJY8OGWjlteqYeBCA==}
+  electron-to-chromium@1.5.152:
+    resolution: {integrity: sha512-xBOfg/EBaIlVsHipHl2VdTPJRSvErNUaqW8ejTq5OlOlIYx1wOllCHsAvAIrr55jD1IYEfdR86miUEt8H5IeJg==}
 
   emittery@0.13.1:
     resolution: {integrity: sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==}
@@ -2212,8 +2212,8 @@ packages:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
 
-  semver@7.7.1:
-    resolution: {integrity: sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==}
+  semver@7.7.2:
+    resolution: {integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -2500,8 +2500,8 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
-  undici@6.21.2:
-    resolution: {integrity: sha512-uROZWze0R0itiAKVPsYhFov9LxrPMHLMEQFszeI2gCN6bnIIZ8twzBCJcN2LJrBBLfrP0t1FW0g+JmKVl8Vk1g==}
+  undici@6.21.3:
+    resolution: {integrity: sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==}
     engines: {node: '>=18.17'}
 
   unicorn-magic@0.1.0:
@@ -3200,7 +3200,7 @@ snapshots:
       promise-all-reject-late: 1.0.1
       promise-call-limit: 3.0.2
       read-package-json-fast: 4.0.0
-      semver: 7.7.1
+      semver: 7.7.2
       ssri: 12.0.0
       treeverse: 3.0.0
       walk-up-path: 4.0.0
@@ -3209,11 +3209,11 @@ snapshots:
 
   '@npmcli/fs@3.1.1':
     dependencies:
-      semver: 7.7.1
+      semver: 7.7.2
 
   '@npmcli/fs@4.0.0':
     dependencies:
-      semver: 7.7.1
+      semver: 7.7.2
 
   '@npmcli/git@6.0.3':
     dependencies:
@@ -3223,7 +3223,7 @@ snapshots:
       npm-pick-manifest: 10.0.0
       proc-log: 5.0.0
       promise-retry: 2.0.1
-      semver: 7.7.1
+      semver: 7.7.2
       which: 5.0.0
 
   '@npmcli/installed-package-contents@3.0.0':
@@ -3244,7 +3244,7 @@ snapshots:
       json-parse-even-better-errors: 4.0.0
       pacote: 20.0.0
       proc-log: 5.0.0
-      semver: 7.7.1
+      semver: 7.7.2
     transitivePeerDependencies:
       - supports-color
 
@@ -3259,7 +3259,7 @@ snapshots:
       hosted-git-info: 8.1.0
       json-parse-even-better-errors: 4.0.0
       proc-log: 5.0.0
-      semver: 7.7.1
+      semver: 7.7.2
       validate-npm-package-license: 3.0.4
 
   '@npmcli/promise-spawn@8.0.2':
@@ -3565,8 +3565,8 @@ snapshots:
 
   browserslist@4.24.5:
     dependencies:
-      caniuse-lite: 1.0.30001717
-      electron-to-chromium: 1.5.151
+      caniuse-lite: 1.0.30001718
+      electron-to-chromium: 1.5.152
       node-releases: 2.0.19
       update-browserslist-db: 1.1.3(browserslist@4.24.5)
 
@@ -3647,7 +3647,7 @@ snapshots:
 
   camelcase@6.3.0: {}
 
-  caniuse-lite@1.0.30001717: {}
+  caniuse-lite@1.0.30001718: {}
 
   chalk@4.1.2:
     dependencies:
@@ -3676,7 +3676,7 @@ snapshots:
       parse5: 7.3.0
       parse5-htmlparser2-tree-adapter: 7.1.0
       parse5-parser-stream: 7.1.2
-      undici: 6.21.2
+      undici: 6.21.3
       whatwg-mimetype: 4.0.0
 
   chownr@1.1.4:
@@ -3865,7 +3865,7 @@ snapshots:
   ee-first@1.1.1:
     optional: true
 
-  electron-to-chromium@1.5.151: {}
+  electron-to-chromium@1.5.152: {}
 
   emittery@0.13.1: {}
 
@@ -4067,7 +4067,7 @@ snapshots:
       es6-error: 4.1.1
       matcher: 3.0.0
       roarr: 2.15.4
-      semver: 7.7.1
+      semver: 7.7.2
       serialize-error: 7.0.1
 
   globals@11.12.0: {}
@@ -4229,7 +4229,7 @@ snapshots:
       '@babel/parser': 7.27.2
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
-      semver: 7.7.1
+      semver: 7.7.2
     transitivePeerDependencies:
       - supports-color
 
@@ -4512,7 +4512,7 @@ snapshots:
       jest-util: 29.7.0
       natural-compare: 1.4.0
       pretty-format: 29.7.0
-      semver: 7.7.1
+      semver: 7.7.2
     transitivePeerDependencies:
       - supports-color
 
@@ -4648,7 +4648,7 @@ snapshots:
 
   make-dir@4.0.0:
     dependencies:
-      semver: 7.7.1
+      semver: 7.7.2
 
   make-fetch-happen@13.0.1:
     dependencies:
@@ -4811,7 +4811,7 @@ snapshots:
 
   node-abi@3.75.0:
     dependencies:
-      semver: 7.7.1
+      semver: 7.7.2
     optional: true
 
   node-addon-api@7.1.1:
@@ -4826,7 +4826,7 @@ snapshots:
       make-fetch-happen: 13.0.1
       nopt: 7.2.1
       proc-log: 4.2.0
-      semver: 7.7.1
+      semver: 7.7.2
       tar: 6.2.1
       which: 4.0.0
     transitivePeerDependencies:
@@ -4856,7 +4856,7 @@ snapshots:
 
   npm-install-checks@7.1.1:
     dependencies:
-      semver: 7.7.1
+      semver: 7.7.2
 
   npm-normalize-package-bin@4.0.0: {}
 
@@ -4864,7 +4864,7 @@ snapshots:
     dependencies:
       hosted-git-info: 8.1.0
       proc-log: 5.0.0
-      semver: 7.7.1
+      semver: 7.7.2
       validate-npm-package-name: 6.0.0
 
   npm-packlist@9.0.0:
@@ -4876,7 +4876,7 @@ snapshots:
       npm-install-checks: 7.1.1
       npm-normalize-package-bin: 4.0.0
       npm-package-arg: 12.0.2
-      semver: 7.7.1
+      semver: 7.7.2
 
   npm-registry-fetch@18.0.2:
     dependencies:
@@ -5185,7 +5185,7 @@ snapshots:
 
   semver@6.3.1: {}
 
-  semver@7.7.1: {}
+  semver@7.7.2: {}
 
   sequelize-pool@7.1.0:
     optional: true
@@ -5202,7 +5202,7 @@ snapshots:
       moment-timezone: 0.5.48
       pg-connection-string: 2.9.0
       retry-as-promised: 7.1.1
-      semver: 7.7.1
+      semver: 7.7.2
       sequelize-pool: 7.1.0
       toposort-class: 1.0.1
       uuid: 8.3.2
@@ -5508,7 +5508,7 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  undici@6.21.2: {}
+  undici@6.21.3: {}
 
   unicorn-magic@0.1.0: {}
 


### PR DESCRIPTION
By building Ruby in a separate builder first, we speed up the image builds for the default, secure, and deno images.