### PR TITLE
[devenv] Downgraded node to v22 because the regression of v24 is now also in the nix repos

### DIFF
--- a/.github/workflows/repotests.yml
+++ b/.github/workflows/repotests.yml
@@ -245,7 +245,7 @@ jobs:
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.12'
-      - uses: ruby/setup-ruby@a4effe49ee8ee5b8b5091268c473a4628afb5651 # v1.245.0
+      - uses: ruby/setup-ruby@a4f838919020b587bb8dd4493e8881bb113d3be7 # v1.246.0
         with:
           ruby-version: '3.4'
       - name: setup-cocoapods # Not using an action, as it is not implemented for windows!
@@ -987,7 +987,7 @@ jobs:
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.12'
-      - uses: ruby/setup-ruby@a4effe49ee8ee5b8b5091268c473a4628afb5651 # v1.245.0
+      - uses: ruby/setup-ruby@a4f838919020b587bb8dd4493e8881bb113d3be7 # v1.246.0
         with:
           ruby-version: '3.4'
       - name: pip install custom-json-diff

--- a/devenv.nix
+++ b/devenv.nix
@@ -34,7 +34,7 @@ in
         };
         javascript = {
           enable = true;
-          package = pkgs-unstable.nodejs_24;
+          package = pkgs-unstable.nodejs_22;
         };
         deno = lib.mkIf (lib.elem config.profile [ "deno" ] == true) {
           enable = true;


### PR DESCRIPTION
Node v24.4.0 is now also in the nix repos and making our builds fail. Downgraded to v22 until the regression is patched.