### PR TITLE
config(renovate): custom package rule for actions without semver available

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,10 +17,10 @@
       "rangeStrategy": "auto"
     },
     {
-      "description": "Custom rule: pin GitHub Actions digests to major version. Relaxed extractVersion for those actions which don't support semver",
+      "description": "Pin GitHub Actions digests to major version - for those actions which don't support semver",
       "extends": ["helpers:pinGitHubActionDigests"],
       "matchPackageNames": ["addnab/docker-run-action"],
-      "extractVersion": "^(?<version>v?\\d+$",
+      "extractVersion": "^(?<version>v?\\d+)$",
       "versioning": "regex:^v?(?<major>\\d+)(\\.(?<minor>\\d+)\\.(?<patch>\\d+))?$"
     }
   ]


### PR DESCRIPTION
Closes #2039

Issue is that this particular action doesn't provide semantic version tags.  Created a local package rule modeled from the preset https://docs.renovatebot.com/presets-helpers/#helperspingithubactiondigeststosemver, which is targeted at this one action and relaxes it to match by major version only. 