### PR TITLE
[build] Either run on cron or push, not both

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -34,30 +34,30 @@ name: Build images
 
 on:
   schedule:
-  - cron: "0 8 * * *"
+    - cron: "0 8 * * *"
   push:
-    branches:
-      - master
+#    branches:
+#      - master
     tags:
       - 'v*'
-    paths:
-      - '.github/actions/**'
-      - '.github/workflows/build-images.yml'
-      - '.github/workflows/image-build.yml'
-      - '.pnpmfile.cjs'
-      - 'bin/**'
-      - 'ci/images/**'
-      - '!ci/images/al10/**'
-      - 'data/**'
-      - 'index.cjs'
-      - 'lib/**'
-      - 'LICENSE'
-      - 'package.json'
-      - 'plugins/**'
-      - '!plugins/.gitkeep'
-      - '!plugins/.npmignore'
-      - 'pnpm-lock.yaml'
-      - '!**.test.js'
+#    paths:
+#      - '.github/actions/**'
+#      - '.github/workflows/build-images.yml'
+#      - '.github/workflows/image-build.yml'
+#      - '.pnpmfile.cjs'
+#      - 'bin/**'
+#      - 'ci/images/**'
+#      - '!ci/images/al10/**'
+#      - 'data/**'
+#      - 'index.cjs'
+#      - 'lib/**'
+#      - 'LICENSE'
+#      - 'package.json'
+#      - 'plugins/**'
+#      - '!plugins/.gitkeep'
+#      - '!plugins/.npmignore'
+#      - 'pnpm-lock.yaml'
+#      - '!**.test.js'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/build-rolling-image.yml
+++ b/.github/workflows/build-rolling-image.yml
@@ -13,27 +13,27 @@ name: Build rolling image
 on:
   schedule:
   - cron: "0 8 * * *"
-  push:
-    branches:
-      - master
-    paths:
-      - '.github/actions/**'
-      - '.github/workflows/build-rolling-image.yml'
-      - '.github/workflows/image-build.yml'
-      - '.pnpmfile.cjs'
-      - 'bin/**'
-      - 'ci/images/**'
-      - '!ci/images/al10/**'
-      - 'plugins/**'
-      - '!plugins/.gitkeep'
-      - '!plugins/.npmignore'
-      - 'data/**'
-      - 'index.cjs'
-      - 'lib/**'
-      - 'LICENSE'
-      - 'package.json'
-      - 'pnpm-lock.yaml'
-      - '!**.test.js'
+#  push:
+#    branches:
+#      - master
+#    paths:
+#      - '.github/actions/**'
+#      - '.github/workflows/build-rolling-image.yml'
+#      - '.github/workflows/image-build.yml'
+#      - '.pnpmfile.cjs'
+#      - 'bin/**'
+#      - 'ci/images/**'
+#      - '!ci/images/al10/**'
+#      - 'plugins/**'
+#      - '!plugins/.gitkeep'
+#      - '!plugins/.npmignore'
+#      - 'data/**'
+#      - 'index.cjs'
+#      - 'lib/**'
+#      - 'LICENSE'
+#      - 'package.json'
+#      - 'pnpm-lock.yaml'
+#      - '!**.test.js'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,8 +24,8 @@ on:
       - '.github/actions/**'
       - '.github/workflows/**'
       - '**.js'
-  schedule:
-    - cron: '17 9 * * 6'
+#  schedule:
+#    - cron: '17 9 * * 6'
 
 jobs:
   analyze:


### PR DESCRIPTION
We have workflows that run on cron and push on master, which is using too much resources and in some cases simply not necessary.
This PR removes either cron or push, depending on the workflow.