### PR TITLE
[renovate] Removed renovate scheduling -- just send PRs when updates are found

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,6 @@
     "config:recommended",
     ":separateMultipleMajorReleases",
     ":enableVulnerabilityAlerts",
-    "schedule:daily",
     "customManagers:biomeVersions",
     "customManagers:dockerfileVersions",
     "helpers:pinGitHubActionDigestsToSemver"


### PR DESCRIPTION
Seeing how renovate is configure to only open a maximum of 2 branches, we can have it send any updates asap after we close some.