### PR TITLE
[build] Repository for debian 10 is no longer available

### DIFF
--- a/.github/workflows/binary-builds.yml
+++ b/.github/workflows/binary-builds.yml
@@ -73,7 +73,7 @@ jobs:
             arch: arm64
             runner: windows-11-arm
           # Set which images to use
-          - image: debian:10
+          - image: debian:11
           - libc: musl
             image: alpine:3.21
           # Set the libc-suffix


### PR DESCRIPTION
Debian 10's repository has been removed from the update-site. This PR upgrades us to Debian 11.