### PR TITLE
default to npm when lock file is missing

### DIFF
--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -2901,6 +2901,10 @@ export async function createNodejsBom(path, options) {
       } else if (pkgData?.engines?.yarn) {
         pkgMgr = "yarn";
       } else if (
+        isPackageManagerAllowed("npm", ["yarn", "pnpm", "rush"], options)
+      ) {
+        pkgMgr = "npm";
+      } else if (
         isPackageManagerAllowed("yarn", ["npm", "pnpm", "rush"], options)
       ) {
         pkgMgr = "yarn";


### PR DESCRIPTION
See #2048 