### PR TITLE
[renotavate] Addded 'postUpgradeTasks' to renovate, to have it generate a correct pnpm-lock

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,5 +17,10 @@
       "matchDepTypes": ["engines"],
       "rangeStrategy": "auto"
     }
-  ]
+  ],
+  "postUpgradeTasks": {
+    "commands": ["pnpm i"],
+    "fileFilters": ["pnpm-lock.yaml"],
+    "executionMode": "branch"
+  }
 }


### PR DESCRIPTION
Renovate is removing the checksum and some other configs from the pnpm-lockfile for its updates, which makes our checks fail. This PR tries to fix this by having renovate run 'pnpm i' after updating bur before comitting the changes.