### PR TITLE
[build] Moved image-builds between cloud and hosted servers

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -69,7 +69,6 @@ jobs:
 
           - lang: dotnet6
             distro: debian
-            runner: macos-hosted
 
           - lang: dotnet7
             skip-arm: true
@@ -93,6 +92,7 @@ jobs:
 
           - lang: dotnet10
             distro: debian
+            runner: macos-hosted
 
           - lang: golang123
             distro: alpine
@@ -143,26 +143,26 @@ jobs:
             distro: temurin
 
           - lang: node20
-            runner: macos-hosted
             cdxgen-image:
               additional-image: cdxgen-node
 
           - lang: php83
             distro: debian
+            runner: macos-hosted
 
           - lang: python36
-            runner: macos-hosted
 
           - lang: python39
             distro: opensuse
+            runner: macos-hosted
 
           - lang: python310
             distro: opensuse
+            runner: macos-hosted
 
           - lang: python311
 
           - lang: python312
-            runner: macos-hosted
             base-image:
               lang: lang
             cdxgen-image:
@@ -178,7 +178,6 @@ jobs:
 
           - lang: ruby26
             distro: debian
-            runner: macos-hosted
             skip-arm: true
 
           - lang: ruby33
@@ -187,7 +186,6 @@ jobs:
 
           - lang: ruby34
             distro: debian
-            runner: macos-hosted
 
           - lang: ruby344
             distro: alpine
@@ -201,7 +199,6 @@ jobs:
 
           - lang: swift6
             distro: debian
-            runner: macos-hosted
             base-image:
               additional-image: debian-swift
             cdxgen-image:

--- a/.github/workflows/build-rolling-image.yml
+++ b/.github/workflows/build-rolling-image.yml
@@ -39,6 +39,7 @@ jobs:
         {
           "lang": "rolling",
           "distro": "opensuse",
+          "runner": "macos-hosted",
           "base-image": {
             "lang": "lang"
           }


### PR DESCRIPTION
- 30min and less are built in the cloud
- the rest are built on hosted servers, even if that means they are even slower

So far, several images build faster on hosted, some are the same.
Because we currently only use a single hosted server, there's a bit of a queue there though, but at least we don't use up all cloud compute so fast...