### PR TITLE
[images] Implemented rebuild for the last 2 tags

### DIFF
--- a/.github/workflows/rebuild-release-images.yml
+++ b/.github/workflows/rebuild-release-images.yml
@@ -12,11 +12,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Read latest
+        id: read_latest
         run: |
-          echo "release=$(gh api -H 'Accept: application/vnd.github+json' -H 'X-GitHub-Api-Version: 2022-11-28' /repos/CycloneDX/cdxgen/releases?per_page=1)" > $GITHUB_OUTPUT
+          echo "release=$(gh api -H 'Accept: application/vnd.github+json' -H 'X-GitHub-Api-Version: 2022-11-28' -q '.[0].tag_name' /repos/CycloneDX/cdxgen/releases)" > $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
       - name: Rebuild latest
-        #run: gh workflow run build-images.yml -r refs/tags/${{ steps.run_tests.outputs.release.tag_name }}
-        run: echo ${{ steps.run_tests.outputs.release.tag_name }}
+        run: gh workflow run build-images.yml -r refs/tags/${{ steps.read_latest.outputs.release }}
         env:
           GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
@@ -27,11 +29,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Read previous
+        id: read_previous
         run: |
-          echo "release=$(gh api -H 'Accept: application/vnd.github+json' -H 'X-GitHub-Api-Version: 2022-11-28' /repos/CycloneDX/cdxgen/releases?per_page=1&page=2)" > $GITHUB_OUTPUT
+          echo "release=$(gh api -H 'Accept: application/vnd.github+json' -H 'X-GitHub-Api-Version: 2022-11-28' -q '.[1].tag_name' /repos/CycloneDX/cdxgen/releases)" > $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
       - name: Rebuild previous
-        #run: gh workflow run build-images.yml -r refs/tags/${{ steps.run_tests.outputs.release.tag_name }}
-        run: echo ${{ steps.run_tests.outputs.release.tag_name }}
+        run: gh workflow run build-images.yml -r refs/tags/${{ steps.read_previous.outputs.release.tag_name }}
         env:
           GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}


### PR DESCRIPTION
This PR fixes #1884 for the last 2 tags. Every Sunday during the night, all images for the last 2 tags will be rebuilt.
As we have noticed today, we can't guarantee that these images will build correctly, seeing some of the versioned packages we install might not be available any more in the distro's repo.  😞 