### PR TITLE
[build] Free more space on CI-machine

### DIFF
--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -19,6 +19,11 @@ jobs:
     runs-on: ${{ inputs.runner || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@v4
+      - name: Trim CI agent
+        if: ${{ ! inputs.runner }}
+        run: |
+          chmod +x contrib/free_disk_space.sh
+          ./contrib/free_disk_space.sh
       - name: Set up QEMU
         if: ${{ ! inputs.runner }}
         uses: docker/setup-qemu-action@v3
@@ -91,11 +96,6 @@ jobs:
           echo $SBOM_SIGN_PRIVATE_KEY | base64 -d > $GITHUB_WORKSPACE/private.key
         env:
           SBOM_SIGN_PRIVATE_KEY: ${{ secrets.SBOM_SIGN_PRIVATE_KEY }}
-      - name: Trim CI agent
-        run: |
-          chmod +x contrib/free_disk_space.sh
-          ./contrib/free_disk_space.sh
-        if: ${{ ! inputs.runner }}
       - name: Attach cdx sbom to base
         run: |
           mkdir -p $RUNNER_TEMP/cdxgen-sboms

--- a/contrib/free_disk_space.sh
+++ b/contrib/free_disk_space.sh
@@ -30,17 +30,29 @@ echo "Freeing up disk space on CI system"
 echo "=============================================================================="
 
 echo "Listing 100 largest packages"
-dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -n | tail -n 100
+dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -nr | head -n 100
 df -h
 echo "Removing large packages"
-sudo apt-get remove -y '^dotnet-.*'
-sudo apt-get remove -y '^llvm-.*'
-sudo apt-get remove -y 'php.*'
-sudo apt-get remove -y '^mongodb-.*'
-sudo apt-get remove -y '^mysql-.*'
-sudo apt-get remove -y azure-cli google-cloud-sdk hhvm google-chrome-stable firefox powershell mono-devel libgl1-mesa-dri
+sudo apt-get remove --purge -y '^azure-.*'
+sudo apt-get remove --purge -y '^dotnet-.*'
+sudo apt-get remove --purge -y '^google-cloud-.*'
+sudo apt-get remove --purge -y '^libllvm.*'
+sudo apt-get remove --purge -y '^llvm-.*'
+sudo apt-get remove --purge -y '^microsoft-.*'
+sudo apt-get remove --purge -y '^mongodb-.*'
+sudo apt-get remove --purge -y '^mysql-.*'
+sudo apt-get remove --purge -y '^openjdk.*' 'temurin-.*'
+sudo apt-get remove --purge -y '^php.*'
+sudo apt-get remove --purge -y '^postgresql.*'
+sudo apt-get remove --purge -y firefox
+sudo apt-get remove --purge -y google-chrome-stable
+sudo apt-get remove --purge -y hhvm
+sudo apt-get remove --purge -y libgl1-mesa-dri
+sudo apt-get remove --purge -y mono-devel
+sudo apt-get remove --purge -y powershell
 sudo apt-get autoremove -y
 sudo apt-get clean
+dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -nr | head -n 100
 df -h
 echo "Removing large directories"
 


### PR DESCRIPTION
- Removing some more large packages
- 'apt remove' fails when a package does not exist -- explicitly deleting single packages
- Reverse sort, so largest packages are at the top