### PR TITLE
almalinux 10 upgrade

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -86,7 +86,7 @@ jobs:
         id: build
         with:
           context: .
-          file: ci/base-images/al9/Dockerfile.ruby-builder
+          file: ci/base-images/al10/Dockerfile.ruby-builder
           platforms: linux/amd64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
@@ -129,7 +129,7 @@ jobs:
         id: build
         with:
           context: .
-          file: ci/base-images/al9/Dockerfile.ruby-builder
+          file: ci/base-images/al10/Dockerfile.ruby-builder
           platforms: linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
@@ -243,7 +243,7 @@ jobs:
   containers-secure:
     if: github.repository == 'CycloneDX/cdxgen'
     runs-on: ["self-hosted", "metal", "amd64"]
-    needs: [containers-ruby-builder-deploy-manifest]
+    needs: [containers]
     permissions:
       contents: write
       packages: write

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -8,8 +8,8 @@ LABEL maintainer="cyclonedx" \
       org.opencontainers.image.vendor="cyclonedx" \
       org.opencontainers.image.licenses="Apache-2.0" \
       org.opencontainers.image.title="cdxgen" \
-      org.opencontainers.image.description="Container image for cdxgen SBOM generator packing latest build tools with secure defaults." \
-      org.opencontainers.docker.cmd="docker run --rm -v /tmp:/tmp -p 9090:9090 -v $(pwd):/app:rw -t ghcr.io/cyclonedx/cdxgen-secure cdxgen -r /app --server"
+      org.opencontainers.image.description="Container image for cdxgen SBOM generator packing latest build tools." \
+      org.opencontainers.docker.cmd="docker run --rm -v /tmp:/tmp -p 9090:9090 -v $(pwd):/app:rw -t ghcr.io/cyclonedx/cdxgen -r /app --server"
 
 ARG SWIFT_SIGNING_KEY=52BB7E3DE28A71BE22EC05FFEF80A866B47A981F
 ARG SWIFT_PLATFORM=ubi9
@@ -156,4 +156,4 @@ RUN set -e; \
     && microdnf clean all
 USER cyclonedx
 WORKDIR /app
-CMD ["cdxgen"]
+ENTRYPOINT ["cdxgen"]

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -22,7 +22,6 @@ ARG MAVEN_VERSION=3.9.9
 ARG GRADLE_VERSION=8.14
 ARG GO_VERSION=1.24.3
 ARG NODE_VERSION=24.0.2
-ARG PYTHON_VERSION=3.12
 ARG RUBY_VERSION=3.4.3
 ARG JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF-8"
 ARG SCALA_VERSION=3.6.4
@@ -39,8 +38,7 @@ ENV GOPATH=/opt/app-root/go \
     SBT_HOME="/opt/.sdkman/candidates/sbt/${SBT_VERSION}" \
     SCALA_VERSION=$SCALA_VERSION \
     SCALA_HOME="/opt/.sdkman/candidates/scala/${SCALA_VERSION}" \
-    PYTHON_VERSION=3.12 \
-    PYTHON_CMD=/usr/bin/python3.12 \
+    PYTHON_CMD=/usr/bin/python3 \
     RUBY_VERSION=$RUBY_VERSION \
     PYTHONUNBUFFERED=1 \
     PYTHONIOENCODING="utf-8" \
@@ -83,16 +81,14 @@ RUN set -e; \
         *) echo >&2 "error: unsupported architecture: '$ARCH_NAME'"; exit 1 ;; \
     esac \
     && microdnf install -y php php-curl php-zip php-bcmath php-json php-pear php-mbstring php-devel make gcc git-core \
-        python${PYTHON_VERSION} python${PYTHON_VERSION}-devel python${PYTHON_VERSION}-pip glibc-common glibc-all-langpacks \
+        python3 python3-devel python3-pip glibc-common glibc-all-langpacks \
         openssl-devel libffi-devel libyaml zlib-devel \
         pcre2 which tar gzip zip unzip bzip2 sudo ncurses ncurses-devel sqlite-devel gnupg2 dotnet-sdk-9.0 rust cargo \
     && ruby --version \
     && which ruby \
-    && alternatives --install /usr/bin/python3 python /usr/bin/python${PYTHON_VERSION} 10 \
-    && alternatives --install /usr/bin/python3 python3 /usr/bin/python${PYTHON_VERSION} 10 \
-    && /usr/bin/python${PYTHON_VERSION} --version \
-    && /usr/bin/python${PYTHON_VERSION} -m pip install --no-cache-dir --upgrade setuptools==77.0.3 wheel pip virtualenv \
-    && /usr/bin/python${PYTHON_VERSION} -m pip install --no-cache-dir --upgrade pipenv poetry blint atom-tools uv --target /opt/pypi \
+    && /usr/bin/python3 --version \
+    && /usr/bin/python3 -m pip install --no-cache-dir --upgrade setuptools==77.0.3 wheel pip virtualenv \
+    && /usr/bin/python3 -m pip install --no-cache-dir --upgrade pipenv poetry blint atom-tools uv --target /opt/pypi \
     && /opt/pypi/bin/poetry --version \
     && /opt/pypi/bin/pipenv --version \
     && /opt/pypi/bin/blint --help \

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -4,12 +4,12 @@ LABEL maintainer="cyclonedx" \
       org.opencontainers.image.authors="Prabhu Subramanian <prabhu@appthreat.com>" \
       org.opencontainers.image.source="https://github.com/cyclonedx/cdxgen" \
       org.opencontainers.image.url="https://github.com/cyclonedx/cdxgen" \
-      org.opencontainers.image.version="11.3.x" \
+      org.opencontainers.image.version="11.4.x" \
       org.opencontainers.image.vendor="cyclonedx" \
       org.opencontainers.image.licenses="Apache-2.0" \
       org.opencontainers.image.title="cdxgen" \
-      org.opencontainers.image.description="Container image for cdxgen SBOM generator packing latest build tools." \
-      org.opencontainers.docker.cmd="docker run --rm -v /tmp:/tmp -p 9090:9090 -v $(pwd):/app:rw -t ghcr.io/cyclonedx/cdxgen -r /app --server"
+      org.opencontainers.image.description="Container image for cdxgen SBOM generator packing latest build tools with secure defaults." \
+      org.opencontainers.docker.cmd="docker run --rm -v /tmp:/tmp -p 9090:9090 -v $(pwd):/app:rw -t ghcr.io/cyclonedx/cdxgen-secure cdxgen -r /app --server"
 
 ARG SWIFT_SIGNING_KEY=52BB7E3DE28A71BE22EC05FFEF80A866B47A981F
 ARG SWIFT_PLATFORM=ubi9
@@ -24,6 +24,7 @@ ARG GO_VERSION=1.24.3
 ARG NODE_VERSION=24.0.2
 ARG PYTHON_VERSION=3.12
 ARG RUBY_VERSION=3.4.3
+ARG JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF-8"
 ARG SCALA_VERSION=3.6.4
 
 ENV GOPATH=/opt/app-root/go \
@@ -32,19 +33,19 @@ ENV GOPATH=/opt/app-root/go \
     MAVEN_VERSION=$MAVEN_VERSION \
     GRADLE_VERSION=$GRADLE_VERSION \
     GRADLE_OPTS="-Dorg.gradle.daemon=false" \
-    JAVA_HOME="/root/.sdkman/candidates/java/${JAVA_VERSION}" \
-    MAVEN_HOME="/root/.sdkman/candidates/maven/${MAVEN_VERSION}" \
-    GRADLE_HOME="/root/.sdkman/candidates/gradle/${GRADLE_VERSION}" \
-    SBT_HOME="/root/.sdkman/candidates/sbt/${SBT_VERSION}" \
+    JAVA_HOME="/opt/.sdkman/candidates/java/${JAVA_VERSION}" \
+    MAVEN_HOME="/opt/.sdkman/candidates/maven/${MAVEN_VERSION}" \
+    GRADLE_HOME="/opt/.sdkman/candidates/gradle/${GRADLE_VERSION}" \
+    SBT_HOME="/opt/.sdkman/candidates/sbt/${SBT_VERSION}" \
     SCALA_VERSION=$SCALA_VERSION \
-    SCALA_HOME="/root/.sdkman/candidates/scala/${SCALA_VERSION}" \
+    SCALA_HOME="/opt/.sdkman/candidates/scala/${SCALA_VERSION}" \
     PYTHON_VERSION=3.12 \
     PYTHON_CMD=/usr/bin/python3.12 \
     RUBY_VERSION=$RUBY_VERSION \
     PYTHONUNBUFFERED=1 \
     PYTHONIOENCODING="utf-8" \
     COMPOSER_ALLOW_SUPERUSER=1 \
-    JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF-8 --enable-native-access=ALL-UNNAMED" \
+    JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS \
     SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \
     SWIFT_PLATFORM=$SWIFT_PLATFORM \
     SWIFT_BRANCH=$SWIFT_BRANCH \
@@ -53,16 +54,17 @@ ENV GOPATH=/opt/app-root/go \
     LC_ALL=en_US.UTF-8 \
     LANG=en_US.UTF-8 \
     LANGUAGE=en_US.UTF-8 \
-    NVM_DIR="/root/.nvm" \
+    NVM_DIR="/opt/.nvm" \
     TMPDIR=/tmp \
+    DOTNET_CLI_TELEMETRY_OPTOUT=1 \
     NODE_COMPILE_CACHE="/opt/cdxgen-node-cache" \
     PYTHONPATH=/opt/pypi:${PYTHONPATH} \
     CDXGEN_IN_CONTAINER=true \
-    SDKMAN_DIR=/root/.sdkman \
-    SDKMAN_CANDIDATES_DIR=/root/.sdkman/candidates \
-    DOTNET_CLI_TELEMETRY_OPTOUT=1 \
+    CDXGEN_TEMP_DIR=/tmp/cdxgen-temp \
+    SDKMAN_DIR=/opt/.sdkman \
+    SDKMAN_CANDIDATES_DIR=/opt/.sdkman/candidates \
     RBENV_ROOT=/opt/.rbenv
-ENV PATH=${PATH}:/root/.nvm/versions/node/v${NODE_VERSION}/bin:${JAVA_HOME}/bin:${MAVEN_HOME}/bin:${GRADLE_HOME}/bin:${SCALA_HOME}/bin:${SBT_HOME}/bin:${GOPATH}/bin:/usr/local/go/bin:/usr/local/bin/:/root/.local/bin:/root/.cargo/bin:/opt/pypi/bin:/opt/.rbenv/bin:/opt/.rbenv/versions/3.4.3/bin:
+ENV PATH=${PATH}:/opt/bin:/opt/.nvm/versions/node/v${NODE_VERSION}/bin:${JAVA_HOME}/bin:${MAVEN_HOME}/bin:${GRADLE_HOME}/bin:${SCALA_HOME}/bin:${SBT_HOME}/bin:${GOPATH}/bin:/usr/local/go/bin:/usr/local/bin/:/opt/.local/bin:/opt/pypi/bin:/opt/.rbenv/bin:/opt/.rbenv/versions/3.4.3/bin:
 
 COPY . /opt/cdxgen
 
@@ -83,7 +85,7 @@ RUN set -e; \
     && microdnf install -y php php-curl php-zip php-bcmath php-json php-pear php-mbstring php-devel make gcc git-core \
         python${PYTHON_VERSION} python${PYTHON_VERSION}-devel python${PYTHON_VERSION}-pip glibc-common glibc-all-langpacks \
         openssl-devel libffi-devel libyaml zlib-devel \
-        pcre2 which tar gzip zip unzip bzip2 sudo ncurses ncurses-devel sqlite-devel gnupg2 dotnet-sdk-9.0 \
+        pcre2 which tar gzip zip unzip bzip2 sudo ncurses ncurses-devel sqlite-devel gnupg2 dotnet-sdk-9.0 rust cargo \
     && ruby --version \
     && which ruby \
     && alternatives --install /usr/bin/python3 python /usr/bin/python${PYTHON_VERSION} 10 \
@@ -94,21 +96,21 @@ RUN set -e; \
     && /opt/pypi/bin/poetry --version \
     && /opt/pypi/bin/pipenv --version \
     && /opt/pypi/bin/blint --help \
-    && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
+    && mkdir -p /opt/bin /opt/.nvm /tmp/cdxgen-temp \
     && cargo --version \
     && rustc --version \
     && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash \
-    && source /root/.nvm/nvm.sh \
+    && source ${NVM_DIR}/nvm.sh \
     && nvm install ${NODE_VERSION} \
     && node --version \
     && curl -s "https://get.sdkman.io" | bash \
-    && echo -e "sdkman_auto_answer=true\nsdkman_selfupdate_feature=false\nsdkman_auto_env=true\nsdkman_curl_connect_timeout=20\nsdkman_curl_max_time=0" >> $HOME/.sdkman/etc/config \
-    && source "$HOME/.sdkman/bin/sdkman-init.sh" \
-    && sdk install java $JAVA_VERSION \
-    && sdk install maven $MAVEN_VERSION \
-    && sdk install gradle $GRADLE_VERSION \
-    && sdk install scala $SCALA_VERSION \
-    && sdk install sbt $SBT_VERSION \
+    && echo -e "sdkman_auto_answer=true\nsdkman_selfupdate_feature=false\nsdkman_auto_env=true\nsdkman_curl_connect_timeout=20\nsdkman_curl_max_time=0" >> /opt/.sdkman/etc/config \
+    && source "/opt/.sdkman/bin/sdkman-init.sh" \
+    && sdk install java $JAVA_VERSION /opt/.sdkman/candidates/java \
+    && sdk install maven $MAVEN_VERSION /opt/.sdkman/candidates/maven \
+    && sdk install gradle $GRADLE_VERSION /opt/.sdkman/candidates/gradle \
+    && sdk install scala $SCALA_VERSION /opt/.sdkman/candidates/scala \
+    && sdk install sbt $SBT_VERSION /opt/.sdkman/candidates/sbt \
     && SWIFT_WEBDIR="$SWIFT_WEBROOT/$SWIFT_BRANCH/$(echo $SWIFT_PLATFORM | tr -d .)$OS_ARCH_SUFFIX" \
     && SWIFT_BIN_URL="$SWIFT_WEBDIR/$SWIFT_VERSION/$SWIFT_VERSION-$SWIFT_PLATFORM$OS_ARCH_SUFFIX.tar.gz" \
     && SWIFT_SIG_URL="$SWIFT_BIN_URL.sig" \
@@ -131,10 +133,12 @@ RUN set -e; \
     && /usr/local/bin/lein \
     && curl -L -O https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
     && chmod +x linux-install.sh \
-    && ./linux-install.sh \
+    && ./linux-install.sh && rm linux-install.sh \
     && curl -L --output /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-${GOBIN_VERSION} \
     && chmod +x /usr/local/bin/bazel \
     && useradd -ms /bin/bash cyclonedx \
+    && mv /root/.bashrc /home/cyclonedx/.bashrc \
+    && chown -R cyclonedx:cyclonedx /home/cyclonedx/.bashrc \
     && npm install --global corepack@latest \
     && npm install -g node-gyp @microsoft/rush --omit=dev \
     && npx node-gyp install \
@@ -146,12 +150,14 @@ RUN set -e; \
     && gem install bundler cocoapods \
     && gem --version \
     && bundler --version \
-    && cd /opt/cdxgen && corepack enable && corepack pnpm install --config.strict-dep-builds=true --prod --package-import-method copy --frozen-lockfile && corepack pnpm cache delete \
+    && cd /opt/cdxgen && corepack enable pnpm && pnpm config set global-bin-dir /opt/bin \
+    && pnpm install --config.strict-dep-builds=true --prod --package-import-method copy --frozen-lockfile && pnpm link && pnpm cache delete \
+    && pnpm bin && pnpm bin -g \
     && mkdir -p /opt/cdxgen-node-cache \
     && chown -R cyclonedx:cyclonedx /opt/cdxgen /opt/cdxgen-node-cache \
     && chmod a-w -R /opt \
-    && node /opt/cdxgen/bin/cdxgen.js --help \
     && rm -rf /var/cache/yum /root/.cache/pypoetry /root/.cache/node \
     && microdnf clean all
+USER cyclonedx
 WORKDIR /app
-ENTRYPOINT ["node", "/opt/cdxgen/bin/cdxgen.js"]
+CMD ["cdxgen"]

--- a/ci/Dockerfile-bun
+++ b/ci/Dockerfile-bun
@@ -1,10 +1,10 @@
-FROM almalinux:9.6-minimal
+FROM almalinux:10.0-minimal
 
 LABEL maintainer="cyclonedx" \
       org.opencontainers.image.authors="Prabhu Subramanian <prabhu@appthreat.com>" \
       org.opencontainers.image.source="https://github.com/cyclonedx/cdxgen" \
       org.opencontainers.image.url="https://github.com/cyclonedx/cdxgen" \
-      org.opencontainers.image.version="11.3.x" \
+      org.opencontainers.image.version="11.4.x" \
       org.opencontainers.image.vendor="cyclonedx" \
       org.opencontainers.image.licenses="Apache-2.0" \
       org.opencontainers.image.title="cdxgen" \
@@ -35,7 +35,6 @@ ENV GOPATH=/opt/app-root/go \
     SBT_HOME="/root/.sdkman/candidates/sbt/${SBT_VERSION}" \
     PYTHON_VERSION=3.12 \
     PYTHON_CMD=/usr/bin/python3.12 \
-    RUBY_VERSION=$RUBY_VERSION \
     PYTHONUNBUFFERED=1 \
     PYTHONIOENCODING="utf-8" \
     COMPOSER_ALLOW_SUPERUSER=1 \
@@ -114,7 +113,7 @@ RUN set -e; \
     && /usr/local/bin/lein \
     && curl -L -O https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
     && chmod +x linux-install.sh \
-    && ./linux-install.sh \
+    && ./linux-install.sh && rm linux-install.sh \
     && useradd -ms /bin/bash cyclonedx \
     && pecl channel-update pecl.php.net \
     && pecl install timezonedb \

--- a/ci/Dockerfile-deno
+++ b/ci/Dockerfile-deno
@@ -4,7 +4,7 @@ LABEL maintainer="cyclonedx" \
       org.opencontainers.image.authors="Prabhu Subramanian <prabhu@appthreat.com>" \
       org.opencontainers.image.source="https://github.com/cyclonedx/cdxgen" \
       org.opencontainers.image.url="https://github.com/cyclonedx/cdxgen" \
-      org.opencontainers.image.version="11.3.x" \
+      org.opencontainers.image.version="11.4.x" \
       org.opencontainers.image.vendor="cyclonedx" \
       org.opencontainers.image.licenses="Apache-2.0" \
       org.opencontainers.image.title="cdxgen" \
@@ -133,7 +133,7 @@ RUN set -e; \
     && /usr/local/bin/lein \
     && curl -L -O https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
     && chmod +x linux-install.sh \
-    && ./linux-install.sh \
+    && ./linux-install.sh && rm linux-install.sh \
     && curl -L --output /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-${GOBIN_VERSION} \
     && chmod +x /usr/local/bin/bazel \
     && bazel --version \

--- a/ci/Dockerfile-ppc64
+++ b/ci/Dockerfile-ppc64
@@ -1,10 +1,10 @@
-FROM almalinux:9.6-minimal
+FROM almalinux:10.0-minimal
 
 LABEL maintainer="cyclonedx" \
       org.opencontainers.image.authors="Prabhu Subramanian <prabhu@appthreat.com>" \
       org.opencontainers.image.source="https://github.com/cyclonedx/cdxgen" \
       org.opencontainers.image.url="https://github.com/cyclonedx/cdxgen" \
-      org.opencontainers.image.version="11.3.x" \
+      org.opencontainers.image.version="11.4.x" \
       org.opencontainers.image.vendor="cyclonedx" \
       org.opencontainers.image.licenses="Apache-2.0" \
       org.opencontainers.image.title="cdxgen" \
@@ -85,7 +85,7 @@ RUN set -e; \
     && /usr/local/bin/lein \
     && curl -L -O https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
     && chmod +x linux-install.sh \
-    && ./linux-install.sh \
+    && ./linux-install.sh && rm linux-install.sh \
     && useradd -ms /bin/bash cyclonedx \
     && npm install -g corepack \
     && npm install -g @microsoft/rush --omit=dev \

--- a/ci/Dockerfile-secure
+++ b/ci/Dockerfile-secure
@@ -9,7 +9,7 @@ LABEL maintainer="cyclonedx" \
       org.opencontainers.image.licenses="Apache-2.0" \
       org.opencontainers.image.title="cdxgen" \
       org.opencontainers.image.description="Container image for cdxgen SBOM generator packing latest build tools with secure defaults." \
-      org.opencontainers.docker.cmd="docker run --rm -v /tmp:/tmp -p 9090:9090 -v $(pwd):/app:rw -t ghcr.io/cyclonedx/cdxgen-secure cdxgen -r /app --server"
+      org.opencontainers.docker.cmd="docker run --rm -v /tmp:/tmp -p 9090:9090 -v $(pwd):/app:rw -t ghcr.io/cyclonedx/cdxgen-secure -r /app --server"
 
 ENV NODE_OPTIONS='--permission --allow-fs-read="/app/*" --allow-fs-read="/opt/*" --allow-fs-read="/home/cyclonedx/*" --allow-fs-read="/tmp/cdxgen-temp/*" --allow-fs-write="/tmp/cdxgen-temp/*" --allow-fs-write="/app/*.json" --allow-child-process --trace-warnings' \
     NODE_NO_WARNINGS=1 \
@@ -17,4 +17,4 @@ ENV NODE_OPTIONS='--permission --allow-fs-read="/app/*" --allow-fs-read="/opt/*"
     COMPOSER_ALLOW_SUPERUSER=0
 USER cyclonedx
 WORKDIR /app
-CMD ["cdxgen"]
+ENTRYPOINT ["cdxgen"]

--- a/ci/Dockerfile-secure
+++ b/ci/Dockerfile-secure
@@ -1,169 +1,20 @@
-FROM ghcr.io/cyclonedx/cdxgen-ruby-builder:master
+FROM ghcr.io/cyclonedx/cdxgen:master
 
 LABEL maintainer="cyclonedx" \
       org.opencontainers.image.authors="Prabhu Subramanian <prabhu@appthreat.com>" \
       org.opencontainers.image.source="https://github.com/cyclonedx/cdxgen" \
       org.opencontainers.image.url="https://github.com/cyclonedx/cdxgen" \
-      org.opencontainers.image.version="11.3.x" \
+      org.opencontainers.image.version="11.4.x" \
       org.opencontainers.image.vendor="cyclonedx" \
       org.opencontainers.image.licenses="Apache-2.0" \
       org.opencontainers.image.title="cdxgen" \
       org.opencontainers.image.description="Container image for cdxgen SBOM generator packing latest build tools with secure defaults." \
       org.opencontainers.docker.cmd="docker run --rm -v /tmp:/tmp -p 9090:9090 -v $(pwd):/app:rw -t ghcr.io/cyclonedx/cdxgen-secure cdxgen -r /app --server"
 
-ARG SWIFT_SIGNING_KEY=52BB7E3DE28A71BE22EC05FFEF80A866B47A981F
-ARG SWIFT_PLATFORM=ubi9
-ARG SWIFT_BRANCH=swift-6.1-release
-ARG SWIFT_VERSION=swift-6.1-RELEASE
-ARG SWIFT_WEBROOT=https://download.swift.org
-ARG JAVA_VERSION=24-tem
-ARG SBT_VERSION=1.10.11
-ARG MAVEN_VERSION=3.9.9
-ARG GRADLE_VERSION=8.14
-ARG GO_VERSION=1.24.3
-ARG NODE_VERSION=24.0.2
-ARG PYTHON_VERSION=3.12
-ARG RUBY_VERSION=3.4.3
-ARG JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF-8"
-ARG SCALA_VERSION=3.6.4
-
-ENV GOPATH=/opt/app-root/go \
-    JAVA_VERSION=$JAVA_VERSION \
-    SBT_VERSION=$SBT_VERSION \
-    MAVEN_VERSION=$MAVEN_VERSION \
-    GRADLE_VERSION=$GRADLE_VERSION \
-    GRADLE_OPTS="-Dorg.gradle.daemon=false" \
-    JAVA_HOME="/opt/.sdkman/candidates/java/${JAVA_VERSION}" \
-    MAVEN_HOME="/opt/.sdkman/candidates/maven/${MAVEN_VERSION}" \
-    GRADLE_HOME="/opt/.sdkman/candidates/gradle/${GRADLE_VERSION}" \
-    SBT_HOME="/opt/.sdkman/candidates/sbt/${SBT_VERSION}" \
-    SCALA_VERSION=$SCALA_VERSION \
-    SCALA_HOME="/opt/.sdkman/candidates/scala/${SCALA_VERSION}" \
-    PYTHON_VERSION=3.12 \
-    PYTHON_CMD=/usr/bin/python3.12 \
-    RUBY_VERSION=$RUBY_VERSION \
-    PYTHONUNBUFFERED=1 \
-    PYTHONIOENCODING="utf-8" \
-    COMPOSER_ALLOW_SUPERUSER=1 \
-    JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS \
-    SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \
-    SWIFT_PLATFORM=$SWIFT_PLATFORM \
-    SWIFT_BRANCH=$SWIFT_BRANCH \
-    SWIFT_VERSION=$SWIFT_VERSION \
-    SWIFT_WEBROOT=$SWIFT_WEBROOT \
-    LC_ALL=en_US.UTF-8 \
-    LANG=en_US.UTF-8 \
-    LANGUAGE=en_US.UTF-8 \
-    NVM_DIR="/opt/.nvm" \
-    TMPDIR=/tmp \
-    DOTNET_CLI_TELEMETRY_OPTOUT=1 \
-    NODE_COMPILE_CACHE="/opt/cdxgen-node-cache" \
-    NODE_NO_WARNINGS=1 \
-    PYTHONPATH=/opt/pypi:${PYTHONPATH} \
-    CDXGEN_IN_CONTAINER=true \
-    CDXGEN_SECURE_MODE=true \
-    CDXGEN_DEBUG_MODE=debug \
-    CDXGEN_TEMP_DIR=/tmp/cdxgen-temp \
-    SDKMAN_DIR=/opt/.sdkman \
-    SDKMAN_CANDIDATES_DIR=/opt/.sdkman/candidates \
-    RBENV_ROOT=/opt/.rbenv
-ENV PATH=${PATH}:/opt/bin:/opt/.nvm/versions/node/v${NODE_VERSION}/bin:${JAVA_HOME}/bin:${MAVEN_HOME}/bin:${GRADLE_HOME}/bin:${SCALA_HOME}/bin:${SBT_HOME}/bin:${GOPATH}/bin:/usr/local/go/bin:/usr/local/bin/:/opt/.local/bin:/opt/pypi/bin:/opt/.rbenv/bin:/opt/.rbenv/versions/3.4.3/bin:
-
-COPY . /opt/cdxgen
-
-RUN set -e; \
-    ARCH_NAME="$(rpm --eval '%{_arch}')"; \
-    url=; \
-    case "${ARCH_NAME##*-}" in \
-        'x86_64') \
-            OS_ARCH_SUFFIX=''; \
-            GOBIN_VERSION='amd64'; \
-            ;; \
-        'aarch64') \
-            OS_ARCH_SUFFIX='-aarch64'; \
-            GOBIN_VERSION='arm64'; \
-            ;; \
-        *) echo >&2 "error: unsupported architecture: '$ARCH_NAME'"; exit 1 ;; \
-    esac \
-    && microdnf install -y php php-curl php-zip php-bcmath php-json php-pear php-mbstring php-devel make gcc git-core \
-        python${PYTHON_VERSION} python${PYTHON_VERSION}-devel python${PYTHON_VERSION}-pip glibc-common glibc-all-langpacks \
-        openssl-devel libffi-devel libyaml zlib-devel \
-        pcre2 which tar gzip zip unzip bzip2 sudo ncurses ncurses-devel sqlite-devel gnupg2 dotnet-sdk-9.0 rust cargo \
-    && ruby --version \
-    && which ruby \
-    && alternatives --install /usr/bin/python3 python /usr/bin/python${PYTHON_VERSION} 10 \
-    && alternatives --install /usr/bin/python3 python3 /usr/bin/python${PYTHON_VERSION} 10 \
-    && /usr/bin/python${PYTHON_VERSION} --version \
-    && /usr/bin/python${PYTHON_VERSION} -m pip install --no-cache-dir --upgrade setuptools==77.0.3 wheel pip virtualenv \
-    && /usr/bin/python${PYTHON_VERSION} -m pip install --no-cache-dir --upgrade pipenv poetry blint atom-tools uv --target /opt/pypi \
-    && /opt/pypi/bin/poetry --version \
-    && /opt/pypi/bin/pipenv --version \
-    && /opt/pypi/bin/blint --help \
-    && mkdir -p /opt/bin /opt/.nvm /tmp/cdxgen-temp \
-    && cargo --version \
-    && rustc --version \
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash \
-    && source ${NVM_DIR}/nvm.sh \
-    && nvm install ${NODE_VERSION} \
-    && node --version \
-    && curl -s "https://get.sdkman.io" | bash \
-    && echo -e "sdkman_auto_answer=true\nsdkman_selfupdate_feature=false\nsdkman_auto_env=true\nsdkman_curl_connect_timeout=20\nsdkman_curl_max_time=0" >> /opt/.sdkman/etc/config \
-    && source "/opt/.sdkman/bin/sdkman-init.sh" \
-    && sdk install java $JAVA_VERSION /opt/.sdkman/candidates/java \
-    && sdk install maven $MAVEN_VERSION /opt/.sdkman/candidates/maven \
-    && sdk install gradle $GRADLE_VERSION /opt/.sdkman/candidates/gradle \
-    && sdk install scala $SCALA_VERSION /opt/.sdkman/candidates/scala \
-    && sdk install sbt $SBT_VERSION /opt/.sdkman/candidates/sbt \
-    && SWIFT_WEBDIR="$SWIFT_WEBROOT/$SWIFT_BRANCH/$(echo $SWIFT_PLATFORM | tr -d .)$OS_ARCH_SUFFIX" \
-    && SWIFT_BIN_URL="$SWIFT_WEBDIR/$SWIFT_VERSION/$SWIFT_VERSION-$SWIFT_PLATFORM$OS_ARCH_SUFFIX.tar.gz" \
-    && SWIFT_SIG_URL="$SWIFT_BIN_URL.sig" \
-    && export GNUPGHOME="$(mktemp -d)" \
-    && curl -fsSL "$SWIFT_BIN_URL" -o swift.tar.gz "$SWIFT_SIG_URL" -o swift.tar.gz.sig \
-    && gpg --batch --quiet --keyserver keyserver.ubuntu.com --recv-keys "$SWIFT_SIGNING_KEY" \
-    && gpg --batch --verify swift.tar.gz.sig swift.tar.gz \
-    && tar -xzf swift.tar.gz --directory / --strip-components=1 \
-    && chmod -R o+r /usr/lib/swift \
-    && chmod +x /usr/bin/swift \
-    && rm -rf "$GNUPGHOME" swift.tar.gz.sig swift.tar.gz \
-    && swift --version \
-    && curl -LO "https://dl.google.com/go/go${GO_VERSION}.linux-${GOBIN_VERSION}.tar.gz" \
-    && tar -C /usr/local -xzf go${GO_VERSION}.linux-${GOBIN_VERSION}.tar.gz \
-    && rm go${GO_VERSION}.linux-${GOBIN_VERSION}.tar.gz \
-    && go telemetry off \
-    && curl -LO "https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein" \
-    && chmod +x lein \
-    && mv lein /usr/local/bin/ \
-    && /usr/local/bin/lein \
-    && curl -L -O https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
-    && chmod +x linux-install.sh \
-    && ./linux-install.sh \
-    && curl -L --output /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-${GOBIN_VERSION} \
-    && chmod +x /usr/local/bin/bazel \
-    && useradd -ms /bin/bash cyclonedx \
-    && mv /root/.bashrc /home/cyclonedx/.bashrc \
-    && chown -R cyclonedx:cyclonedx /home/cyclonedx/.bashrc \
-    && npm install --global corepack@latest \
-    && npm install -g node-gyp @microsoft/rush --omit=dev \
-    && npx node-gyp install \
-    && pecl channel-update pecl.php.net \
-    && pecl install timezonedb \
-    && echo 'extension=timezonedb.so' >> /etc/php.ini \
-    && php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" && php composer-setup.php \
-    && mv composer.phar /usr/local/bin/composer \
-    && gem install bundler cocoapods \
-    && gem --version \
-    && bundler --version \
-    && cd /opt/cdxgen && corepack enable pnpm && pnpm config set global-bin-dir /opt/bin \
-    && pnpm install --config.strict-dep-builds=true --prod --package-import-method copy --frozen-lockfile && pnpm link && pnpm cache delete \
-    && pnpm bin && pnpm bin -g \
-    && mkdir -p /opt/cdxgen-node-cache \
-    && chown -R cyclonedx:cyclonedx /opt/cdxgen /opt/cdxgen-node-cache \
-    && chmod a-w -R /opt \
-    && rm -rf /var/cache/yum /root/.cache/pypoetry /root/.cache/node \
-    && microdnf clean all
 ENV NODE_OPTIONS='--permission --allow-fs-read="/app/*" --allow-fs-read="/opt/*" --allow-fs-read="/home/cyclonedx/*" --allow-fs-read="/tmp/cdxgen-temp/*" --allow-fs-write="/tmp/cdxgen-temp/*" --allow-fs-write="/app/*.json" --allow-child-process --trace-warnings' \
+    NODE_NO_WARNINGS=1 \
+    CDXGEN_SECURE_MODE=true \
     COMPOSER_ALLOW_SUPERUSER=0
-RUN cdxgen --help
 USER cyclonedx
 WORKDIR /app
 CMD ["cdxgen"]

--- a/ci/base-images/al10/Dockerfile.ruby-builder
+++ b/ci/base-images/al10/Dockerfile.ruby-builder
@@ -1,10 +1,10 @@
-FROM almalinux:9.6-minimal AS ruby-builder
+FROM almalinux:10.0-minimal AS ruby-builder
 
 LABEL maintainer="cyclonedx" \
       org.opencontainers.image.authors="Prabhu Subramanian <prabhu@appthreat.com>" \
       org.opencontainers.image.source="https://github.com/cyclonedx/cdxgen" \
       org.opencontainers.image.url="https://github.com/cyclonedx/cdxgen" \
-      org.opencontainers.image.version="11.3.x" \
+      org.opencontainers.image.version="11.4.x" \
       org.opencontainers.image.vendor="cyclonedx" \
       org.opencontainers.image.licenses="Apache-2.0" \
       org.opencontainers.image.title="cdxgen" \

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@cyclonedx/cdxgen",
-  "version": "11.3.2",
+  "version": "11.4.0",
   "exports": "./lib/cli/index.js",
   "compilerOptions": {
     "lib": ["deno.window"],

--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@cyclonedx/cdxgen",
-  "version": "11.3.2",
+  "version": "11.4.0",
   "exports": "./lib/cli/index.js",
   "include": ["*.js", "lib/**", "bin/**", "data/**", "types/**"],
   "exclude": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cyclonedx/cdxgen",
-  "version": "11.3.2",
+  "version": "11.4.0",
   "description": "Creates CycloneDX Software Bill of Materials (SBOM) from source or container image",
   "homepage": "http://github.com/cyclonedx/cdxgen",
   "author": "Prabhu Subramanian <prabhu@appthreat.com>",


### PR DESCRIPTION
Upgrade to almalinux 10. The new images are much cleaner with just python 3.12 (without the 3.9 bloat). cdxgen-secure and cdxgen are now identical differing only in some environment variables such as NODE_OPTIONS.