### PR TITLE
[build] Fixed regression with node v24.4.0

### DIFF
--- a/.github/workflows/binary-builds.yml
+++ b/.github/workflows/binary-builds.yml
@@ -45,7 +45,7 @@ jobs:
         os: [ darwin, linux, windows ]
         arch: [ amd64, arm64]
         libc: [ gnu, musl ]
-        node: [ 24 ]
+        node: [ 24.3 ]
         exclude:
           # Musl can only be built on linux
           - os: darwin

--- a/.github/workflows/dockertests.yml
+++ b/.github/workflows/dockertests.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: true
       matrix:
         os: ['ubuntu-24.04', 'ubuntu-24.04-arm']
-        node-version: ['24']
+        node-version: ['24.3']
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -88,7 +88,7 @@ jobs:
       fail-fast: true
       matrix:
         os: ['ubuntu-24.04', 'ubuntu-24.04-arm']
-        node-version: ['24']
+        node-version: ['24.3']
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -123,7 +123,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        node-version: ['24']
+        node-version: ['24.3']
         os: [ubuntu-24.04, ubuntu-24.04-arm]
     runs-on: ${{ matrix.os }}
     steps:
@@ -157,7 +157,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        node-version: ['24']
+        node-version: ['24.3']
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/java-reachables-test.yml
+++ b/.github/workflows/java-reachables-test.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         java-version: ['24']
-        node-version: ['24']
+        node-version: ['24.3']
         os: ['ubuntu-24.04']
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -95,7 +95,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ['20', '21', '22', '23', '24']
+        node-version: ['20', '21', '22', '23', '24.3']
         os: ['ubuntu-22.04', 'ubuntu-24.04', 'windows-latest', 'windows-11-arm', 'ubuntu-22.04-arm', 'ubuntu-24.04-arm', 'macos-latest', 'macos-13']
     runs-on: ${{ matrix.os }}
     steps:
@@ -119,7 +119,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        node-version: ['24']
+        node-version: ['24.3']
         os: [windows, macos, ubuntu]
         deno_version: [2.x]
         include:

--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: '24'
+          node-version: '24.3'
           registry-url: https://registry.npmjs.org/
       - name: Release npm package
         if: startsWith(github.ref, 'refs/tags/')
@@ -180,7 +180,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: '24'
+          node-version: '24.3'
           registry-url: https://registry.npmjs.org/
       - uses: oras-project/setup-oras@8d34698a59f5ffe24821f0b48ab62a3de8b64b20 # v1.2.3
       - name: Free disk space
@@ -262,7 +262,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: '24'
+          node-version: '24.3'
           registry-url: https://registry.npmjs.org/
       - uses: oras-project/setup-oras@8d34698a59f5ffe24821f0b48ab62a3de8b64b20 # v1.2.3
       - name: Free disk space
@@ -331,7 +331,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: '24'
+          node-version: '24.3'
           registry-url: https://registry.npmjs.org/
       - uses: oras-project/setup-oras@8d34698a59f5ffe24821f0b48ab62a3de8b64b20 # v1.2.3
       - name: Free disk space
@@ -399,7 +399,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: '24'
+          node-version: '24.3'
           registry-url: https://registry.npmjs.org/
       - uses: oras-project/setup-oras@8d34698a59f5ffe24821f0b48ab62a3de8b64b20 # v1.2.3
       - name: Free disk space
@@ -450,7 +450,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: '24'
+          node-version: '24.3'
           registry-url: https://registry.npmjs.org/
       - uses: oras-project/setup-oras@8d34698a59f5ffe24821f0b48ab62a3de8b64b20 # v1.2.3
       - name: Free disk space

--- a/.github/workflows/nydus-demo.yml
+++ b/.github/workflows/nydus-demo.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         java-version: ['24']
-        node-version: ['24']
+        node-version: ['24.3']
         os: ['ubuntu-latest']
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/python-atom-tests.yml
+++ b/.github/workflows/python-atom-tests.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         java-version: ['24']
-        node-version: ['24']
+        node-version: ['24.3']
         os: ['ubuntu-24.04']
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/repotests.yml
+++ b/.github/workflows/repotests.yml
@@ -160,7 +160,7 @@ jobs:
       fail-fast: true
       matrix:
         java-version: ['24']
-        node-version: ['24']
+        node-version: ['24.3']
         os: ['self-hosted-ubuntu', 'ubuntu-24.04-arm', 'windows-latest', 'macos-15']
     runs-on: ${{ matrix.os }}
     steps:
@@ -921,7 +921,7 @@ jobs:
       fail-fast: true
       matrix:
         java-version: ['24']
-        node-version: ['24']
+        node-version: ['24.3']
         os: ['ubuntu-24.04', 'ubuntu-24.04-arm', 'macos-15']
     runs-on: ${{ matrix.os }}
     env:

--- a/ci/images/alpine/Dockerfile.node24
+++ b/ci/images/alpine/Dockerfile.node24
@@ -1,5 +1,5 @@
 # Base-image
-FROM node:24-alpine AS base
+FROM node:24.3-alpine AS base
 
 ENV PATH=${PATH}:/usr/local/bin
 


### PR DESCRIPTION
Locked node v24 to v24.3 because of a regression in v24.4. This seems to be an issue related to using pnpm and having large dependencies: https://github.com/pnpm/pnpm/issues/9743

This PR should be reverted as soon as a newer version of node (or pnpm?) is released that fixes the problem!