### PR TITLE
config(renovate): pin github actions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,6 +17,10 @@
       "rangeStrategy": "auto"
     },
     {
+      "matchManagers": "github-actions",
+      "rangeStrategy": "pin"
+    },
+    {
       "description": "Separate GitHub Action pin updates",
       "groupName": "GitHub Action pins",
       "matchManagers": ["github-actions"],


### PR DESCRIPTION
This rule _should_ update github action versions to semver