### PR TITLE
Exclude install.sh from .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,3 +12,5 @@ plugins/.npmignore
 plugins/**/node_modules
 !pnpm-lock.yaml
 !*.md
+# Required for debian images
+!ci/images/debian/install.sh


### PR DESCRIPTION
** on the top of .dockerignore file includes everything. We manually exclude some file/directories. Debian images installs required deps using `install.sh`. Without it, the build will fail