### PR TITLE
[build] Removed building of 'evinse' on deno

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -128,17 +128,18 @@ jobs:
               deno compile --allow-read --allow-env --allow-run --allow-sys=uid,systemMemoryInfo,gid,osRelease,homedir --allow-write --allow-net --include=./data --include=./package.json --output cdxgenx.exe bin/cdxgen.js
               .\cdxgenx.exe --help
               (Get-FileHash .\cdxgenx.exe).hash | Out-File -FilePath .\cdxgenx.exe.sha256
-              deno compile --allow-read --allow-env --allow-run --allow-sys=uid,systemMemoryInfo,gid,osRelease,homedir --allow-write --allow-net --node-modules-dir=auto --allow-ffi --allow-scripts=npm:@appthreat/sqlite3@6.0.7 --include=./data --include=./package.json --include=node_modules/sqlite3/build/Release --output evinse.exe bin/evinse.js
-              .\evinse.exe --help
-              (Get-FileHash .\evinse.exe).hash | Out-File -FilePath .\evinse.exe.sha256
+#              deno compile --allow-read --allow-env --allow-run --allow-sys=uid,systemMemoryInfo,gid,osRelease,homedir --allow-write --allow-net --node-modules-dir=auto --allow-ffi --allow-scripts=npm:@appthreat/sqlite3@6.0.7 --include=./data --include=./package.json --include=node_modules/sqlite3/build/Release --output evinse.exe bin/evinse.js
+#              .\evinse.exe --help
+#              (Get-FileHash .\evinse.exe).hash | Out-File -FilePath .\evinse.exe.sha256
             artifact: cdxgenx.exe
           - os: macos
             build: |
               deno compile --allow-read --allow-env --allow-run --allow-sys=uid,systemMemoryInfo,gid,homedir --allow-write --allow-net --include=./data --include=./package.json --target aarch64-apple-darwin --output cdxgenx-darwin-arm64 bin/cdxgen.js
               shasum -a 256 cdxgenx-darwin-arm64 > cdxgenx-darwin-arm64.sha256
-              deno compile --allow-read --allow-env --allow-run --allow-sys=uid,systemMemoryInfo,gid,homedir --allow-write --allow-net --node-modules-dir=auto --allow-ffi --allow-scripts=npm:@appthreat/sqlite3@6.0.7 --include=./data --include=./package.json --include=node_modules/sqlite3/build/Release --target aarch64-apple-darwin --output evinse-darwin-arm64 bin/evinse.js
-              shasum -a 256 evinse-darwin-arm64 > evinse-darwin-arm64.sha256
-              ./evinse-darwin-arm64 --help
+              ./cdxgenx --help
+#              deno compile --allow-read --allow-env --allow-run --allow-sys=uid,systemMemoryInfo,gid,homedir --allow-write --allow-net --node-modules-dir=auto --allow-ffi --allow-scripts=npm:@appthreat/sqlite3@6.0.7 --include=./data --include=./package.json --include=node_modules/sqlite3/build/Release --target aarch64-apple-darwin --output evinse-darwin-arm64 bin/evinse.js
+#              shasum -a 256 evinse-darwin-arm64 > evinse-darwin-arm64.sha256
+#              ./evinse-darwin-arm64 --help
             artifact: cdxgenx-darwin-arm64
           - os: ubuntu
             build: |
@@ -146,10 +147,10 @@ jobs:
               shasum -a 256 cdxgenx > cdxgenx.sha256
               chmod + cdxgenx
               ./cdxgenx --help
-              deno compile --allow-read --allow-env --allow-run --allow-sys=uid,systemMemoryInfo,gid,homedir --allow-write --allow-net --node-modules-dir=auto --allow-ffi --allow-scripts=npm:@appthreat/sqlite3@6.0.7 --include=./data --include=./package.json --include=node_modules/sqlite3/build/Release --output evinse bin/evinse.js
-              shasum -a 256 evinse > evinse.sha256
-              chmod + evinse
-              ./evinse --help
+#              deno compile --allow-read --allow-env --allow-run --allow-sys=uid,systemMemoryInfo,gid,homedir --allow-write --allow-net --node-modules-dir=auto --allow-ffi --allow-scripts=npm:@appthreat/sqlite3@6.0.7 --include=./data --include=./package.json --include=node_modules/sqlite3/build/Release --output evinse bin/evinse.js
+#              shasum -a 256 evinse > evinse.sha256
+#              chmod + evinse
+#              ./evinse --help
             artifact: cdxgenx
     runs-on: ${{ matrix.os }}-latest
     steps:


### PR DESCRIPTION
Currently, we are unable to build 'evinse' on deno, so it was removed from the workflow.