### PR TITLE
[build] Configured all checkouts to NOT persist the credentials

### DIFF
--- a/.github/workflows/binary-builds.yml
+++ b/.github/workflows/binary-builds.yml
@@ -141,6 +141,8 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Setup alpine builder
         run: |
           apk add --no-cache nodejs make python3 python3-dev py3-pip py3-virtualenv gcc g++ musl-dev npm
@@ -267,6 +269,8 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/dockertests.yml
+++ b/.github/workflows/dockertests.yml
@@ -20,6 +20,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
@@ -49,6 +51,7 @@ jobs:
           CDXGEN_TEMP_DIR: ${{ runner.temp }}/cdxgen-dockertests
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           repository: 'grafana-operator/grafana-operator'
           path: 'repotests/grafana-operator'
       - name: dockertests
@@ -98,6 +101,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
@@ -146,6 +151,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
@@ -190,6 +197,8 @@ jobs:
         java-version: ['24']
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -27,6 +27,8 @@ jobs:
     runs-on: ${{ fromJSON(inputs.image).runner || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Free disk space
         if: ${{ ! fromJSON(inputs.image).runner }}
         uses: jlumbroso/free-disk-space@main

--- a/.github/workflows/java-reachables-test.yml
+++ b/.github/workflows/java-reachables-test.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
@@ -34,11 +36,13 @@ jobs:
           mkdir -p bomresults
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           repository: 'DependencyTrack/dependency-track'
           path: 'repotests/dependency-track'
           ref: '4.11.1'
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           repository: 'DependencyTrack/frontend'
           path: 'repotests/frontend'
           ref: '4.13.0'
@@ -69,17 +73,21 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: setup paths
         run: |
           mkdir -p repotests
           mkdir -p rubyresults
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           repository: 'bionomia/bionomia'
           path: 'repotests/bionomia'
           ref: '5ada8b5f4a5f68561a7195e2badc2f744dc4676e'
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           repository: 'OWASP/railsgoat'
           path: 'repotests/railsgoat'
           ref: 'c1e8ff1e3b24a1c48fcfc9fbee0f65dc296b49d9'
@@ -108,8 +116,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           repository: 'playframework/play-samples'
           path: 'repotests/play-samples'
           ref: '0dccba17856e89dbb5e457ab760efb14cc691395'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -21,6 +21,8 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -72,6 +74,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
@@ -123,6 +127,8 @@ jobs:
     runs-on: ${{ matrix.os }}-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
@@ -149,6 +155,8 @@ jobs:
         os: [macos-latest]
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Trim CI agent
         run: |
           chmod +x contrib/free_disk_space.sh

--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -26,6 +26,8 @@ jobs:
       id-token: write
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Use Node.js
       uses: actions/setup-node@v4
       with:
@@ -68,6 +70,8 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
@@ -111,6 +115,8 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
@@ -156,6 +162,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           fetch-depth: 0
       - uses: docker/login-action@v3
         with:
@@ -184,6 +191,8 @@ jobs:
       id-token: write
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Use Node.js
       uses: actions/setup-node@v4
       with:
@@ -265,6 +274,8 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
@@ -333,6 +344,8 @@ jobs:
       id-token: write
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Use Node.js
       uses: actions/setup-node@v4
       with:
@@ -401,6 +414,8 @@ jobs:
       id-token: write
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Use Node.js
       uses: actions/setup-node@v4
       with:
@@ -451,6 +466,8 @@ jobs:
       id-token: write
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Use Node.js
       uses: actions/setup-node@v4
       with:

--- a/.github/workflows/nydus-demo.yml
+++ b/.github/workflows/nydus-demo.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
@@ -24,6 +26,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           repository: 'DependencyTrack/dependency-track'
           path: 'repotests/dependency-track'
       - name: setup nydus

--- a/.github/workflows/python-atom-tests.yml
+++ b/.github/workflows/python-atom-tests.yml
@@ -12,6 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           fetch-depth: 0
       - uses: coursier/cache-action@v6
       - name: Use Node.js
@@ -34,35 +35,43 @@ jobs:
           CI: true
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           repository: 'scipy/scipy'
           path: 'repotests/scipy'
           ref: 'v1.15.2'
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           repository: 'psf/black'
           path: 'repotests/black'
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           repository: 'psf/pyperf'
           path: 'repotests/pyperf'
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           repository: 'psf/cachecontrol'
           path: 'repotests/cachecontrol'
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           repository: 'pallets/flask'
           path: 'repotests/flask'
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           repository: 'pallets/click'
           path: 'repotests/click'
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           repository: 'pallets/jinja'
           path: 'repotests/jinja'
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           repository: 'pypa/bandersnatch'
           path: 'repotests/bandersnatch'
       - name: repotests

--- a/.github/workflows/repotests.yml
+++ b/.github/workflows/repotests.yml
@@ -18,12 +18,16 @@ jobs:
     runs-on: ["self-hosted", "ubuntu", "amd64"]
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           repository: 'hoolicorp/java-sec-code'
           path: 'repotests/java-sec-code'
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           repository: 'wix/greyhound'
           path: 'repotests/greyhound'
           ref: '385bb84a6f712ee18064a3b5ecb8d9dcbc1c75f3'
@@ -63,31 +67,38 @@ jobs:
     runs-on: ["self-hosted", "ubuntu", "arm64"]
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@v5
         with:
           go-version: '1.23'
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           repository: 'aws-solutions/iot-device-simulator'
           path: 'repotests/iot-device-simulator'
           ref: 'v3.0.9'
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           repository: 'ollama/ollama'
           path: 'repotests/ollama'
           ref: 'v0.5.7'
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           repository: 'caddyserver/caddy'
           path: 'repotests/caddy'
           ref: 'v2.9.1'
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           repository: 'flutter/gallery'
           ref: 'v2.10.2'
           path: 'repotests/gallery'
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           repository: 'ShiftLeftSecurity/shiftleft-go-example'
           path: 'repotests/shiftleft-go-example'
       - name: Trim CI agent
@@ -136,6 +147,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
@@ -226,218 +239,265 @@ jobs:
           pip install custom-json-diff
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           repository: 'ShiftLeftSecurity/shiftleft-java-example'
           path: 'repotests/shiftleft-java-example'
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           repository: 'ShiftLeftSecurity/shiftleft-ts-example'
           path: 'repotests/shiftleft-ts-example'
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           repository: 'HooliCorp/vulnerable_net_core'
           path: 'repotests/vulnerable_net_core'
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           repository: 'HooliCorp/Goatly.NET'
           path: 'repotests/Goatly.NET'
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           repository: 'HooliCorp/DjanGoat'
           path: 'repotests/DjanGoat'
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           repository: 'prabhu/Vulnerable-Web-Application'
           path: 'repotests/Vulnerable-Web-Application'
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           repository: 'prabhu/railsgoat'
           path: 'repotests/railsgoat'
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           repository: 'bazelbuild/examples'
           path: 'repotests/bazel-examples'
           ref: 'b51e3bdd468ce8c4a516d7dca993909dcc84af32'
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           repository: 'gojek/ziggurat'
           ref: '4.9.4'
           path: 'repotests/ziggurat'
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           repository: 'apple/swift-markdown'
           ref: '0.3.0'
           path: 'repotests/swift-markdown'
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           repository: 'GoogleCloudPlatform/microservices-demo'
           ref: 'v0.8.1'
           path: 'repotests/microservices-demo'
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           repository: 'zoom/meetingsdk-vuejs-sample'
           ref: 'v2.18.0'
           path: 'repotests/meetingsdk-vuejs-sample'
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           repository: 'kriasoft/react-app'
           path: 'repotests/react-app'
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           repository: 'patrickjuchli/basic-ftp'
           path: 'repotests/basic-ftp'
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           repository: 'Atome-FE/llama-node'
           path: 'repotests/llama-node'
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           repository: 'DIYgod/RSSHub'
           path: 'repotests/RSSHub'
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           repository: 'sveltejs/examples'
           path: 'repotests/sveltejs-examples'
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           repository: 'openpbs/openpbs'
           ref: 'v23.06.06'
           path: 'repotests/openpbs'
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           repository: 'home-assistant/android'
           ref: '2023.11.3'
           path: 'repotests/ha-android'
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           repository: 'rust-lang/rust'
           ref: '1.74.0'
           path: 'repotests/rs-rust'
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           repository: 'rust-lang/cargo'
           ref: '0.75.0'
           path: 'repotests/rs-cargo'
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           repository: 'Keats/validator'
           ref: 'v0.15.0'
           path: 'repotests/rs-validator'
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           repository: 'tokio-rs/axum'
           ref: 'axum-v0.6.20'
           path: 'repotests/rs-axum'
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           repository: 'fsprojects/FAKE'
           ref: '6.0.0'
           path: 'repotests/dotnet-paket'
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           repository: 'timheuer/SimpleFrameworkApp'
           ref: 'master'
           path: 'repotests/SimpleFrameworkApp'
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           repository: 'chabbasaad/Reporting-Windows-Application'
           ref: 'master'
           path: 'repotests/Reporting-Windows-Application'
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           repository: 'appthreat/blint'
           ref: 'v1.0.34'
           path: 'repotests/blint'
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           repository: 'hoolicorp/java-sec-code'
           path: 'repotests/java-sec-code'
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           repository: 'DefectDojo/django-DefectDojo'
           ref: '2.28.2'
           path: 'repotests/django-DefectDojo'
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           repository: 'googleprojectzero/Jackalope'
           path: 'repotests/Jackalope'
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           repository: 'hritik14/broken-mvn-wrapper'
           path: 'repotests/broken-mvn-wrapper'
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           repository: 'microsoft/dotnet-podcasts'
           path: 'repotests/dotnet-podcasts'
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           repository: 'microsoft/react-native-windows'
           path: 'repotests/react-native-windows'
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           repository: 'oracle/dbt-oracle'
           path: 'repotests/dbt-oracle'
           ref: 'v1.7.6'
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           repository: 'fortra/impacket'
           path: 'repotests/impacket'
           ref: 'impacket_0_9_20'
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           repository: 'wix/greyhound'
           path: 'repotests/greyhound'
           ref: '385bb84a6f712ee18064a3b5ecb8d9dcbc1c75f3'
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           repository: 'owasp-dep-scan/blint'
           path: 'repotests/blint'
           ref: 'v2.2.2'
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           repository: 'malice00/cdxgen-expo-test'
           ref: 'main'
           path: 'repotests/expo-test'
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           repository: 'malice00/cdxgen-cocoapods-test'
           ref: 'main'
           path: 'repotests/cocoapods-test'
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           repository: 'elastic/elasticsearch'
           path: 'repotests/elasticsearch'
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           repository: 'quarkusio/quarkus-quickstarts'
           path: 'repotests/quarkus-quickstarts'
           ref: '3.17.3'
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           repository: 'aws-solutions/iot-device-simulator'
           path: 'repotests/iot-device-simulator'
           ref: 'v3.0.9'
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           repository: 'bionomia/bionomia'
           path: 'repotests/bionomia'
           ref: '5ada8b5f4a5f68561a7195e2badc2f744dc4676e'
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           repository: 'MaibornWolff/SecObserve'
           path: 'repotests/SecObserve'
           ref: 'v1.28.0'
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           repository: 'SeanyCash/TwinCAT_CNC'
           path: 'repotests/TwinCAT_CNC'
           ref: '0e1020338c10cf77249aeaff34520f9516816167'
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           repository: 'playframework/play-samples'
           path: 'repotests/play-samples'
           ref: '0dccba17856e89dbb5e457ab760efb14cc691395'
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           repository: 'com-lihaoyi/mill'
           path: 'repotests/mill'
           ref: '0.12.10'
@@ -850,6 +910,8 @@ jobs:
       NODE_NO_WARNINGS: 1
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
@@ -914,15 +976,18 @@ jobs:
           pip install custom-json-diff
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           repository: 'hoolicorp/java-sec-code'
           path: 'repotests/java-sec-code'
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           repository: 'quarkusio/quarkus-quickstarts'
           path: 'repotests/quarkus-quickstarts'
           ref: '3.17.3'
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           repository: 'aws-solutions/iot-device-simulator'
           path: 'repotests/iot-device-simulator'
           ref: 'v3.0.9'

--- a/.github/workflows/snapshot-tests.yml
+++ b/.github/workflows/snapshot-tests.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
 
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v4


### PR DESCRIPTION
By default, the checkout-action persists the credential into the workspace. This is an insecure practice, so this PR sets this option to `false` on all checkouts.

This fixes #1881 