### PR TITLE
[build] Added a parameter to control tagging images as 'latest'

### DIFF
--- a/.github/actions/build-docker-images-generate-attach-sboms/action.yml
+++ b/.github/actions/build-docker-images-generate-attach-sboms/action.yml
@@ -13,6 +13,9 @@ inputs:
   images:
     description: The name(s) of the image(s) to load metadata for
     required: true
+  latest:
+    description: Tag this image as 'latest' on top of the given tags
+    required: true
   main-tag:
     description: The tag to attach the SBOMs to, defaults to the first tag returned from the metadata extraction
   signing-key:
@@ -31,6 +34,7 @@ runs:
       id: metadata
       uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
       with:
+        flavor: latest=${{ inputs.latest }}
         images: ${{ inputs.images }}
     - name: Build and push image
       uses: ./.github/actions/build-docker-image

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -39,6 +39,11 @@ on:
   schedule:
     - cron: "0 4 * * *"
   workflow_dispatch:
+    inputs:
+      latest:
+        description: Tag the images as 'latest' on top of the given tags
+        required: true
+        type: boolean
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -213,6 +218,7 @@ jobs:
     secrets: inherit
     with:
       image: ${{ toJSON(matrix.image) }}
+      latest: ${{ inputs.latest || startsWith(github.ref, 'refs/tags/') }}
 
   retry:
     needs: images

--- a/.github/workflows/build-rolling-image.yml
+++ b/.github/workflows/build-rolling-image.yml
@@ -39,6 +39,7 @@ jobs:
             "lang": "lang"
           }
         }
+      latest: false
 
   retry:
     needs: image

--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -13,6 +13,9 @@ on:
       image:
         required: true
         type: string
+      latest:
+        required: true
+        type: boolean
 
 env:
   REPO: ghcr.io
@@ -88,6 +91,7 @@ jobs:
             ${{ fromJSON(inputs.image).cdxgen-image.additional-image && format('{0}/{1}/{2}', env.REPO, env.TEAM, fromJSON(inputs.image).cdxgen-image.additional-image) || '' }}
             ${{ fromJSON(inputs.image).cdxgen-image.additional-image2 && format('{0}/{1}/{2}', env.REPO, env.TEAM, fromJSON(inputs.image).cdxgen-image.additional-image2) || '' }}
             ${{ fromJSON(inputs.image).cdxgen-image.additional-image3 && format('{0}/{1}/{2}', env.REPO, env.TEAM, fromJSON(inputs.image).cdxgen-image.additional-image3) || '' }}
+          latest: ${{ inputs.latest }}
           main-tag: ${{ env.REPO }}/${{ env.TEAM }}/cdxgen${{ fromJSON(inputs.image).distro && format('-{0}', fromJSON(inputs.image).distro) }}-${{ fromJSON(inputs.image).lang }}:${{ env.TAG }}
           signing-key: ${{ secrets.SBOM_SIGN_PRIVATE_KEY }}
           tags: |
@@ -107,6 +111,7 @@ jobs:
             ${{ fromJSON(inputs.image).cdxgen-image.additional-image && format('{0}/{1}/{2}', env.REPO, env.TEAM, fromJSON(inputs.image).cdxgen-image.additional-image) || '' }}
             ${{ fromJSON(inputs.image).cdxgen-image.additional-image2 && format('{0}/{1}/{2}', env.REPO, env.TEAM, fromJSON(inputs.image).cdxgen-image.additional-image2) || '' }}
             ${{ fromJSON(inputs.image).cdxgen-image.additional-image3 && format('{0}/{1}/{2}', env.REPO, env.TEAM, fromJSON(inputs.image).cdxgen-image.additional-image3) || '' }}
+          latest: ${{ inputs.latest }}
           signing-key: ${{ secrets.SBOM_SIGN_PRIVATE_KEY }}
           target: cdxgen
 

--- a/.github/workflows/rebuild-release-images.yml
+++ b/.github/workflows/rebuild-release-images.yml
@@ -2,7 +2,7 @@ name: Rebuild release images
 
 on:
   schedule:
-    - cron: "0 2 * * 0"
+    - cron: "0 16 * * 6"
   workflow_dispatch:
 
 concurrency:
@@ -23,7 +23,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
       - name: Rebuild latest
-        run: gh workflow run build-images.yml -r refs/tags/${{ steps.read_latest.outputs.release }}
+        run: gh workflow run build-images.yml -r refs/tags/${{ steps.read_latest.outputs.release }} -f latest=true
         env:
           GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
@@ -38,7 +38,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
       - name: Rebuild previous
-        run: gh workflow run build-images.yml -r refs/tags/${{ steps.read_previous.outputs.release }}
+        run: gh workflow run build-images.yml -r refs/tags/${{ steps.read_previous.outputs.release }} -f latest=false
         env:
           GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}


### PR DESCRIPTION
Rebuilding our images re-tagged them as 'latest'. Because this is done for the last 2 versions and runs in parallel, the tag can land on the previous version instead of the current. This PR should fix this.