### PR TITLE
bugfix: normalize component evidence identities to always be array

### DIFF
--- a/lib/stages/postgen/postgen.js
+++ b/lib/stages/postgen/postgen.js
@@ -225,6 +225,26 @@ export function applyStandards(bomJson, options) {
 }
 
 /**
+ * Method to normalize the identity field from a component's evidence block.
+ *
+ * In different versions of CycloneDX, the `identity` field can be either a single object or an array of objects.
+ * This function ensures that the result is always an array for consistent processing.
+ *
+ * @param {Object} comp - The component object potentially containing evidence.identity.
+ * @returns {Array} An array of identity objects (empty if none are present).
+ */
+function normalizeIdentities(comp) {
+  const identity = comp?.evidence?.identity;
+  if (Array.isArray(identity)) {
+    return identity;
+  }
+  if (identity) {
+    return [identity];
+  }
+  return [];
+}
+
+/**
  * Method to get the purl identity confidence.
  *
  * @param comp Component
@@ -235,7 +255,7 @@ function getIdentityConfidence(comp) {
     return undefined;
   }
   let confidence;
-  for (const aidentity of comp?.evidence?.identity || []) {
+  for (const aidentity of normalizeIdentities(comp)) {
     if (aidentity?.field === "purl") {
       if (confidence === undefined) {
         confidence = aidentity.confidence || 0;
@@ -258,7 +278,7 @@ function getIdentityTechniques(comp) {
     return undefined;
   }
   const techniques = new Set();
-  for (const aidentity of comp?.evidence?.identity || []) {
+  for (const aidentity of normalizeIdentities(comp)) {
     if (aidentity?.field === "purl") {
       for (const amethod of aidentity.methods || []) {
         techniques.add(amethod?.technique);


### PR DESCRIPTION
# TLDR
Normalize evidence.identity field for consistent processing across CycloneDX versions

# Summary
In different versions of CycloneDX, the evidence.identity field can be either:
* a single object, or
* an array of objects.

This inconsistency can lead to runtime issues when iterating over the field. To resolve this, this PR introduces a utility function normalizeIdentities(comp) that ensures evidence.identity is always treated as an array, allowing for safe iteration.

# Changes
**Added**: normalizeIdentities(comp) function to normalize the evidence.identity field.

**Updated**: Replaced direct iteration over comp?.evidence?.identity || [] with normalizeIdentities(comp) to handle both single-object and array formats consistently.

# Benefits
* Prevents potential runtime errors or missed identity data.
* Ensures forward/backward compatibility with varying CycloneDX schema versions.

# Linked Issue
https://github.com/CycloneDX/cdxgen/issues/1850