### PR TITLE
Verify oci images with SBOM attachments

### DIFF
--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -93,6 +93,7 @@ jobs:
           SBOM_SIGN_PRIVATE_KEY: ${{ secrets.SBOM_SIGN_PRIVATE_KEY }}
       - name: Attach cdx sbom to base
         run: |
+          mkdir -p $RUNNER_TEMP/cdxgen-sboms
           corepack pnpm install --config.strict-dep-builds=true --package-import-method copy --frozen-lockfile
           node bin/cdxgen.js -t docker -o sbom-oci-base-image.cdx.json ${{ fromJSON(steps.base-metadata.outputs.json).tags[0] }}
           node bin/verify.js -i sbom-oci-base-image.cdx.json --public-key contrib/bom-signer/public.key
@@ -103,15 +104,18 @@ jobs:
         env:
           SBOM_SIGN_ALGORITHM: RS512
           SBOM_SIGN_PRIVATE_KEY: ${{ github.workspace }}/private.key
+          CDXGEN_TEMP_DIR: ${{ runner.temp }}/cdxgen-sboms
       - name: Attach cdx sbom
         run: |
+          mkdir -p $RUNNER_TEMP/cdxgen-sboms
           corepack pnpm install --config.strict-dep-builds=true --package-import-method copy --frozen-lockfile
           node bin/cdxgen.js -t docker -o sbom-oci-image.cdx.json ${{ fromJSON(steps.cdxgen-metadata.outputs.json).tags[0] }}
           node bin/verify.js -i sbom-oci-image.cdx.json --public-key contrib/bom-signer/public.key
           oras attach --artifact-type sbom/cyclonedx ${{ fromJSON(steps.cdxgen-metadata.outputs.json).tags[0] }} ./sbom-oci-image.cdx.json:application/json
           oras discover --format tree ${{ fromJSON(steps.cdxgen-metadata.outputs.json).tags[0] }}
         continue-on-error: true
-        if: ${{ startsWith(github.ref, 'refs/tags/') && ! fromJSON(inputs.image).cdxgen-image.skip-tags }}
+        if: ${{ ! fromJSON(inputs.image).cdxgen-image.skip-tags }}
         env:
           SBOM_SIGN_ALGORITHM: RS512
           SBOM_SIGN_PRIVATE_KEY: ${{ github.workspace }}/private.key
+          CDXGEN_TEMP_DIR: ${{ runner.temp }}/cdxgen-sboms

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@cyclonedx/cdxgen",
-  "version": "11.3.1",
+  "version": "11.3.2",
   "exports": "./lib/cli/index.js",
   "compilerOptions": {
     "lib": ["deno.window"],

--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@cyclonedx/cdxgen",
-  "version": "11.3.1",
+  "version": "11.3.2",
   "exports": "./lib/cli/index.js",
   "include": ["*.js", "lib/**", "bin/**", "data/**", "types/**"],
   "exclude": [

--- a/lib/managers/oci.js
+++ b/lib/managers/oci.js
@@ -1,0 +1,66 @@
+import { Buffer } from "node:buffer";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import { MAX_BUFFER, getAllFiles, getTmpDir, isWin } from "../helpers/utils.js";
+
+export function getBomWithOras(image) {
+  let result = spawnSync(
+    "oras",
+    [
+      "discover",
+      "--format",
+      "json",
+      "--artifact-type",
+      "sbom/cyclonedx",
+      image,
+    ],
+    {
+      encoding: "utf-8",
+      shell: isWin,
+      maxBuffer: MAX_BUFFER,
+    },
+  );
+  if (result.status !== 0 || result.error) {
+    console.log(
+      "Install oras by following the instructions at: https://oras.land/docs/installation",
+    );
+    if (result.stderr) {
+      console.log(result.stderr);
+    }
+    return undefined;
+  }
+  if (result.stdout) {
+    const out = Buffer.from(result.stdout).toString();
+    try {
+      const manifestObj = JSON.parse(out);
+      if (
+        manifestObj?.manifests?.length &&
+        Array.isArray(manifestObj.manifests) &&
+        manifestObj.manifests[0]?.reference
+      ) {
+        const imageRef = manifestObj.manifests[0].reference;
+        const tmpDir = getTmpDir();
+        result = spawnSync("oras", ["pull", imageRef, "-o", tmpDir], {
+          encoding: "utf-8",
+          shell: isWin,
+          maxBuffer: MAX_BUFFER,
+        });
+        if (result.status !== 0 || result.error) {
+          console.log(
+            `Unable to pull the SBOM attachment for ${imageRef} with oras!`,
+          );
+          return undefined;
+        }
+        const bomFiles = getAllFiles(tmpDir, "**/*.{bom,cdx}.json");
+        if (bomFiles.length) {
+          return JSON.parse(fs.readFileSync(bomFiles.pop(), "utf8"));
+        }
+      } else {
+        console.log(`${image} does not contain any SBOM attachment!`);
+      }
+    } catch (e) {
+      console.log(e);
+    }
+  }
+  return undefined;
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cyclonedx/cdxgen",
-  "version": "11.3.1",
+  "version": "11.3.2",
   "description": "Creates CycloneDX Software Bill of Materials (SBOM) from source or container image",
   "homepage": "http://github.com/cyclonedx/cdxgen",
   "author": "Prabhu Subramanian <prabhu@appthreat.com>",

--- a/types/lib/managers/oci.d.ts
+++ b/types/lib/managers/oci.d.ts
@@ -1,0 +1,2 @@
+export function getBomWithOras(image: any): any;
+//# sourceMappingURL=oci.d.ts.map

--- a/types/lib/managers/oci.d.ts.map
+++ b/types/lib/managers/oci.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"oci.d.ts","sourceRoot":"","sources":["../../../lib/managers/oci.js"],"names":[],"mappings":"AAKA,gDA4DC"}


### PR DESCRIPTION
cdx-verify can be used to verify the SBOM attached in container images.