### PR TITLE
Testing Node.js nightly builds

### DIFF
--- a/.github/workflows/test-nodejs-nightly.yml
+++ b/.github/workflows/test-nodejs-nightly.yml
@@ -1,4 +1,4 @@
-name: Test NodeJS nightly build
+name: Test Node.js nightly build
 
 on:
   schedule:
@@ -23,3 +23,14 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
+      - name: Install latest Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 25-nightly
+      - name: Test
+        run: |
+          # Install pnpm
+          npm install --global pnpm
+
+          # Install dependencies
+          pnpm install


### PR DESCRIPTION
To pro-actively figure out if we will be having issues with new versions of node and also to figure out when those issues are solved in case they were released, we added a workflow to tries to run 'pnpm install' daily, using the latest nightly build.