### PR TITLE
proto upgrade

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -46,7 +46,7 @@ jobs:
       - name: check sbom for vulns
         if: github.ref == 'refs/heads/master'
         run: |
-          node bin/cdxgen.js -t js -o $(pwd)/reports/sbom-build-js.cdx.json --no-recurse --profile research $(pwd)
+          node bin/cdxgen.js -t js -o $(pwd)/reports/sbom-build-js.cdx.json --export-proto --proto-bin-file $(pwd)/reports/sbom-build-js.cdx.proto --no-recurse --profile research $(pwd)
           docker pull ghcr.io/cyclonedx/cdxgen:master
           node bin/cdxgen.js -t docker -o $(pwd)/reports/sbom-container-js.cdx.json ghcr.io/cyclonedx/cdxgen:master
           depscan --src $(pwd) --bom-dir $(pwd)/reports --reports-dir $(pwd)/reports --reachability-analyzer SemanticReachability --explain
@@ -57,7 +57,7 @@ jobs:
       - name: Generate atom and slices
         if: startsWith(github.ref, 'refs/tags/')
         run: |
-          node bin/cdxgen.js -t js -o $(pwd)/reports/sbom-build-js.cdx.json --no-recurse --profile research $(pwd)
+          node bin/cdxgen.js -t js -o $(pwd)/reports/sbom-build-js.cdx.json --export-proto --proto-bin-file $(pwd)/reports/sbom-build-js.cdx.proto --no-recurse --profile research $(pwd)
       - name: Upload atom and slices
         uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
@@ -67,6 +67,7 @@ jobs:
             reports/js-reachables.slices.json
             reports/js-usages.slices.json
             reports/sbom-build-js.cdx.json
+            reports/sbom-build-js.cdx.proto
   matrix-unit-test:
     permissions:
       contents: read

--- a/README.md
+++ b/README.md
@@ -152,7 +152,8 @@ Options:
       --validate               Validate the generated SBOM using json schema. Defaults to true. Pass --no-validate to di
                                sable.                                                          [boolean] [default: true]
       --evidence               Generate SBOM with evidence for supported languages.           [boolean] [default: false]
-      --spec-version           CycloneDX Specification version to use. Defaults to 1.6           [number] [default: 1.6]
+      --spec-version           CycloneDX Specification version to use. Defaults to 1.6
+                                                                        [number] [choices: 1.4, 1.5, 1.6] [default: 1.6]
       --filter                 Filter components containing this word in purl or component.properties.value. Multiple va
                                lues allowed.                                                                     [array]
       --only                   Include components only containing this word in purl. Useful to generate BOM with first p
@@ -163,6 +164,8 @@ Options:
   [choices: "appsec", "research", "operational", "threat-modeling", "license-compliance", "generic", "machine-learning",
                                                        "ml", "deep-learning", "ml-deep", "ml-tiny"] [default: "generic"]
       --exclude                Additional glob pattern(s) to ignore                                              [array]
+      --export-proto           Serialize and export BOM as protobuf binary.                   [boolean] [default: false]
+      --proto-bin-file         Path for the serialized protobuf binary.                             [default: "bom.cdx"]
       --include-formulation    Generate formulation section with git metadata and build tools. Defaults to false.
                                                                                               [boolean] [default: false]
       --include-crypto         Include crypto libraries as components.                        [boolean] [default: false]

--- a/bin/cdxgen.js
+++ b/bin/cdxgen.js
@@ -1058,7 +1058,7 @@ const needsBomSigning = ({ generateKeyAndSign }) =>
     if (!validateBom(bomNSData.bomJson)) {
       process.exit(1);
     }
-    thoughtLog("BOM file looks valid. Thank you for using cdxgen!");
+    thoughtLog("✅ BOM file looks valid.");
   }
   thoughtEnd();
   // Automatically submit the bom data
@@ -1075,6 +1075,7 @@ const needsBomSigning = ({ generateKeyAndSign }) =>
   if (options.exportProto) {
     const protobomModule = await import("../lib/helpers/protobom.js");
     protobomModule.writeBinary(bomNSData.bomJson, options.protoBinFile);
+    thoughtLog("BOM file is also available in .proto format!");
   }
   if (options.print && bomNSData.bomJson && bomNSData.bomJson.components) {
     printSummary(bomNSData.bomJson);

--- a/bin/cdxgen.js
+++ b/bin/cdxgen.js
@@ -266,12 +266,10 @@ const args = yargs(hideBin(process.argv))
     type: "boolean",
     default: false,
     description: "Serialize and export BOM as protobuf binary.",
-    hidden: true,
   })
   .option("proto-bin-file", {
     description: "Path for the serialized protobuf binary.",
     default: "bom.cdx",
-    hidden: true,
   })
   .option("include-formulation", {
     type: "boolean",

--- a/bin/repl.js
+++ b/bin/repl.js
@@ -20,6 +20,7 @@ import {
   printTable,
   printVulnerabilities,
 } from "../lib/helpers/display.js";
+import { readBinary } from "../lib/helpers/protobom.js";
 import { getTmpDir } from "../lib/helpers/utils.js";
 import { validateBom } from "../lib/helpers/validator.js";
 
@@ -79,6 +80,12 @@ export const importSbom = (sbomOrPath) => {
     } catch (e) {
       console.log(`⚠ Unable to import the BOM from ${sbomOrPath} due to ${e}`);
     }
+  } else if (
+    (sbomOrPath?.endsWith(".cdx") || sbomOrPath?.endsWith(".proto")) &&
+    fs.existsSync(sbomOrPath)
+  ) {
+    sbom = readBinary(sbomOrPath, true);
+    printSummary(sbom);
   } else {
     console.log(`⚠ ${sbomOrPath} is invalid.`);
   }

--- a/contrib/cloud-init.txt
+++ b/contrib/cloud-init.txt
@@ -158,7 +158,7 @@ runcmd:
   - tar -xzf swift.tar.gz --directory / --strip-components=1
   - chmod -R o+r /usr/lib/swift
   - apt-get autoremove -y
-  - curl -fsSL https://deb.nodesource.com/setup_23.x -o nodesource_setup.sh
+  - curl -fsSL https://deb.nodesource.com/setup_24.x -o nodesource_setup.sh
   - bash nodesource_setup.sh
   - apt install -y nodejs
   - rm nodesource_setup.sh

--- a/contrib/lima/cdxgen-ubuntu.yaml
+++ b/contrib/lima/cdxgen-ubuntu.yaml
@@ -67,7 +67,7 @@ provision:
     sdk install maven $MAVEN_VERSION
     sdk install gradle $GRADLE_VERSION
     sdk install sbt $SBT_VERSION
-    curl -fsSL https://deb.nodesource.com/setup_23.x -o nodesource_setup.sh
+    curl -fsSL https://deb.nodesource.com/setup_24.x -o nodesource_setup.sh
     bash nodesource_setup.sh
     apt install -y nodejs
     rm nodesource_setup.sh

--- a/deno.json
+++ b/deno.json
@@ -61,7 +61,8 @@
   },
   "imports": {
     "@appthreat/atom": "npm:@appthreat/atom@2.2.5",
-    "@appthreat/cdx-proto": "npm:@appthreat/cdx-proto@1.0.1",
+    "@appthreat/cdx-proto": "npm:@appthreat/cdx-proto@1.1.0",
+    "@bufbuild/protobuf": "npm:@bufbuild/protobuf@2.5.2",
     "@babel/parser": "npm:@babel/parser@^7.27.2",
     "@babel/traverse": "npm:@babel/traverse@^7.27.1",
     "@npmcli/arborist": "npm:@npmcli/arborist@^9.1.2",

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -101,7 +101,8 @@ Options:
       --validate               Validate the generated SBOM using json schema. Defaults to true. Pass --no-validate to di
                                sable.                                                          [boolean] [default: true]
       --evidence               Generate SBOM with evidence for supported languages.           [boolean] [default: false]
-      --spec-version           CycloneDX Specification version to use. Defaults to 1.6           [number] [default: 1.6]
+      --spec-version           CycloneDX Specification version to use. Defaults to 1.6
+                                                                        [number] [choices: 1.4, 1.5, 1.6] [default: 1.6]
       --filter                 Filter components containing this word in purl or component.properties.value. Multiple va
                                lues allowed.                                                                     [array]
       --only                   Include components only containing this word in purl. Useful to generate BOM with first p
@@ -112,6 +113,8 @@ Options:
   [choices: "appsec", "research", "operational", "threat-modeling", "license-compliance", "generic", "machine-learning",
                                                        "ml", "deep-learning", "ml-deep", "ml-tiny"] [default: "generic"]
       --exclude                Additional glob pattern(s) to ignore                                              [array]
+      --export-proto           Serialize and export BOM as protobuf binary.                   [boolean] [default: false]
+      --proto-bin-file         Path for the serialized protobuf binary.                             [default: "bom.cdx"]
       --include-formulation    Generate formulation section with git metadata and build tools. Defaults to false.
                                                                                               [boolean] [default: false]
       --include-crypto         Include crypto libraries as components.                        [boolean] [default: false]

--- a/lib/helpers/protobom.js
+++ b/lib/helpers/protobom.js
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { readFileSync, writeFileSync } from "node:fs";
 
 import { cdx_15, cdx_16 } from "@appthreat/cdx-proto";
 import {
@@ -7,6 +7,8 @@ import {
   toBinary,
   toJson,
 } from "@bufbuild/protobuf";
+
+import { safeExistsSync } from "./utils.js";
 
 /**
  * Stringify the given bom json based on the type.
@@ -55,10 +57,10 @@ export const writeBinary = (bomJson, binFile) => {
  *
  * @param {string} binFile Binary file name
  * @param {boolean} asJson Convert to JSON
- * @param {number} specVersion Specification version. Defaults to 1.5
+ * @param {number} specVersion Specification version. Defaults to 1.6
  */
-export const readBinary = (binFile, asJson = true, specVersion = 1.5) => {
-  if (!existsSync(binFile)) {
+export const readBinary = (binFile, asJson = true, specVersion = 1.6) => {
+  if (!safeExistsSync(binFile)) {
     return undefined;
   }
   let bomSchema;

--- a/lib/helpers/protobom.js
+++ b/lib/helpers/protobom.js
@@ -1,6 +1,12 @@
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 
 import { cdx_15, cdx_16 } from "@appthreat/cdx-proto";
+import {
+  fromBinary,
+  fromJsonString,
+  toBinary,
+  toJson,
+} from "@bufbuild/protobuf";
 
 /**
  * Stringify the given bom json based on the type.
@@ -23,19 +29,23 @@ const stringifyIfNeeded = (bomJson) => {
  */
 export const writeBinary = (bomJson, binFile) => {
   if (bomJson && binFile) {
-    let bomObject;
+    let bomSchema;
     if (+bomJson.specVersion === 1.6) {
-      bomObject = new cdx_16.Bom();
+      bomSchema = cdx_16.BomSchema;
     } else {
-      bomObject = new cdx_15.Bom();
+      bomSchema = cdx_15.BomSchema;
     }
     writeFileSync(
       binFile,
-      bomObject
-        .fromJsonString(stringifyIfNeeded(bomJson), {
+      toBinary(
+        bomSchema,
+        fromJsonString(bomSchema, stringifyIfNeeded(bomJson), {
           ignoreUnknownFields: true,
-        })
-        .toBinary({ writeUnknownFields: true }),
+        }),
+      ),
+      {
+        writeUnknownFields: true,
+      },
     );
   }
 };
@@ -51,17 +61,17 @@ export const readBinary = (binFile, asJson = true, specVersion = 1.5) => {
   if (!existsSync(binFile)) {
     return undefined;
   }
-  let bomLib;
+  let bomSchema;
   if (specVersion === 1.6) {
-    bomLib = new cdx_16.Bom();
+    bomSchema = cdx_16.BomSchema;
   } else {
-    bomLib = new cdx_15.Bom();
+    bomSchema = cdx_15.BomSchema;
   }
-  const bomObject = bomLib.fromBinary(readFileSync(binFile), {
+  const bomObject = fromBinary(bomSchema, readFileSync(binFile), {
     readUnknownFields: true,
   });
   if (asJson) {
-    return bomObject.toJson({ emitDefaultValues: true });
+    return toJson(bomSchema, bomObject, { emitDefaultValues: true });
   }
   return bomObject;
 };

--- a/lib/helpers/protobom.test.js
+++ b/lib/helpers/protobom.test.js
@@ -22,11 +22,13 @@ test("proto binary tests", () => {
   expect(bomObject.serialNumber).toEqual(
     "urn:uuid:cc8b5a04-2698-4375-b04c-cedfa4317fee",
   );
+  expect(bomObject.specVersion).toEqual("1.5");
   bomObject = readBinary(binFile, false, 1.5);
   expect(bomObject).toBeDefined();
   expect(bomObject.serialNumber).toEqual(
     "urn:uuid:cc8b5a04-2698-4375-b04c-cedfa4317fee",
   );
+  expect(bomObject.specVersion).toEqual("1.5");
   if (tempDir?.startsWith(getTmpDir()) && rmSync) {
     rmSync(tempDir, { recursive: true, force: true });
   }

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "cdx-verify": "bin/verify.js"
   },
   "scripts": {
-    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --inject-globals false lib/managers/docker.test.js lib/helpers/utils.test.js lib/helpers/display.test.js lib/stages/postgen/postgen.test.js lib/evinser/swiftsem.test.js lib/server/server.test.js",
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --inject-globals false lib/managers/docker.test.js lib/helpers/protobom.test.js lib/helpers/utils.test.js lib/helpers/display.test.js lib/stages/postgen/postgen.test.js lib/evinser/swiftsem.test.js lib/server/server.test.js",
     "watch": "node --experimental-vm-modules node_modules/jest/bin/jest.js --watch --inject-globals false",
     "lint:check": "biome check",
     "lint": "biome check --fix",
@@ -110,7 +110,8 @@
   },
   "optionalDependencies": {
     "@appthreat/atom": "2.2.5",
-    "@appthreat/cdx-proto": "1.0.1",
+    "@appthreat/cdx-proto": "1.1.0",
+    "@bufbuild/protobuf": "2.5.2",
     "@cyclonedx/cdxgen-plugins-bin": "1.6.12",
     "@cyclonedx/cdxgen-plugins-bin-darwin-amd64": "1.6.12",
     "@cyclonedx/cdxgen-plugins-bin-darwin-arm64": "1.6.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,7 +146,7 @@ importers:
         version: 2.0.0
       jest:
         specifier: ^30.0.0
-        version: 30.0.0(@types/node@24.0.3)
+        version: 30.0.1(@types/node@24.0.3)
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
@@ -155,8 +155,11 @@ importers:
         specifier: 2.2.5
         version: 2.2.5
       '@appthreat/cdx-proto':
-        specifier: 1.0.1
-        version: 1.0.1
+        specifier: 1.1.0
+        version: 1.1.0
+      '@bufbuild/protobuf':
+        specifier: 2.5.2
+        version: 2.5.2
       '@cyclonedx/cdxgen-plugins-bin':
         specifier: 1.6.12
         version: 1.6.12
@@ -228,9 +231,9 @@ packages:
     engines: {node: '>=16.0.0'}
     hasBin: true
 
-  '@appthreat/cdx-proto@1.0.1':
-    resolution: {integrity: sha512-r/X6RRn3B4hzRmdvuEmVbqfPV2fItY5y6+J3JJO7hrMMT4bMjYAu1J0rNcT1tbQ1yP91MpgJzyoHTzCqpmw5/A==}
-    engines: {node: '>=18'}
+  '@appthreat/cdx-proto@1.1.0':
+    resolution: {integrity: sha512-dLUcN8ZZJeY0LQN/hPlB6CuQFDpcumjkuQnmEffIqWKdD6yGTB6zzC5wUmQknLjkv/JAI2txFtmJoqIpxsZ9jw==}
+    engines: {node: '>=20'}
 
   '@appthreat/sqlite3@6.0.6':
     resolution: {integrity: sha512-0nJUe+lLET/Y0bY8j/PXLtozC0DqFBtau3uDXkPugH50jZyd4zd3s7RhR3oDYo0xZEVixcZOqJz+15jbRxmdCg==}
@@ -450,8 +453,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@bufbuild/protobuf@1.7.2':
-    resolution: {integrity: sha512-i5GE2Dk5ekdlK1TR7SugY4LWRrKSfb5T1Qn4unpIMbfxoeGKERKQ59HG3iYewacGD10SR7UzevfPnh6my4tNmQ==}
+  '@bufbuild/protobuf@2.5.2':
+    resolution: {integrity: sha512-foZ7qr0IsUBjzWIq+SuBLfdQCpJ1j8cTuNNT4owngTHoN5KsJb8L9t65fzz7SCeSWzescoOil/0ldqiL041ABg==}
 
   '@cyclonedx/cdxgen-plugins-bin-darwin-amd64@1.6.12':
     resolution: {integrity: sha512-8iVxUFj3DlCcHmA9+n3sRHcf3gq+ohbhNe9uq+ppsMJ5So48DWdVjHveZN7MWpxTnZqk8KJTAYNPFvaLKAFYBQ==}
@@ -552,53 +555,12 @@ packages:
     resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
     engines: {node: '>=8'}
 
-  '@jest/console@30.0.0':
-    resolution: {integrity: sha512-vfpJap6JZQ3I8sUN8dsFqNAKJYO4KIGxkcB+3Fw7Q/BJiWY5HwtMMiuT1oP0avsiDhjE/TCLaDgbGfHwDdBVeg==}
+  '@jest/console@30.0.1':
+    resolution: {integrity: sha512-ThsJ+1I1/7CSTCmddZWqwkwremh3kmKCEoa7oafYL0A1a4tiXWKHzp8+a4m0EbXfGsYVjaVjjzywOQ1ZCnLlzg==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  '@jest/core@30.0.0':
-    resolution: {integrity: sha512-1zU39zFtWSl5ZuDK3Rd6P8S28MmS4F11x6Z4CURrgJ99iaAJg68hmdJ2SAHEEO6ociaNk43UhUYtHxWKEWoNYw==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-    peerDependencies:
-      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
-    peerDependenciesMeta:
-      node-notifier:
-        optional: true
-
-  '@jest/diff-sequences@30.0.0':
-    resolution: {integrity: sha512-xMbtoCeKJDto86GW6AiwVv7M4QAuI56R7dVBr1RNGYbOT44M2TIzOiske2RxopBqkumDY+A1H55pGvuribRY9A==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
-  '@jest/environment@30.0.0':
-    resolution: {integrity: sha512-09sFbMMgS5JxYnvgmmtwIHhvoyzvR5fUPrVl8nOCrC5KdzmmErTcAxfWyAhJ2bv3rvHNQaKiS+COSG+O7oNbXw==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
-  '@jest/expect-utils@30.0.0':
-    resolution: {integrity: sha512-UiWfsqNi/+d7xepfOv8KDcbbzcYtkWBe3a3kVDtg6M1kuN6CJ7b4HzIp5e1YHrSaQaVS8sdCoyCMCZClTLNKFQ==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
-  '@jest/expect@30.0.0':
-    resolution: {integrity: sha512-XZ3j6syhMeKiBknmmc8V3mNIb44kxLTbOQtaXA4IFdHy+vEN0cnXRzbRjdGBtrp4k1PWyMWNU3Fjz3iejrhpQg==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
-  '@jest/fake-timers@30.0.0':
-    resolution: {integrity: sha512-yzBmJcrMHAMcAEbV2w1kbxmx8WFpEz8Cth3wjLMSkq+LO8VeGKRhpr5+BUp7PPK+x4njq/b6mVnDR8e/tPL5ng==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
-  '@jest/get-type@30.0.0':
-    resolution: {integrity: sha512-VZWMjrBzqfDKngQ7sUctKeLxanAbsBFoZnPxNIG6CmxK7Gv6K44yqd0nzveNIBfuhGZMmk1n5PGbvdSTOu0yTg==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
-  '@jest/globals@30.0.0':
-    resolution: {integrity: sha512-OEzYes5A1xwBJVMPqFRa8NCao8Vr42nsUZuf/SpaJWoLE+4kyl6nCQZ1zqfipmCrIXQVALC5qJwKy/7NQQLPhw==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
-  '@jest/pattern@30.0.0':
-    resolution: {integrity: sha512-k+TpEThzLVXMkbdxf8KHjZ83Wl+G54ytVJoDIGWwS96Ql4xyASRjc6SU1hs5jHVql+hpyK9G8N7WuFhLpGHRpQ==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
-  '@jest/reporters@30.0.0':
-    resolution: {integrity: sha512-5WHNlLO0Ok+/o6ML5IzgVm1qyERtLHBNhwn67PAq92H4hZ+n5uW/BYj1VVwmTdxIcNrZLxdV9qtpdZkXf16HxA==}
+  '@jest/core@30.0.1':
+    resolution: {integrity: sha512-wImaJH4bFaV8oDJkCureHnnua0dOtgVgogh62gFKjTMXyKRVLjiVOJU9VypxXNqDUAM+W23VHJrJRauW3OLPeQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
     peerDependencies:
       node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
@@ -606,32 +568,73 @@ packages:
       node-notifier:
         optional: true
 
-  '@jest/schemas@30.0.0':
-    resolution: {integrity: sha512-NID2VRyaEkevCRz6badhfqYwri/RvMbiHY81rk3AkK/LaiB0LSxi1RdVZ7MpZdTjNugtZeGfpL0mLs9Kp3MrQw==}
+  '@jest/diff-sequences@30.0.1':
+    resolution: {integrity: sha512-n5H8QLDJ47QqbCNn5SuFjCRDrOLEZ0h8vAHCK5RL9Ls7Xa8AQLa/YxAc9UjFqoEDM48muwtBGjtMY5cr0PLDCw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  '@jest/snapshot-utils@30.0.0':
-    resolution: {integrity: sha512-C/QSFUmvZEYptg2Vin84FggAphwHvj6la39vkw1CNOZQORWZ7O/H0BXmdeeeGnvlXDYY8TlFM5jgFnxLAxpFjA==}
+  '@jest/environment@30.0.1':
+    resolution: {integrity: sha512-JFI3qCT4ps9UjQNievPdsmpX+mOcAjOR2aemGUJbNiwpsuSCbiAaXwa2yBCND7OqCxUoiWMh6Lf/cwGxt/m2NA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  '@jest/source-map@30.0.0':
-    resolution: {integrity: sha512-oYBJ4d/NF4ZY3/7iq1VaeoERHRvlwKtrGClgescaXMIa1mmb+vfJd0xMgbW9yrI80IUA7qGbxpBWxlITrHkWoA==}
+  '@jest/expect-utils@30.0.1':
+    resolution: {integrity: sha512-txHSNST7ud1V7JVFS5N1qqU+Wf6tiFPxDbjQpklTnckeVecFF8O+LD6efgF5z1dBigp4nMmDIYYxslQJHaS7QA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  '@jest/test-result@30.0.0':
-    resolution: {integrity: sha512-685zco9HdgBaaWiB9T4xjLtBuN0Q795wgaQPpmuAeZPHwHZSoKFAUnozUtU+ongfi4l5VCz8AclOE5LAQdyjxQ==}
+  '@jest/expect@30.0.1':
+    resolution: {integrity: sha512-mxhK5Zt8z+gOrXkv6RxQoRb1741EkcliTaNAIzrj1w4ch3TruFW+1QbLOTarovxo02EIh+a+JGky3r25p0nhIA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  '@jest/test-sequencer@30.0.0':
-    resolution: {integrity: sha512-Hmvv5Yg6UmghXIcVZIydkT0nAK7M/hlXx9WMHR5cLVwdmc14/qUQt3mC72T6GN0olPC6DhmKE6Cd/pHsgDbuqQ==}
+  '@jest/fake-timers@30.0.1':
+    resolution: {integrity: sha512-H/rYdOcSa+vlux7a3aw6bqQ/nMFMGQqmflAl4qFTThidyakO63ATiHSuhHL1yY39IFBCIbIiUpqr8ognXZA54A==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  '@jest/transform@30.0.0':
-    resolution: {integrity: sha512-8xhpsCGYJsUjqpJOgLyMkeOSSlhqggFZEWAnZquBsvATtueoEs7CkMRxOUmJliF3E5x+mXmZ7gEEsHank029Og==}
+  '@jest/get-type@30.0.1':
+    resolution: {integrity: sha512-AyYdemXCptSRFirI5EPazNxyPwAL0jXt3zceFjaj8NFiKP9pOi0bfXonf6qkf82z2t3QWPeLCWWw4stPBzctLw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  '@jest/types@30.0.0':
-    resolution: {integrity: sha512-1Nox8mAL52PKPfEnUQWBvKU/bp8FTT6AiDu76bFDEJj/qsRFSAVSldfCH3XYMqialti2zHXKvD5gN0AaHc0yKA==}
+  '@jest/globals@30.0.1':
+    resolution: {integrity: sha512-5IdHDqKVayXzBL8sKM5AvPaAnrfO9GXphDLwOg6VWjUiqSrGcj/Hd518QpfDWOeu1aWjBblst3rxeRgbtOEJ8Q==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/pattern@30.0.1':
+    resolution: {integrity: sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/reporters@30.0.1':
+    resolution: {integrity: sha512-r0vZe9j3J97Luj/qQ4G+nYpcvdhl1JuEeoJ7WgUN6FOUixztDKkqHjVtURmfUCoU7rqd1Hj5g5nKm35jClFhfw==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+
+  '@jest/schemas@30.0.1':
+    resolution: {integrity: sha512-+g/1TKjFuGrf1Hh0QPCv0gISwBxJ+MQSNXmG9zjHy7BmFhtoJ9fdNhWJp3qUKRi93AOZHXtdxZgJ1vAtz6z65w==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/snapshot-utils@30.0.1':
+    resolution: {integrity: sha512-6Dpv7vdtoRiISEFwYF8/c7LIvqXD7xDXtLPNzC2xqAfBznKip0MQM+rkseKwUPUpv2PJ7KW/YsnwWXrIL2xF+A==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/source-map@30.0.1':
+    resolution: {integrity: sha512-MIRWMUUR3sdbP36oyNyhbThLHyJ2eEDClPCiHVbrYAe5g3CHRArIVpBw7cdSB5fr+ofSfIb2Tnsw8iEHL0PYQg==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/test-result@30.0.1':
+    resolution: {integrity: sha512-VpPEdwN+NivPsExCb9FCcIfIIP4x6vzGg4xfaH0URYkZcJixwe2E69uRqp9MPq6A4mWUoQRtjPNocFA/kRoiFg==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/test-sequencer@30.0.1':
+    resolution: {integrity: sha512-2D3F5XSPIfGMvdK+T6z8fExQso3sPnkBJsUM5x3YQ1Aaz+4Qrs4X8eqzMyC0i0ENfhcijidzz5yMTM4PvK+mKg==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/transform@30.0.1':
+    resolution: {integrity: sha512-BXZJPGD56+bwIq8EM0X6VqtM+/W4NCMBOxTe4MtfpPVyoZ+rIs6thzdem853vav2jQzpXDsyKir3DRQS5mS9Rw==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/types@30.0.1':
+    resolution: {integrity: sha512-HGwoYRVF0QSKJu1ZQX0o5ZrUrrhj0aOOFA8hXrumD7SIzjouevhawbTjmXdwOmURdGluU9DM/XvGm3NyFoiQjw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   '@jridgewell/gen-mapping@0.3.8':
@@ -982,8 +985,8 @@ packages:
   b4a@1.6.7:
     resolution: {integrity: sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==}
 
-  babel-jest@30.0.0:
-    resolution: {integrity: sha512-JQ0DhdFjODbSawDf0026uZuwaqfKkQzk+9mwWkq2XkKFIaMhFVOxlVmbFCOnnC76jATdxrff3IiUAvOAJec6tw==}
+  babel-jest@30.0.1:
+    resolution: {integrity: sha512-JlqAR53kHcRkLUpxvLYzUdo/Zn5HYPtheVMpSh+JQQppC9TYjkXoEt/PGUT86L3t7lNZLH83Wa+wziYVARYWXQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
     peerDependencies:
       '@babel/core': ^7.11.0
@@ -992,8 +995,8 @@ packages:
     resolution: {integrity: sha512-C5OzENSx/A+gt7t4VH1I2XsflxyPUmXRFPKBxt33xncdOmq7oROVM3bZv9Ysjjkv8OJYDMa+tKuKMvqU/H3xdw==}
     engines: {node: '>=12'}
 
-  babel-plugin-jest-hoist@30.0.0:
-    resolution: {integrity: sha512-DSRm+US/FCB4xPDD6Rnslb6PAF9Bej1DZ+1u4aTiqJnk7ZX12eHsnDiIOqjGvITCq+u6wLqUhgS+faCNbVY8+g==}
+  babel-plugin-jest-hoist@30.0.1:
+    resolution: {integrity: sha512-zTPME3pI50NsFW8ZBaVIOeAxzEY7XHlmWeXXu9srI+9kNfzCUTy8MFan46xOGZY8NZThMqq+e3qZUKsvXbasnQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   babel-preset-current-node-syntax@1.1.0:
@@ -1001,8 +1004,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
 
-  babel-preset-jest@30.0.0:
-    resolution: {integrity: sha512-hgEuu/W7gk8QOWUA9+m3Zk+WpGvKc1Egp6rFQEfYxEoM9Fk/q8nuTXNL65OkhwGrTApauEGgakOoWVXj+UfhKw==}
+  babel-preset-jest@30.0.1:
+    resolution: {integrity: sha512-+YHejD5iTWI46cZmcc/YtX4gaKBtdqCHCVfuVinizVpbmyjO3zYmeuyFdfA8duRqQZfgCAMlsfmkVbJ+e2MAJw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
     peerDependencies:
       '@babel/core': ^7.11.0
@@ -1370,8 +1373,8 @@ packages:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
     engines: {node: '>=6'}
 
-  expect@30.0.0:
-    resolution: {integrity: sha512-xCdPp6gwiR9q9lsPCHANarIkFTN/IMZso6Kkq03sOm9IIGtzK/UJqml0dkhHibGh8HKOj8BIDIpZ0BZuU7QK6w==}
+  expect@30.0.1:
+    resolution: {integrity: sha512-FLzSqyMY397aV5awKVGWOKrfrzQRxoGAofdTt9ucJ6dSVY+1c6yEfcw/JZ1oqfLnL78FONo9GfVaEb8VJ5irGw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   exponential-backoff@3.1.2:
@@ -1613,16 +1616,16 @@ packages:
     resolution: {integrity: sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==}
     engines: {node: 20 || >=22}
 
-  jest-changed-files@30.0.0:
-    resolution: {integrity: sha512-rzGpvCdPdEV1Ma83c1GbZif0L2KAm3vXSXGRlpx7yCt0vhruwCNouKNRh3SiVcISHP1mb3iJzjb7tAEnNu1laQ==}
+  jest-changed-files@30.0.1:
+    resolution: {integrity: sha512-5F/T4oaUdWPE6Ttms/hq5M4YVJA1+s1lWqmUK27xfnj1MBy6HmtnRpXXD2KuKZbD5ntwCxTDVAaRrDyIh+HkBg==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-circus@30.0.0:
-    resolution: {integrity: sha512-nTwah78qcKVyndBS650hAkaEmwWGaVsMMoWdJwMnH77XArRJow2Ir7hc+8p/mATtxVZuM9OTkA/3hQocRIK5Dw==}
+  jest-circus@30.0.1:
+    resolution: {integrity: sha512-gJl83BUlAgtIx7UkLjIbsTwuQI+PE/959AE+/NbJaUuAgh23LGXWAGQqLdIlXU6TvLEEAmDR4caEI6pfW2PGBg==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-cli@30.0.0:
-    resolution: {integrity: sha512-fWKAgrhlwVVCfeizsmIrPRTBYTzO82WSba3gJniZNR3PKXADgdC0mmCSK+M+t7N8RCXOVfY6kvCkvjUNtzmHYQ==}
+  jest-cli@30.0.1:
+    resolution: {integrity: sha512-jULGjC6PV7vA7oB2gFh3h6lZBWo0XvGnLA9d9Ct2PyM7hmr7DTApStl3beqR0aglUIxCOTHIwmQsnWlbJbGCtg==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
@@ -1631,8 +1634,8 @@ packages:
       node-notifier:
         optional: true
 
-  jest-config@30.0.0:
-    resolution: {integrity: sha512-p13a/zun+sbOMrBnTEUdq/5N7bZMOGd1yMfqtAJniPNuzURMay4I+vxZLK1XSDbjvIhmeVdG8h8RznqYyjctyg==}
+  jest-config@30.0.1:
+    resolution: {integrity: sha512-5BGh/41Pe1p/aWj9HlEEjbi5JzTFZXYAszGS1cw19//jaPr4Usb16qPGkznzyJLL8ud/7jCplbmF7msTkzqYoA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
     peerDependencies:
       '@types/node': '*'
@@ -1646,40 +1649,40 @@ packages:
       ts-node:
         optional: true
 
-  jest-diff@30.0.0:
-    resolution: {integrity: sha512-TgT1+KipV8JTLXXeFX0qSvIJR/UXiNNojjxb/awh3vYlBZyChU/NEmyKmq+wijKjWEztyrGJFL790nqMqNjTHA==}
+  jest-diff@30.0.1:
+    resolution: {integrity: sha512-9uJGfS2tBBFTvn3ZjfPjrw0r7KtAcutTMs3k39+ur2xD0/MTdmz8SrTzuy1dMlGxmbSet1k79UFSJ2+U7dNEvQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-docblock@30.0.0:
-    resolution: {integrity: sha512-By/iQ0nvTzghEecGzUMCp1axLtBh+8wB4Hpoi5o+x1stycjEmPcH1mHugL4D9Q+YKV++vKeX/3ZTW90QC8ICPg==}
+  jest-docblock@30.0.1:
+    resolution: {integrity: sha512-/vF78qn3DYphAaIc3jy4gA7XSAz167n9Bm/wn/1XhTLW7tTBIzXtCJpb/vcmc73NIIeeohCbdL94JasyXUZsGA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-each@30.0.0:
-    resolution: {integrity: sha512-qkFEW3cfytEjG2KtrhwtldZfXYnWSanO8xUMXLe4A6yaiHMHJUalk0Yyv4MQH6aeaxgi4sGVrukvF0lPMM7U1w==}
+  jest-each@30.0.1:
+    resolution: {integrity: sha512-zQIKhGrSq6NudJ6SKUBv7wsgRZ3iVe9TXfJ0UNWmrAxaFlsxyVDVq5WkTTWVvCCTCs99fy0s3y62Jx7lLHVJPg==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-environment-node@30.0.0:
-    resolution: {integrity: sha512-sF6lxyA25dIURyDk4voYmGU9Uwz2rQKMfjxKnDd19yk+qxKGrimFqS5YsPHWTlAVBo+YhWzXsqZoaMzrTFvqfg==}
+  jest-environment-node@30.0.1:
+    resolution: {integrity: sha512-3MnzhHa1pGH8NgkYp0AjBqFplAW2LECRSpNjM4iA4MBbnyuMf0sBiZG7pzd66smSgilF7hnJr3qVLnlHRsRdIA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-haste-map@30.0.0:
-    resolution: {integrity: sha512-p4bXAhXTawTsADgQgTpbymdLaTyPW1xWNu1oIGG7/N3LIAbZVkH2JMJqS8/IUcnGR8Kc7WFE+vWbJvsqGCWZXw==}
+  jest-haste-map@30.0.1:
+    resolution: {integrity: sha512-NnvtwP+HmTZQ5blCTjigGlmqHktvGSXk8fqh9qvtbPI04CXX9Qf3hEE8FjtAZiSAkPgYZopZm8jTezvXNStDGA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-leak-detector@30.0.0:
-    resolution: {integrity: sha512-E/ly1azdVVbZrS0T6FIpyYHvsdek4FNaThJTtggjV/8IpKxh3p9NLndeUZy2+sjAI3ncS+aM0uLLon/dBg8htA==}
+  jest-leak-detector@30.0.1:
+    resolution: {integrity: sha512-67NTiVwvaI5K35oEy2Z3Xo6z4WIzSgcw08AEUXTcgNxhu8D8A7jOol/9YqA6ZJMVXC0QttsU7fxMOJYee08n0A==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-matcher-utils@30.0.0:
-    resolution: {integrity: sha512-m5mrunqopkrqwG1mMdJxe1J4uGmS9AHHKYUmoxeQOxBcLjEvirIrIDwuKmUYrecPHVB/PUBpXs2gPoeA2FSSLQ==}
+  jest-matcher-utils@30.0.1:
+    resolution: {integrity: sha512-4R9ct2D3kZTtRTjPVqWbuQpRgG4lVQ5ifI+Ni52OhEeT4XWnNaPe0AtixpkueMKUJDdh96r6xE7V1+imN2hhHQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-message-util@30.0.0:
-    resolution: {integrity: sha512-pV3qcrb4utEsa/U7UI2VayNzSDQcmCllBZLSoIucrESRu0geKThFZOjjh0kACDJFJRAQwsK7GVsmS6SpEceD8w==}
+  jest-message-util@30.0.1:
+    resolution: {integrity: sha512-/TZhT/tMqBVHhOOYY/VdCBoFN66f7rTAQ0TTh4igilDDd6y0SRP8OW7Fm+IV5bYW8MmdEstDQMZkBivmzDPy8A==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-mock@30.0.0:
-    resolution: {integrity: sha512-W2sRA4ALXILrEetEOh2ooZG6fZ01iwVs0OWMKSSWRcUlaLr4ESHuiKXDNTg+ZVgOq8Ei5445i/Yxrv59VT+XkA==}
+  jest-mock@30.0.1:
+    resolution: {integrity: sha512-t57+MErWxWWCrhy4JyQHkgELFHv83u9MqO4XVNP9qAsrknDeX031hG1dEPPwDx77obsciQjXptN2nq1Y83T3CQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   jest-pnp-resolver@1.2.3:
@@ -1691,48 +1694,48 @@ packages:
       jest-resolve:
         optional: true
 
-  jest-regex-util@30.0.0:
-    resolution: {integrity: sha512-rT84010qRu/5OOU7a9TeidC2Tp3Qgt9Sty4pOZ/VSDuEmRupIjKZAb53gU3jr4ooMlhwScrgC9UixJxWzVu9oQ==}
+  jest-regex-util@30.0.1:
+    resolution: {integrity: sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-resolve-dependencies@30.0.0:
-    resolution: {integrity: sha512-Yhh7odCAUNXhluK1bCpwIlHrN1wycYaTlZwq1GdfNBEESNNI/z1j1a7dUEWHbmB9LGgv0sanxw3JPmWU8NeebQ==}
+  jest-resolve-dependencies@30.0.1:
+    resolution: {integrity: sha512-9lTOL/lsSs1o39/urF1J7eiN+w432Hf2EBVH6V6bzDoxJcr0juRJoWNH0fwDkF/725IjyU5JDEzUUZ/MATXzNA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-resolve@30.0.0:
-    resolution: {integrity: sha512-zwWl1P15CcAfuQCEuxszjiKdsValhnWcj/aXg/R3aMHs8HVoCWHC4B/+5+1BirMoOud8NnN85GSP2LEZCbj3OA==}
+  jest-resolve@30.0.1:
+    resolution: {integrity: sha512-VWbbfmQVqEjwRZKo/UgBdUE8RbPCZMEDeR3KLLZe+GaGeCmyUraTdSdfDa8WfmyK/JSHxF/zM7OtGoBr5KXiMw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-runner@30.0.0:
-    resolution: {integrity: sha512-xbhmvWIc8X1IQ8G7xTv0AQJXKjBVyxoVJEJgy7A4RXsSaO+k/1ZSBbHwjnUhvYqMvwQPomWssDkUx6EoidEhlw==}
+  jest-runner@30.0.1:
+    resolution: {integrity: sha512-ntEAnH2AtpAi34j/5mEJTczXMjpVnw5jOKParWM0A0POrelfzJT+WEucIQWIonwlHo96T42B3lHzEUggZfaDNw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-runtime@30.0.0:
-    resolution: {integrity: sha512-/O07qVgFrFAOGKGigojmdR3jUGz/y3+a/v9S/Yi2MHxsD+v6WcPppglZJw0gNJkRBArRDK8CFAwpM/VuEiiRjA==}
+  jest-runtime@30.0.1:
+    resolution: {integrity: sha512-lseQgeKgA9B2BYbGQUrd/XF22wB/Sic6MOCLz7VZ2M159Etzl3dO337foInA68f+f2exmmK0cDxq1lbMToBIVA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-snapshot@30.0.0:
-    resolution: {integrity: sha512-6oCnzjpvfj/UIOMTqKZ6gedWAUgaycMdV8Y8h2dRJPvc2wSjckN03pzeoonw8y33uVngfx7WMo1ygdRGEKOT7w==}
+  jest-snapshot@30.0.1:
+    resolution: {integrity: sha512-Ap2g2X9dkA9Dd9a79DIBkAsE7jsMBydT/xjNGfj8V5ng1kuxpPTqOYHAlHjBZM+cppmCzHSbWn89BVQ9Qh9ibw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-util@30.0.0:
-    resolution: {integrity: sha512-fhNBBM9uSUbd4Lzsf8l/kcAdaHD/4SgoI48en3HXcBEMwKwoleKFMZ6cYEYs21SB779PRuRCyNLmymApAm8tZw==}
+  jest-util@30.0.1:
+    resolution: {integrity: sha512-yKUK3Pq+9NtL2XbGhMW0O5PnHYPjvu3kpplm3j08fyqH6lsa/wLg1SCcNJAI4p8LTtfUMj71MnF3L4PKrlIcJg==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-validate@30.0.0:
-    resolution: {integrity: sha512-d6OkzsdlWItHAikUDs1hlLmpOIRhsZoXTCliV2XXalVQ3ZOeb9dy0CQ6AKulJu/XOZqpOEr/FiMH+FeOBVV+nw==}
+  jest-validate@30.0.1:
+    resolution: {integrity: sha512-Wy5a3L0wNncZiVeEe8g0uL9ZkHqjXBuDYzl4+SVQ9y5VShSpSi+INSfWipDRX57EG0KCa4k+1N1qAj1s+gDBdg==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-watcher@30.0.0:
-    resolution: {integrity: sha512-fbAkojcyS53bOL/B7XYhahORq9cIaPwOgd/p9qW/hybbC8l6CzxfWJJxjlPBAIVN8dRipLR0zdhpGQdam+YBtw==}
+  jest-watcher@30.0.1:
+    resolution: {integrity: sha512-TZUy0f9VypPGse7ObbKyfUo7fhVtzLmmDhX84dv4KMvu2j27Nj49L06hBjAiGwi9m3jZruQuUEtQlctaVLSRZg==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-worker@30.0.0:
-    resolution: {integrity: sha512-VZvxfWIybIvwK8N/Bsfe43LfQgd/rD0c4h5nLUx78CAqPxIQcW2qDjsVAC53iUR8yxzFIeCFFvWOh8en8hGzdg==}
+  jest-worker@30.0.1:
+    resolution: {integrity: sha512-W3zW27LH1+DYwvz5pw4Xw/t83JcWJv24WWp/CtjA2RvQse0k1OViFqUXBAGlUGM6/zTSek/K7EQea+h+SPUKNw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest@30.0.0:
-    resolution: {integrity: sha512-/3G2iFwsUY95vkflmlDn/IdLyLWqpQXcftptooaPH4qkyU52V7qVYf1BjmdSPlp1+0fs6BmNtrGaSFwOfV07ew==}
+  jest@30.0.1:
+    resolution: {integrity: sha512-T+zDYAoEa8+mZuLlRO6VzvHi/D+CtXSvLAPhmVdEYa7mUV7yshs9kvc/6wespnQx0FUHxnhIP7GuZGiIe/BWcg==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
@@ -2108,8 +2111,8 @@ packages:
     resolution: {integrity: sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==}
     engines: {node: 20 || >=22}
 
-  pg-connection-string@2.9.0:
-    resolution: {integrity: sha512-P2DEBKuvh5RClafLngkAuGe9OUlFV7ebu8w1kmaaOgPcpJd1RIFh7otETfI6hAR8YupOLFTY7nuvvIn7PLciUQ==}
+  pg-connection-string@2.9.1:
+    resolution: {integrity: sha512-nkc6NpDcvPVpZXxrreI/FOtX3XemeLl8E0qFr6F2Lrm/I8WOnaWNhIPK2Z7OHpw7gh5XJThi6j6ppgNoaT1w4w==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -2142,8 +2145,8 @@ packages:
   prettify-xml@1.2.0:
     resolution: {integrity: sha512-kuoTbmC+QQUfx45PrdkVzJqrNEp2lhK++WGyiqBx6JrCvZUQDgeYjdV3h53n7p+37s1Iwx6GjAQ7fcIgD8kkLQ==}
 
-  pretty-format@30.0.0:
-    resolution: {integrity: sha512-18NAOUr4ZOQiIR+BgI5NhQE7uREdx4ZyV0dyay5izh4yfQ+1T7BSvggxvRGoXocrRyevqW5OhScUjbi9GB8R8Q==}
+  pretty-format@30.0.1:
+    resolution: {integrity: sha512-2pkYD4WKYrAVyx/Jo7DmV+XAVJ9PuC0gVi9/gCPOxd+dN6WD+Pa7+ScUdh3f9m2klEPEZmfu8HoyYnuaGXzGAA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   proc-log@5.0.0:
@@ -2653,9 +2656,9 @@ snapshots:
       '@appthreat/atom-parsetools': 1.0.4
     optional: true
 
-  '@appthreat/cdx-proto@1.0.1':
+  '@appthreat/cdx-proto@1.1.0':
     dependencies:
-      '@bufbuild/protobuf': 1.7.2
+      '@bufbuild/protobuf': 2.5.2
     optional: true
 
   '@appthreat/sqlite3@6.0.6':
@@ -2892,7 +2895,7 @@ snapshots:
   '@biomejs/cli-win32-x64@2.0.0':
     optional: true
 
-  '@bufbuild/protobuf@1.7.2':
+  '@bufbuild/protobuf@2.5.2':
     optional: true
 
   '@cyclonedx/cdxgen-plugins-bin-darwin-amd64@1.6.12':
@@ -2977,44 +2980,44 @@ snapshots:
 
   '@istanbuljs/schema@0.1.3': {}
 
-  '@jest/console@30.0.0':
+  '@jest/console@30.0.1':
     dependencies:
-      '@jest/types': 30.0.0
+      '@jest/types': 30.0.1
       '@types/node': 24.0.3
       chalk: 4.1.2
-      jest-message-util: 30.0.0
-      jest-util: 30.0.0
+      jest-message-util: 30.0.1
+      jest-util: 30.0.1
       slash: 3.0.0
 
-  '@jest/core@30.0.0':
+  '@jest/core@30.0.1':
     dependencies:
-      '@jest/console': 30.0.0
-      '@jest/pattern': 30.0.0
-      '@jest/reporters': 30.0.0
-      '@jest/test-result': 30.0.0
-      '@jest/transform': 30.0.0
-      '@jest/types': 30.0.0
+      '@jest/console': 30.0.1
+      '@jest/pattern': 30.0.1
+      '@jest/reporters': 30.0.1
+      '@jest/test-result': 30.0.1
+      '@jest/transform': 30.0.1
+      '@jest/types': 30.0.1
       '@types/node': 24.0.3
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 4.2.0
       exit-x: 0.2.2
       graceful-fs: 4.2.11
-      jest-changed-files: 30.0.0
-      jest-config: 30.0.0(@types/node@24.0.3)
-      jest-haste-map: 30.0.0
-      jest-message-util: 30.0.0
-      jest-regex-util: 30.0.0
-      jest-resolve: 30.0.0
-      jest-resolve-dependencies: 30.0.0
-      jest-runner: 30.0.0
-      jest-runtime: 30.0.0
-      jest-snapshot: 30.0.0
-      jest-util: 30.0.0
-      jest-validate: 30.0.0
-      jest-watcher: 30.0.0
+      jest-changed-files: 30.0.1
+      jest-config: 30.0.1(@types/node@24.0.3)
+      jest-haste-map: 30.0.1
+      jest-message-util: 30.0.1
+      jest-regex-util: 30.0.1
+      jest-resolve: 30.0.1
+      jest-resolve-dependencies: 30.0.1
+      jest-runner: 30.0.1
+      jest-runtime: 30.0.1
+      jest-snapshot: 30.0.1
+      jest-util: 30.0.1
+      jest-validate: 30.0.1
+      jest-watcher: 30.0.1
       micromatch: 4.0.8
-      pretty-format: 30.0.0
+      pretty-format: 30.0.1
       slash: 3.0.0
     transitivePeerDependencies:
       - babel-plugin-macros
@@ -3022,58 +3025,58 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@jest/diff-sequences@30.0.0': {}
+  '@jest/diff-sequences@30.0.1': {}
 
-  '@jest/environment@30.0.0':
+  '@jest/environment@30.0.1':
     dependencies:
-      '@jest/fake-timers': 30.0.0
-      '@jest/types': 30.0.0
+      '@jest/fake-timers': 30.0.1
+      '@jest/types': 30.0.1
       '@types/node': 24.0.3
-      jest-mock: 30.0.0
+      jest-mock: 30.0.1
 
-  '@jest/expect-utils@30.0.0':
+  '@jest/expect-utils@30.0.1':
     dependencies:
-      '@jest/get-type': 30.0.0
+      '@jest/get-type': 30.0.1
 
-  '@jest/expect@30.0.0':
+  '@jest/expect@30.0.1':
     dependencies:
-      expect: 30.0.0
-      jest-snapshot: 30.0.0
+      expect: 30.0.1
+      jest-snapshot: 30.0.1
     transitivePeerDependencies:
       - supports-color
 
-  '@jest/fake-timers@30.0.0':
+  '@jest/fake-timers@30.0.1':
     dependencies:
-      '@jest/types': 30.0.0
+      '@jest/types': 30.0.1
       '@sinonjs/fake-timers': 13.0.5
       '@types/node': 24.0.3
-      jest-message-util: 30.0.0
-      jest-mock: 30.0.0
-      jest-util: 30.0.0
+      jest-message-util: 30.0.1
+      jest-mock: 30.0.1
+      jest-util: 30.0.1
 
-  '@jest/get-type@30.0.0': {}
+  '@jest/get-type@30.0.1': {}
 
-  '@jest/globals@30.0.0':
+  '@jest/globals@30.0.1':
     dependencies:
-      '@jest/environment': 30.0.0
-      '@jest/expect': 30.0.0
-      '@jest/types': 30.0.0
-      jest-mock: 30.0.0
+      '@jest/environment': 30.0.1
+      '@jest/expect': 30.0.1
+      '@jest/types': 30.0.1
+      jest-mock: 30.0.1
     transitivePeerDependencies:
       - supports-color
 
-  '@jest/pattern@30.0.0':
+  '@jest/pattern@30.0.1':
     dependencies:
       '@types/node': 24.0.3
-      jest-regex-util: 30.0.0
+      jest-regex-util: 30.0.1
 
-  '@jest/reporters@30.0.0':
+  '@jest/reporters@30.0.1':
     dependencies:
       '@bcoe/v8-coverage': 0.2.3
-      '@jest/console': 30.0.0
-      '@jest/test-result': 30.0.0
-      '@jest/transform': 30.0.0
-      '@jest/types': 30.0.0
+      '@jest/console': 30.0.1
+      '@jest/test-result': 30.0.1
+      '@jest/transform': 30.0.1
+      '@jest/types': 30.0.1
       '@jridgewell/trace-mapping': 0.3.25
       '@types/node': 24.0.3
       chalk: 4.1.2
@@ -3086,59 +3089,59 @@ snapshots:
       istanbul-lib-report: 3.0.1
       istanbul-lib-source-maps: 5.0.6
       istanbul-reports: 3.1.7
-      jest-message-util: 30.0.0
-      jest-util: 30.0.0
-      jest-worker: 30.0.0
+      jest-message-util: 30.0.1
+      jest-util: 30.0.1
+      jest-worker: 30.0.1
       slash: 3.0.0
       string-length: 4.0.2
       v8-to-istanbul: 9.3.0
     transitivePeerDependencies:
       - supports-color
 
-  '@jest/schemas@30.0.0':
+  '@jest/schemas@30.0.1':
     dependencies:
       '@sinclair/typebox': 0.34.35
 
-  '@jest/snapshot-utils@30.0.0':
+  '@jest/snapshot-utils@30.0.1':
     dependencies:
-      '@jest/types': 30.0.0
+      '@jest/types': 30.0.1
       chalk: 4.1.2
       graceful-fs: 4.2.11
       natural-compare: 1.4.0
 
-  '@jest/source-map@30.0.0':
+  '@jest/source-map@30.0.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       callsites: 3.1.0
       graceful-fs: 4.2.11
 
-  '@jest/test-result@30.0.0':
+  '@jest/test-result@30.0.1':
     dependencies:
-      '@jest/console': 30.0.0
-      '@jest/types': 30.0.0
+      '@jest/console': 30.0.1
+      '@jest/types': 30.0.1
       '@types/istanbul-lib-coverage': 2.0.6
       collect-v8-coverage: 1.0.2
 
-  '@jest/test-sequencer@30.0.0':
+  '@jest/test-sequencer@30.0.1':
     dependencies:
-      '@jest/test-result': 30.0.0
+      '@jest/test-result': 30.0.1
       graceful-fs: 4.2.11
-      jest-haste-map: 30.0.0
+      jest-haste-map: 30.0.1
       slash: 3.0.0
 
-  '@jest/transform@30.0.0':
+  '@jest/transform@30.0.1':
     dependencies:
       '@babel/core': 7.27.4
-      '@jest/types': 30.0.0
+      '@jest/types': 30.0.1
       '@jridgewell/trace-mapping': 0.3.25
       babel-plugin-istanbul: 7.0.0
       chalk: 4.1.2
       convert-source-map: 2.0.0
       fast-json-stable-stringify: 2.1.0
       graceful-fs: 4.2.11
-      jest-haste-map: 30.0.0
-      jest-regex-util: 30.0.0
-      jest-util: 30.0.0
+      jest-haste-map: 30.0.1
+      jest-regex-util: 30.0.1
+      jest-util: 30.0.1
       micromatch: 4.0.8
       pirates: 4.0.7
       slash: 3.0.0
@@ -3146,10 +3149,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@jest/types@30.0.0':
+  '@jest/types@30.0.1':
     dependencies:
-      '@jest/pattern': 30.0.0
-      '@jest/schemas': 30.0.0
+      '@jest/pattern': 30.0.1
+      '@jest/schemas': 30.0.1
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
       '@types/node': 24.0.3
@@ -3527,13 +3530,13 @@ snapshots:
   b4a@1.6.7:
     optional: true
 
-  babel-jest@30.0.0(@babel/core@7.27.4):
+  babel-jest@30.0.1(@babel/core@7.27.4):
     dependencies:
       '@babel/core': 7.27.4
-      '@jest/transform': 30.0.0
+      '@jest/transform': 30.0.1
       '@types/babel__core': 7.20.5
       babel-plugin-istanbul: 7.0.0
-      babel-preset-jest: 30.0.0(@babel/core@7.27.4)
+      babel-preset-jest: 30.0.1(@babel/core@7.27.4)
       chalk: 4.1.2
       graceful-fs: 4.2.11
       slash: 3.0.0
@@ -3550,7 +3553,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-jest-hoist@30.0.0:
+  babel-plugin-jest-hoist@30.0.1:
     dependencies:
       '@babel/template': 7.27.2
       '@babel/types': 7.27.6
@@ -3575,10 +3578,10 @@ snapshots:
       '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.27.4)
       '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.27.4)
 
-  babel-preset-jest@30.0.0(@babel/core@7.27.4):
+  babel-preset-jest@30.0.1(@babel/core@7.27.4):
     dependencies:
       '@babel/core': 7.27.4
-      babel-plugin-jest-hoist: 30.0.0
+      babel-plugin-jest-hoist: 30.0.1
       babel-preset-current-node-syntax: 1.1.0(@babel/core@7.27.4)
 
   bare-events@2.5.4:
@@ -3965,14 +3968,14 @@ snapshots:
   expand-template@2.0.3:
     optional: true
 
-  expect@30.0.0:
+  expect@30.0.1:
     dependencies:
-      '@jest/expect-utils': 30.0.0
-      '@jest/get-type': 30.0.0
-      jest-matcher-utils: 30.0.0
-      jest-message-util: 30.0.0
-      jest-mock: 30.0.0
-      jest-util: 30.0.0
+      '@jest/expect-utils': 30.0.1
+      '@jest/get-type': 30.0.1
+      jest-matcher-utils: 30.0.1
+      jest-message-util: 30.0.1
+      jest-mock: 30.0.1
+      jest-util: 30.0.1
 
   exponential-backoff@3.1.2: {}
 
@@ -4244,31 +4247,31 @@ snapshots:
     dependencies:
       '@isaacs/cliui': 8.0.2
 
-  jest-changed-files@30.0.0:
+  jest-changed-files@30.0.1:
     dependencies:
       execa: 5.1.1
-      jest-util: 30.0.0
+      jest-util: 30.0.1
       p-limit: 3.1.0
 
-  jest-circus@30.0.0:
+  jest-circus@30.0.1:
     dependencies:
-      '@jest/environment': 30.0.0
-      '@jest/expect': 30.0.0
-      '@jest/test-result': 30.0.0
-      '@jest/types': 30.0.0
+      '@jest/environment': 30.0.1
+      '@jest/expect': 30.0.1
+      '@jest/test-result': 30.0.1
+      '@jest/types': 30.0.1
       '@types/node': 24.0.3
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.6.0
       is-generator-fn: 2.1.0
-      jest-each: 30.0.0
-      jest-matcher-utils: 30.0.0
-      jest-message-util: 30.0.0
-      jest-runtime: 30.0.0
-      jest-snapshot: 30.0.0
-      jest-util: 30.0.0
+      jest-each: 30.0.1
+      jest-matcher-utils: 30.0.1
+      jest-message-util: 30.0.1
+      jest-runtime: 30.0.1
+      jest-snapshot: 30.0.1
+      jest-util: 30.0.1
       p-limit: 3.1.0
-      pretty-format: 30.0.0
+      pretty-format: 30.0.1
       pure-rand: 7.0.1
       slash: 3.0.0
       stack-utils: 2.0.6
@@ -4276,17 +4279,17 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@30.0.0(@types/node@24.0.3):
+  jest-cli@30.0.1(@types/node@24.0.3):
     dependencies:
-      '@jest/core': 30.0.0
-      '@jest/test-result': 30.0.0
-      '@jest/types': 30.0.0
+      '@jest/core': 30.0.1
+      '@jest/test-result': 30.0.1
+      '@jest/types': 30.0.1
       chalk: 4.1.2
       exit-x: 0.2.2
       import-local: 3.2.0
-      jest-config: 30.0.0(@types/node@24.0.3)
-      jest-util: 30.0.0
-      jest-validate: 30.0.0
+      jest-config: 30.0.1(@types/node@24.0.3)
+      jest-util: 30.0.1
+      jest-validate: 30.0.1
       yargs: 17.7.2
     transitivePeerDependencies:
       - '@types/node'
@@ -4295,30 +4298,30 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@30.0.0(@types/node@24.0.3):
+  jest-config@30.0.1(@types/node@24.0.3):
     dependencies:
       '@babel/core': 7.27.4
-      '@jest/get-type': 30.0.0
-      '@jest/pattern': 30.0.0
-      '@jest/test-sequencer': 30.0.0
-      '@jest/types': 30.0.0
-      babel-jest: 30.0.0(@babel/core@7.27.4)
+      '@jest/get-type': 30.0.1
+      '@jest/pattern': 30.0.1
+      '@jest/test-sequencer': 30.0.1
+      '@jest/types': 30.0.1
+      babel-jest: 30.0.1(@babel/core@7.27.4)
       chalk: 4.1.2
       ci-info: 4.2.0
       deepmerge: 4.3.1
       glob: 11.0.3
       graceful-fs: 4.2.11
-      jest-circus: 30.0.0
-      jest-docblock: 30.0.0
-      jest-environment-node: 30.0.0
-      jest-regex-util: 30.0.0
-      jest-resolve: 30.0.0
-      jest-runner: 30.0.0
-      jest-util: 30.0.0
-      jest-validate: 30.0.0
+      jest-circus: 30.0.1
+      jest-docblock: 30.0.1
+      jest-environment-node: 30.0.1
+      jest-regex-util: 30.0.1
+      jest-resolve: 30.0.1
+      jest-runner: 30.0.1
+      jest-util: 30.0.1
+      jest-validate: 30.0.1
       micromatch: 4.0.8
       parse-json: 5.2.0
-      pretty-format: 30.0.0
+      pretty-format: 30.0.1
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
@@ -4327,227 +4330,227 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-diff@30.0.0:
+  jest-diff@30.0.1:
     dependencies:
-      '@jest/diff-sequences': 30.0.0
-      '@jest/get-type': 30.0.0
+      '@jest/diff-sequences': 30.0.1
+      '@jest/get-type': 30.0.1
       chalk: 4.1.2
-      pretty-format: 30.0.0
+      pretty-format: 30.0.1
 
-  jest-docblock@30.0.0:
+  jest-docblock@30.0.1:
     dependencies:
       detect-newline: 3.1.0
 
-  jest-each@30.0.0:
+  jest-each@30.0.1:
     dependencies:
-      '@jest/get-type': 30.0.0
-      '@jest/types': 30.0.0
+      '@jest/get-type': 30.0.1
+      '@jest/types': 30.0.1
       chalk: 4.1.2
-      jest-util: 30.0.0
-      pretty-format: 30.0.0
+      jest-util: 30.0.1
+      pretty-format: 30.0.1
 
-  jest-environment-node@30.0.0:
+  jest-environment-node@30.0.1:
     dependencies:
-      '@jest/environment': 30.0.0
-      '@jest/fake-timers': 30.0.0
-      '@jest/types': 30.0.0
+      '@jest/environment': 30.0.1
+      '@jest/fake-timers': 30.0.1
+      '@jest/types': 30.0.1
       '@types/node': 24.0.3
-      jest-mock: 30.0.0
-      jest-util: 30.0.0
-      jest-validate: 30.0.0
+      jest-mock: 30.0.1
+      jest-util: 30.0.1
+      jest-validate: 30.0.1
 
-  jest-haste-map@30.0.0:
+  jest-haste-map@30.0.1:
     dependencies:
-      '@jest/types': 30.0.0
+      '@jest/types': 30.0.1
       '@types/node': 24.0.3
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
-      jest-regex-util: 30.0.0
-      jest-util: 30.0.0
-      jest-worker: 30.0.0
+      jest-regex-util: 30.0.1
+      jest-util: 30.0.1
+      jest-worker: 30.0.1
       micromatch: 4.0.8
       walker: 1.0.8
     optionalDependencies:
       fsevents: 2.3.3
 
-  jest-leak-detector@30.0.0:
+  jest-leak-detector@30.0.1:
     dependencies:
-      '@jest/get-type': 30.0.0
-      pretty-format: 30.0.0
+      '@jest/get-type': 30.0.1
+      pretty-format: 30.0.1
 
-  jest-matcher-utils@30.0.0:
+  jest-matcher-utils@30.0.1:
     dependencies:
-      '@jest/get-type': 30.0.0
+      '@jest/get-type': 30.0.1
       chalk: 4.1.2
-      jest-diff: 30.0.0
-      pretty-format: 30.0.0
+      jest-diff: 30.0.1
+      pretty-format: 30.0.1
 
-  jest-message-util@30.0.0:
+  jest-message-util@30.0.1:
     dependencies:
       '@babel/code-frame': 7.27.1
-      '@jest/types': 30.0.0
+      '@jest/types': 30.0.1
       '@types/stack-utils': 2.0.3
       chalk: 4.1.2
       graceful-fs: 4.2.11
       micromatch: 4.0.8
-      pretty-format: 30.0.0
+      pretty-format: 30.0.1
       slash: 3.0.0
       stack-utils: 2.0.6
 
-  jest-mock@30.0.0:
+  jest-mock@30.0.1:
     dependencies:
-      '@jest/types': 30.0.0
+      '@jest/types': 30.0.1
       '@types/node': 24.0.3
-      jest-util: 30.0.0
+      jest-util: 30.0.1
 
-  jest-pnp-resolver@1.2.3(jest-resolve@30.0.0):
+  jest-pnp-resolver@1.2.3(jest-resolve@30.0.1):
     optionalDependencies:
-      jest-resolve: 30.0.0
+      jest-resolve: 30.0.1
 
-  jest-regex-util@30.0.0: {}
+  jest-regex-util@30.0.1: {}
 
-  jest-resolve-dependencies@30.0.0:
+  jest-resolve-dependencies@30.0.1:
     dependencies:
-      jest-regex-util: 30.0.0
-      jest-snapshot: 30.0.0
+      jest-regex-util: 30.0.1
+      jest-snapshot: 30.0.1
     transitivePeerDependencies:
       - supports-color
 
-  jest-resolve@30.0.0:
+  jest-resolve@30.0.1:
     dependencies:
       chalk: 4.1.2
       graceful-fs: 4.2.11
-      jest-haste-map: 30.0.0
-      jest-pnp-resolver: 1.2.3(jest-resolve@30.0.0)
-      jest-util: 30.0.0
-      jest-validate: 30.0.0
+      jest-haste-map: 30.0.1
+      jest-pnp-resolver: 1.2.3(jest-resolve@30.0.1)
+      jest-util: 30.0.1
+      jest-validate: 30.0.1
       slash: 3.0.0
       unrs-resolver: 1.9.0
 
-  jest-runner@30.0.0:
+  jest-runner@30.0.1:
     dependencies:
-      '@jest/console': 30.0.0
-      '@jest/environment': 30.0.0
-      '@jest/test-result': 30.0.0
-      '@jest/transform': 30.0.0
-      '@jest/types': 30.0.0
+      '@jest/console': 30.0.1
+      '@jest/environment': 30.0.1
+      '@jest/test-result': 30.0.1
+      '@jest/transform': 30.0.1
+      '@jest/types': 30.0.1
       '@types/node': 24.0.3
       chalk: 4.1.2
       emittery: 0.13.1
       exit-x: 0.2.2
       graceful-fs: 4.2.11
-      jest-docblock: 30.0.0
-      jest-environment-node: 30.0.0
-      jest-haste-map: 30.0.0
-      jest-leak-detector: 30.0.0
-      jest-message-util: 30.0.0
-      jest-resolve: 30.0.0
-      jest-runtime: 30.0.0
-      jest-util: 30.0.0
-      jest-watcher: 30.0.0
-      jest-worker: 30.0.0
+      jest-docblock: 30.0.1
+      jest-environment-node: 30.0.1
+      jest-haste-map: 30.0.1
+      jest-leak-detector: 30.0.1
+      jest-message-util: 30.0.1
+      jest-resolve: 30.0.1
+      jest-runtime: 30.0.1
+      jest-util: 30.0.1
+      jest-watcher: 30.0.1
+      jest-worker: 30.0.1
       p-limit: 3.1.0
       source-map-support: 0.5.13
     transitivePeerDependencies:
       - supports-color
 
-  jest-runtime@30.0.0:
+  jest-runtime@30.0.1:
     dependencies:
-      '@jest/environment': 30.0.0
-      '@jest/fake-timers': 30.0.0
-      '@jest/globals': 30.0.0
-      '@jest/source-map': 30.0.0
-      '@jest/test-result': 30.0.0
-      '@jest/transform': 30.0.0
-      '@jest/types': 30.0.0
+      '@jest/environment': 30.0.1
+      '@jest/fake-timers': 30.0.1
+      '@jest/globals': 30.0.1
+      '@jest/source-map': 30.0.1
+      '@jest/test-result': 30.0.1
+      '@jest/transform': 30.0.1
+      '@jest/types': 30.0.1
       '@types/node': 24.0.3
       chalk: 4.1.2
       cjs-module-lexer: 2.1.0
       collect-v8-coverage: 1.0.2
       glob: 11.0.3
       graceful-fs: 4.2.11
-      jest-haste-map: 30.0.0
-      jest-message-util: 30.0.0
-      jest-mock: 30.0.0
-      jest-regex-util: 30.0.0
-      jest-resolve: 30.0.0
-      jest-snapshot: 30.0.0
-      jest-util: 30.0.0
+      jest-haste-map: 30.0.1
+      jest-message-util: 30.0.1
+      jest-mock: 30.0.1
+      jest-regex-util: 30.0.1
+      jest-resolve: 30.0.1
+      jest-snapshot: 30.0.1
+      jest-util: 30.0.1
       slash: 3.0.0
       strip-bom: 4.0.0
     transitivePeerDependencies:
       - supports-color
 
-  jest-snapshot@30.0.0:
+  jest-snapshot@30.0.1:
     dependencies:
       '@babel/core': 7.27.4
       '@babel/generator': 7.27.5
       '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.27.4)
       '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.27.4)
       '@babel/types': 7.27.6
-      '@jest/expect-utils': 30.0.0
-      '@jest/get-type': 30.0.0
-      '@jest/snapshot-utils': 30.0.0
-      '@jest/transform': 30.0.0
-      '@jest/types': 30.0.0
+      '@jest/expect-utils': 30.0.1
+      '@jest/get-type': 30.0.1
+      '@jest/snapshot-utils': 30.0.1
+      '@jest/transform': 30.0.1
+      '@jest/types': 30.0.1
       babel-preset-current-node-syntax: 1.1.0(@babel/core@7.27.4)
       chalk: 4.1.2
-      expect: 30.0.0
+      expect: 30.0.1
       graceful-fs: 4.2.11
-      jest-diff: 30.0.0
-      jest-matcher-utils: 30.0.0
-      jest-message-util: 30.0.0
-      jest-util: 30.0.0
-      pretty-format: 30.0.0
+      jest-diff: 30.0.1
+      jest-matcher-utils: 30.0.1
+      jest-message-util: 30.0.1
+      jest-util: 30.0.1
+      pretty-format: 30.0.1
       semver: 7.7.2
       synckit: 0.11.8
     transitivePeerDependencies:
       - supports-color
 
-  jest-util@30.0.0:
+  jest-util@30.0.1:
     dependencies:
-      '@jest/types': 30.0.0
+      '@jest/types': 30.0.1
       '@types/node': 24.0.3
       chalk: 4.1.2
       ci-info: 4.2.0
       graceful-fs: 4.2.11
       picomatch: 4.0.2
 
-  jest-validate@30.0.0:
+  jest-validate@30.0.1:
     dependencies:
-      '@jest/get-type': 30.0.0
-      '@jest/types': 30.0.0
+      '@jest/get-type': 30.0.1
+      '@jest/types': 30.0.1
       camelcase: 6.3.0
       chalk: 4.1.2
       leven: 3.1.0
-      pretty-format: 30.0.0
+      pretty-format: 30.0.1
 
-  jest-watcher@30.0.0:
+  jest-watcher@30.0.1:
     dependencies:
-      '@jest/test-result': 30.0.0
-      '@jest/types': 30.0.0
+      '@jest/test-result': 30.0.1
+      '@jest/types': 30.0.1
       '@types/node': 24.0.3
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
-      jest-util: 30.0.0
+      jest-util: 30.0.1
       string-length: 4.0.2
 
-  jest-worker@30.0.0:
+  jest-worker@30.0.1:
     dependencies:
       '@types/node': 24.0.3
       '@ungap/structured-clone': 1.3.0
-      jest-util: 30.0.0
+      jest-util: 30.0.1
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@30.0.0(@types/node@24.0.3):
+  jest@30.0.1(@types/node@24.0.3):
     dependencies:
-      '@jest/core': 30.0.0
-      '@jest/types': 30.0.0
+      '@jest/core': 30.0.1
+      '@jest/types': 30.0.1
       import-local: 3.2.0
-      jest-cli: 30.0.0(@types/node@24.0.3)
+      jest-cli: 30.0.1(@types/node@24.0.3)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -4929,7 +4932,7 @@ snapshots:
       lru-cache: 11.1.0
       minipass: 7.1.2
 
-  pg-connection-string@2.9.0:
+  pg-connection-string@2.9.1:
     optional: true
 
   picocolors@1.1.1: {}
@@ -4969,9 +4972,9 @@ snapshots:
 
   prettify-xml@1.2.0: {}
 
-  pretty-format@30.0.0:
+  pretty-format@30.0.1:
     dependencies:
-      '@jest/schemas': 30.0.0
+      '@jest/schemas': 30.0.1
       ansi-styles: 5.2.0
       react-is: 18.3.1
 
@@ -5085,7 +5088,7 @@ snapshots:
       lodash: 4.17.21
       moment: 2.30.1
       moment-timezone: 0.5.48
-      pg-connection-string: 2.9.0
+      pg-connection-string: 2.9.1
       retry-as-promised: 7.1.1
       semver: 7.7.2
       sequelize-pool: 7.1.0

--- a/types/lib/helpers/protobom.d.ts.map
+++ b/types/lib/helpers/protobom.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"protobom.d.ts","sourceRoot":"","sources":["../../../lib/helpers/protobom.js"],"names":[],"mappings":"AAuBO,qCAHI,MAAM,MAAS,WACf,MAAM,QAmBhB;AASM,oCAJI,MAAM,WACN,OAAO,gBACP,MAAM,OAmBhB"}
+{"version":3,"file":"protobom.d.ts","sourceRoot":"","sources":["../../../lib/helpers/protobom.js"],"names":[],"mappings":"AA6BO,qCAHI,MAAM,MAAS,WACf,MAAM,QAuBhB;AASM,oCAJI,MAAM,WACN,OAAO,gBACP,MAAM,OAmBhB"}

--- a/types/lib/helpers/protobom.d.ts.map
+++ b/types/lib/helpers/protobom.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"protobom.d.ts","sourceRoot":"","sources":["../../../lib/helpers/protobom.js"],"names":[],"mappings":"AA6BO,qCAHI,MAAM,MAAS,WACf,MAAM,QAuBhB;AASM,oCAJI,MAAM,WACN,OAAO,gBACP,MAAM,OAmBhB"}
+{"version":3,"file":"protobom.d.ts","sourceRoot":"","sources":["../../../lib/helpers/protobom.js"],"names":[],"mappings":"AA+BO,qCAHI,MAAM,MAAS,WACf,MAAM,QAuBhB;AASM,oCAJI,MAAM,WACN,OAAO,gBACP,MAAM,OAmBhB"}


### PR DESCRIPTION
Upgraded protobuf dependencies and made proto-related cli arguments public, so people can start using. Attached zip includes the cdxgen BOM is json and .proto format. 410 KB vs 107 KB.

[bom.zip](https://github.com/user-attachments/files/20818839/bom.zip)

Might need some effort to make things compatible with protobuf libraries in other languages, but its time to try this.