### PR TITLE
[build] Don't try to install NPM -- it's already installed

### DIFF
--- a/ci/base-images/sle/Dockerfile.node20
+++ b/ci/base-images/sle/Dockerfile.node20
@@ -27,7 +27,6 @@ RUN set -e; \
     && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-${GCC_VERSION} 10 \
     && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${GCC_VERSION} 10 \
     && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${GCC_VERSION} 10 \
-    && npm install -g npm \
     && npm install -g node-gyp corepack \
     && npx node-gyp install \
     && node -v \


### PR DESCRIPTION
The node20-image is failing to build, because it tries to install `npm`, which is already installed!