### PR TITLE
[renovate] Adding a comment to the PR that explains the usage of the updated dependency

### DIFF
--- a/.github/workflows/fix-renovate-pnpm-checksum.yml
+++ b/.github/workflows/fix-renovate-pnpm-checksum.yml
@@ -20,14 +20,22 @@ jobs:
   fix-lock:
     permissions:
       contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.WORKFLOW_TOKEN }}
-      - name: PNPM install
-        run: corepack pnpm i --no-frozen-lockfile
+      - name: PNPM install & why
+        run: |
+          corepack pnpm i --no-frozen-lockfile
+          message=`git log -1 --pretty=%B | head -n 1`
+          read -a array <<< "$message"
+          corepack pnpm why ${array[3]} > _why.txt
+      - uses: mshick/add-pr-comment@v2
+        with:
+          message-path: _why.txt
       - uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # v9.1.4
         with:
           add: 'pnpm-lock.yaml'


### PR DESCRIPTION
When a node dependency is updated, this PR will post a comment to the triggering PR with the output of `pnpm why <dependency>`, so we can directly see where it is used and if/what might be influenced by this update.