### PR TITLE
[build] Do not load docker image into local registry, export a tarball instead

### DIFF
--- a/.github/actions/build-docker-image/action.yml
+++ b/.github/actions/build-docker-image/action.yml
@@ -1,18 +1,17 @@
 name: Build a Docker image
 description: |
   This action does the actual building of an image, based on the given
-  parameters. Depending on the configured 'action', the image is then pushed
-  to a registry or loaded into the local Docker.
+  parameters.
 
 inputs:
-  action:
-    description: Action to run on completion of the build -- either 'load' or 'push''
-    required: true
   dockerfile:
     description: Dockerfile that describes the image
     required: true
   labels:
     description: Labels to add to the image
+  output:
+    description: Controls what should be done with the image(s) after building
+    required: true
   platforms:
     description: The platforms for which to build the image
     required: true
@@ -32,7 +31,7 @@ runs:
         context: .
         file: ${{ inputs.dockerfile }}
         labels: ${{ inputs.labels }}
-        load: ${{ inputs.action == 'load' }}
+        outputs: type=${{ inputs.output }}
         platforms: ${{ inputs.platforms }}
         push: ${{ inputs.action == 'push' }}
         tags: ${{ inputs.tags }}

--- a/.github/actions/build-docker-images-generate-attach-sboms/action.yml
+++ b/.github/actions/build-docker-images-generate-attach-sboms/action.yml
@@ -35,9 +35,9 @@ runs:
     - name: Build and push image
       uses: ./.github/actions/build-docker-image
       with:
-        action: push
         dockerfile: ${{ inputs.dockerfile }}
         labels: ${{ steps.metadata.outputs.labels }}
+        output: registry
         platforms: linux/amd64${{ inputs.build-arm == 'true' && ',linux/arm64' || '' }}
         tags: ${{ inputs.tags || steps.metadata.outputs.tags }}
         target: ${{ inputs.target }}

--- a/.github/actions/generate-attach-sbom/action.yml
+++ b/.github/actions/generate-attach-sbom/action.yml
@@ -26,21 +26,20 @@ runs:
     - name: Build and load image
       uses: ./.github/actions/build-docker-image
       with:
-        action: load
         dockerfile: ${{ inputs.dockerfile }}
+        output: docker,dest=${{ runner.temp }}/image.tar
         platforms: ${{ inputs.platform }}
         tags: ${{ inputs.tag }}
         target: ${{ inputs.target }}
     - name: Generate and attach SBOM
       shell: bash
       run: |
-        node bin/cdxgen.js -t docker -o sbom-oci-image.cdx.json ${{ inputs.tag }}
+        node bin/cdxgen.js -t docker -o sbom-oci-image.cdx.json ${{ runner.temp }}/image.tar
         node bin/verify.js -i sbom-oci-image.cdx.json --public-key contrib/bom-signer/public.key
         oras attach --artifact-type sbom/cyclonedx --platform ${{ inputs.platform }} ${{ inputs.tag }} ./sbom-oci-image.cdx.json:application/json
         oras discover --format tree --platform ${{ inputs.platform }} ${{ inputs.tag }}
         node bin/verify.js -i ${{ inputs.tag }} --platform ${{ inputs.platform }} --public-key contrib/bom-signer/public.key
-        docker rmi ${{ inputs.tag }}
-        rm sbom-oci-image.cdx.json
+        rm sbom-oci-image.cdx.json ${{ runner.temp }}/image.tar
       env:
         CDXGEN_TEMP_DIR: ${{ runner.temp }}/cdxgen-sboms
         DOCKER_USE_CLI: true


### PR DESCRIPTION
I noticed in the logs that buildx exports the image to the docker daemon as a tarball. Because cdxgen then exports the image from the daemon to a tarball again, I figured we could just export to a tarball right away and save some time on our workflows.