### PR TITLE
[build] Changed the group-names to (hopefully) have runs abort on newer commits

### DIFF
--- a/.github/workflows/binary-builds.yml
+++ b/.github/workflows/binary-builds.yml
@@ -20,7 +20,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -61,7 +61,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-rolling-image.yml
+++ b/.github/workflows/build-rolling-image.yml
@@ -37,7 +37,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/dockertests.yml
+++ b/.github/workflows/dockertests.yml
@@ -14,7 +14,7 @@ on:
       - '!**.test.js'
   workflow_dispatch:
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 jobs:
   linux-tests:

--- a/.github/workflows/java-reachables-test.yml
+++ b/.github/workflows/java-reachables-test.yml
@@ -14,7 +14,7 @@ on:
       - '!**.test.js'
   workflow_dispatch:
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 jobs:
   java-js-sample-tests:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -29,7 +29,7 @@ on:
       - '!**.test.js'
   workflow_dispatch:
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 jobs:
   depscan:

--- a/.github/workflows/python-atom-tests.yml
+++ b/.github/workflows/python-atom-tests.yml
@@ -14,7 +14,7 @@ on:
       - '!**.test.js'
   workflow_dispatch:
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 jobs:
   build:

--- a/.github/workflows/repotests.yml
+++ b/.github/workflows/repotests.yml
@@ -13,7 +13,7 @@ on:
       - 'pnpm-lock.yaml'
   workflow_dispatch:
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 jobs:
   cli-tests-quick-amd64:

--- a/.github/workflows/snapshot-tests.yml
+++ b/.github/workflows/snapshot-tests.yml
@@ -21,7 +21,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: "${{ github.workflow }}-${{ github.head_ref || github.run_id }}"
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
We had tons of running jobs, all from the same branch (eg master) that should be cancelled on a new commit. Not only does this eat heavily into our resources, it also gives us no guarantee on the order of the workflow and therefore on eg the actual images or artifacts that are released as 'latest'.