### PR TITLE
Added information about runtime Node in 'version' output

### DIFF
--- a/bin/cdxgen.js
+++ b/bin/cdxgen.js
@@ -35,6 +35,7 @@ import {
   isWin,
   remoteHostsAccessed,
   safeExistsSync,
+  safeSpawnSync,
 } from "../lib/helpers/utils.js";
 import { validateBom } from "../lib/helpers/validator.js";
 import { postProcess } from "../lib/stages/postgen/postgen.js";
@@ -375,7 +376,7 @@ const args = yargs(hideBin(process.argv))
   .epilogue("for documentation, visit https://cyclonedx.github.io/cdxgen")
   .config(config)
   .scriptName("cdxgen")
-  .version()
+  .version(version())
   .alias("v", "version")
   .help("h")
   .alias("h", "help")
@@ -385,15 +386,19 @@ if (process.env?.CDXGEN_NODE_OPTIONS) {
   process.env.NODE_OPTIONS = `${process.env.NODE_OPTIONS || ""} ${process.env.CDXGEN_NODE_OPTIONS}`;
 }
 
-if (args.version) {
+function version() {
   const packageJsonAsString = fs.readFileSync(
-    join(dirName, "..", "package.json"),
+    join(dirName, "package.json"),
     "utf-8",
   );
   const packageJson = JSON.parse(packageJsonAsString);
 
-  console.log(packageJson.version);
-  process.exit(0);
+  const nodeVersion = safeSpawnSync(process.execPath, ["-v"], {
+    encoding: "utf-8",
+    shell: isWin,
+  });
+
+  return `\x1b[1mCycloneDX Generator ${packageJson.version}\x1b[0m\nNode: ${process.execPath}, version: ${nodeVersion.stdout.trim()}`;
 }
 
 if (process.env.GLOBAL_AGENT_HTTP_PROXY || process.env.HTTP_PROXY) {


### PR DESCRIPTION
Similar to other tools, don't simply log the version number, but add some more information about the runtime environment:
- Node binary path
- Node version
