### PR TITLE
musl arm64 builds

### DIFF
--- a/.github/workflows/binary-builds.yml
+++ b/.github/workflows/binary-builds.yml
@@ -18,6 +18,85 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  musl-builds-arm64:
+    if: github.repository == 'CycloneDX/cdxgen'
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ 'ubuntu-22.04-arm' ]
+        include:
+          - os: ubuntu-22.04-arm
+            build: |
+              rm -rf ci contrib tools_config
+              pnpm --package=@appthreat/caxa dlx caxa --input . --output "cdxgen" -- "{{caxa}}/node_modules/.bin/node" "{{caxa}}/bin/cdxgen.js"
+              chmod +x cdxgen
+              ./cdxgen --help
+              sha256sum cdxgen > cdxgen.sha256
+              rm -rf node_modules
+              pnpm install --config.strict-dep-builds=true --virtual-store-dir node_modules/pnpm --no-optional --prod --package-import-method copy --frozen-lockfile              
+              pnpm --package=@appthreat/caxa dlx caxa --input . --output "cdxgen-slim" -- "{{caxa}}/node_modules/.bin/node" "{{caxa}}/bin/cdxgen.js"
+              chmod +x cdxgen-slim
+              ./cdxgen-slim --version
+              sha256sum cdxgen-slim > cdxgen-slim.sha256
+              pnpm --package=@appthreat/caxa dlx caxa --input . --output "cdx-verify" -- "{{caxa}}/node_modules/.bin/node" "{{caxa}}/bin/verify.js"
+              chmod +x cdx-verify
+              ./cdx-verify --version
+              sha256sum cdx-verify > cdx-verify.sha256
+              ./cdxgen --help
+              ./cdxgen-slim --help
+              ./cdx-verify --help
+              mv cdxgen cdxgen-musl-arm64
+              mv cdxgen.sha256 cdxgen-musl-arm64.sha256
+              mv cdxgen-slim cdxgen-musl-arm64-slim
+              mv cdxgen-slim.sha256 cdxgen-musl-arm64-slim.sha256
+              mv cdx-verify cdx-musl-arm64-verify
+              mv cdx-verify.sha256 cdx-musl-arm64-verify.sha256
+            artifact: cdxgen-musl-arm64
+            sartifact: cdxgen-musl-arm64-slim
+            vartifact: cdx-musl-arm64-verify
+    runs-on: ${{ matrix.os }}
+    container:
+      image: alpine:3.20
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - name: Setup alpine builder
+        run: |
+          apk add --no-cache nodejs make python3 python3-dev py3-pip py3-virtualenv gcc g++ musl-dev npm git
+      - name: Clone repo
+        env:
+          REPO_URL: https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git
+          REF: ${{ github.ref }}
+        run: |
+          if [[ "$REF" == refs/heads/* ]]; then
+            REF_NAME="${REF#refs/heads/}"
+          else
+            REF_NAME="$REF"
+          fi
+          echo "Cloning ${REF} as ${REF_NAME}"
+          git clone --depth=1 --branch "$REF_NAME" "$REPO_URL" .
+          ls -lh
+      - name: Install pnpm
+        run: |
+          npm install --global pnpm@10.12.1
+          pnpm install --config.strict-dep-builds=true --virtual-store-dir node_modules/pnpm --prod --package-import-method copy --frozen-lockfile
+      - name: Produce sae
+        run: |
+          ${{ matrix.build }}
+        env:
+          CDXGEN_DEBUG_MODE: debug
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: |
+            ${{ matrix.artifact }}
+            ${{ matrix.artifact }}.sha256
+            ${{ matrix.sartifact }}
+            ${{ matrix.sartifact }}.sha256
+            ${{ matrix.vartifact }}
+            ${{ matrix.vartifact }}.sha256
   musl-builds:
     if: github.repository == 'CycloneDX/cdxgen'
     strategy:

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/cyclonedx/cdxgen-ruby-builder:master as base
+FROM ghcr.io/cyclonedx/cdxgen-ruby-builder:master AS base
 
 ARG SWIFT_SIGNING_KEY=52BB7E3DE28A71BE22EC05FFEF80A866B47A981F
 ARG SWIFT_PLATFORM=ubi9
@@ -134,7 +134,7 @@ RUN set -e; \
     && gem --version \
     && bundler --version
 
-FROM base as cdxgen
+FROM base AS cdxgen
 
 LABEL maintainer="cyclonedx" \
       org.opencontainers.image.authors="Prabhu Subramanian <prabhu@appthreat.com>" \


### PR DESCRIPTION
Workaround the current github actions limitations with alpine containers.

```
JavaScript Actions in Alpine containers are only supported on x64 Linux runners. Detected Linux Arm64
```
