### PR TITLE
JS-implementation of getting runtime + version

### DIFF
--- a/bin/cdxgen.js
+++ b/bin/cdxgen.js
@@ -29,6 +29,7 @@ import {
   commandsExecuted,
   DEBUG_MODE,
   dirNameStr,
+  getRuntimeInformation,
   getTmpDir,
   isMac,
   isSecureMode,
@@ -404,27 +405,9 @@ function version() {
   );
   const packageJson = JSON.parse(packageJsonAsString);
 
-  let runtime;
-  let runtimeVersion;
+  const runtimeInfo = getRuntimeInformation();
 
-  if (typeof globalThis.Deno !== "undefined" && globalThis.Deno.version?.deno) {
-    runtime = "Deno";
-    runtimeVersion = globalThis.Deno.version.deno;
-  } else if (typeof globalThis.Bun !== "undefined" && globalThis.Bun.version) {
-    runtime = "Bun";
-    runtimeVersion = globalThis.Bun.version;
-  } else if (
-    typeof globalThis.process !== "undefined" &&
-    globalThis.process.versions?.node
-  ) {
-    runtime = "Node.js";
-    runtimeVersion = globalThis.process.versions.node;
-  } else {
-    runtime = "Unknown";
-    runtimeVersion = "N/A";
-  }
-
-  return `\x1b[1mCycloneDX Generator ${packageJson.version}\x1b[0m\nRuntime: ${runtime}, Version: ${runtimeVersion}`;
+  return `\x1b[1mCycloneDX Generator ${packageJson.version}\x1b[0m\nRuntime: ${runtimeInfo.runtime}, Version: ${runtimeInfo.version}`;
 }
 
 if (process.env.GLOBAL_AGENT_HTTP_PROXY || process.env.HTTP_PROXY) {

--- a/lib/helpers/envcontext.js
+++ b/lib/helpers/envcontext.js
@@ -13,11 +13,11 @@ import {
   GO_CMD,
   getJavaCommand,
   getPythonCommand,
+  getRuntimeInformation,
   getTmpDir,
   isMac,
   isWin,
   MAX_BUFFER,
-  NODE_CMD,
   NPM_CMD,
   RUBY_CMD,
   RUSTC_CMD,
@@ -222,20 +222,17 @@ export function collectPythonInfo(dir) {
  * @returns Object containing node details
  */
 export function collectNodeInfo(dir) {
-  const versionDesc = getCommandOutput(NODE_CMD, dir, ["--version"]);
-  let moduleDesc = getCommandOutput(NPM_CMD, dir, ["--version"]);
+  const runtimeInfo = getRuntimeInformation();
+  const nodeInfo = {
+    type: "platform",
+    name: runtimeInfo.runtime,
+    version: runtimeInfo.version,
+  };
+  const moduleDesc = getCommandOutput(NPM_CMD, dir, ["--version"]);
   if (moduleDesc) {
-    moduleDesc = `npm: ${moduleDesc}`;
+    nodeInfo.description = `npm: ${moduleDesc}`;
   }
-  if (versionDesc) {
-    return {
-      type: "platform",
-      name: "node",
-      version: versionDesc.trim(),
-      description: moduleDesc,
-    };
-  }
-  return undefined;
+  return nodeInfo;
 }
 
 /**

--- a/lib/helpers/utils.js
+++ b/lib/helpers/utils.js
@@ -15895,3 +15895,31 @@ function collectAllLdConfs(basePath, ldConf, allLdConfDirs, libPaths) {
     }
   }
 }
+
+/**
+ * Get information about the runtime.
+ *
+ * @returns {Object} Object containing the name and version of the runtime
+ */
+export function getRuntimeInformation() {
+  const runtimeInfo = {};
+
+  if (typeof globalThis.Deno !== "undefined" && globalThis.Deno.version?.deno) {
+    runtimeInfo.runtime = "Deno";
+    runtimeInfo.version = globalThis.Deno.version.deno;
+  } else if (typeof globalThis.Bun !== "undefined" && globalThis.Bun.version) {
+    runtimeInfo.runtime = "Bun";
+    runtimeInfo.version = globalThis.Bun.version;
+  } else if (
+    typeof globalThis.process !== "undefined" &&
+    globalThis.process.versions?.node
+  ) {
+    runtimeInfo.runtime = "Node.js";
+    runtimeInfo.version = globalThis.process.versions.node;
+  } else {
+    runtimeInfo.runtime = "Unknown";
+    runtimeInfo.version = "N/A";
+  }
+
+  return runtimeInfo;
+}

--- a/lib/helpers/utils.js
+++ b/lib/helpers/utils.js
@@ -13675,11 +13675,7 @@ export async function getPipFrozenTree(
 
   // FIX: Create a set of explicit dependencies from requirements.txt to identify root packages.
   const explicitDeps = new Set();
-  if (
-    reqOrSetupFile &&
-    reqOrSetupFile.endsWith(".txt") &&
-    safeExistsSync(reqOrSetupFile)
-  ) {
+  if (reqOrSetupFile?.endsWith(".txt") && safeExistsSync(reqOrSetupFile)) {
     const reqData = readFileSync(reqOrSetupFile, { encoding: "utf-8" });
     // We only need the package names, so we pass `false` to avoid fetching full metadata.
     const tempPkgList = await parseReqFile(reqData, false);


### PR DESCRIPTION
The implementation just added only supported NodeJS and was calling the binary to check. This version is fully implemented in JavaScript and can handle Deno and Bun as well.