### PR TITLE
fix: unformatted go.mod which is valid leads to parse error

### DIFF
--- a/lib/helpers/utils.js
+++ b/lib/helpers/utils.js
@@ -6265,7 +6265,7 @@ export async function parseGoModData(goModData, gosumMap) {
   const pkgs = goModData.split("\n");
   for (let l of pkgs) {
     // Windows of course
-    l = l.replace("\r", "");
+    l = l.replace("\r", "").replace(/[\t ]+/g, " ");
     // Capture the parent component name from the module
     if (l.startsWith("module ")) {
       parentComponent.name = l.split(" ").pop().trim();

--- a/test/gomod/go.mod
+++ b/test/gomod/go.mod
@@ -1,17 +1,17 @@
-module cdxgen/test
+module	 cdxgen/test
 
-go 1.14
+go	 1.14
 
-require (
-    google.golang.org/grpc v1.32.0
+require	 (
+    google.golang.org/grpc	 v1.32.0
     github.com/aws/aws-sdk-go v1.38.47
-    github.com/spf13/viper v1.3.0
-    github.com/spf13/cobra v1.0.0
+    github.com/spf13/viper 	v1.3.0
+    github.com/spf13/cobra     v1.0.0
 )
 
 // Having both replace sections is invalid in a go.mod file, but it allows the tests to validate both cases
-replace google.golang.org/grpc => google.golang.org/grpc v1.21.0
+replace	 google.golang.org/grpc =>	 google.golang.org/grpc v1.21.0
 
-replace (
-    github.com/spf13/viper => github.com/spf13/viper v1.0.2
+replace 	(
+    github.com/spf13/viper => 	github.com/spf13/viper v1.0.2
 )


### PR DESCRIPTION
`tab` is valid char as a sperater for go.mod

i wonder if runing `go mod edit --fmt` before parse `go.mod` will be a better way