### PR TITLE
[renovate] configured minimumReleaseAge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "enabledManagers": ["github-actions", "jsonata", "npm", "nvm"],
   "extends": [
     "config:recommended",
     ":separateMultipleMajorReleases",
@@ -9,7 +10,7 @@
     "helpers:pinGitHubActionDigests"
   ],
   "labels": ["dependency"],
-  "enabledManagers": ["github-actions", "jsonata", "npm", "nvm"],
+  "minimumReleaseAge": "3 days",
   "packageRules": [
     {
       "matchDepTypes": ["engines"],


### PR DESCRIPTION
Configured renovate to wait for packages to be at least 3 days old before updating to them, so we don't have bleeding edge updates and also possibly fall into the 72 hours unpublish period of the NPM-registry.