### PR TITLE
[build] Run the repotests on github's runners

### DIFF
--- a/.github/workflows/repotests.yml
+++ b/.github/workflows/repotests.yml
@@ -173,7 +173,7 @@ jobs:
       matrix:
         java-version: ['24']
         node-version: ['24.3']
-        os: ['self-hosted-ubuntu', 'ubuntu-24.04-arm', 'windows-latest', 'macos-15']
+        os: ['ubuntu-24.04', 'ubuntu-24.04-arm', 'windows-latest', 'macos-15']
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
The quick-tests are running on hosted servers, run all others in github's cloud.