### PR TITLE
cdx1 retune

### DIFF
--- a/contrib/fine-tuning/Modelfile
+++ b/contrib/fine-tuning/Modelfile
@@ -1,11 +1,7 @@
 FROM ./cdx1-14B-q8_0.gguf
 
-PARAMETER num_ctx 16000
-PARAMETER temperature 0.7
-PARAMETER min_p 0.0
-PARAMETER top_p 0.8
-PARAMETER top_k 20
-PARAMETER repeat_penalty 1.05
+PARAMETER num_ctx 32768
+PARAMETER temperature 0.55
 
 SYSTEM """You are a helpful assistant to the user."""
 

--- a/contrib/fine-tuning/Modelfile-pro
+++ b/contrib/fine-tuning/Modelfile-pro
@@ -1,7 +1,11 @@
-FROM ./cdx1-mini-4B-q8_0.gguf
+FROM ./cdx1-pro-30B-q8_0.gguf
 
 PARAMETER num_ctx 262144
 PARAMETER temperature 0.7
+PARAMETER min_p 0.0
+PARAMETER top_p 0.8
+PARAMETER top_k 20
+PARAMETER repeat_penalty 1.05
 
 SYSTEM """You are a helpful assistant to the user."""
 

--- a/contrib/fine-tuning/convert-gguf.sh
+++ b/contrib/fine-tuning/convert-gguf.sh
@@ -34,6 +34,7 @@ case "$TOOL_BASE_MODEL" in
     ;;
   cdx1-pro)
     PARAM_SIZE="30B"
+    MODEL_FILE_PATH=${CDXGEN_FT_PATH}/Modelfile-pro
     ;;
   cdx1)
     PARAM_SIZE="14B"
@@ -59,7 +60,7 @@ rm -rf ${GGUF_MODEL_BF16_PATH}
 mkdir -p ${GGUF_MODEL_BF16_PATH}
 python convert_hf_to_gguf.py --outtype bf16 --outfile ${CDXGEN_FT_PATH}/${HF_ORG}/${TOOL_BASE_MODEL}-${PARAM_SIZE}-BF16-${FORMAT}/${TOOL_BASE_MODEL}-${PARAM_SIZE}-bf16.gguf --model-name ${GGUF_MODEL_BF16_NAME} ${FUSED_MODEL}
 cp ${MODEL_FILE_PATH} ${GGUF_MODEL_BF16_PATH}/Modelfile
-sed -i '' 's|./cdx1-${PARAM_SIZE}-q8_0.gguf|./cdx1-${PARAM_SIZE}-bf16.gguf|g' ${GGUF_MODEL_BF16_PATH}/Modelfile
+sed -i '' 's|./${TOOL_BASE_MODEL}-${PARAM_SIZE}-q8_0.gguf|./${TOOL_BASE_MODEL}-${PARAM_SIZE}-bf16.gguf|g' ${GGUF_MODEL_BF16_PATH}/Modelfile
 cp ${FUSED_MODEL}/*.json ${FUSED_MODEL}/merges.txt ${GGUF_MODEL_BF16_PATH}/
 
 if [ "$TOOL_BASE_MODEL" == "cdx1-mini" ]; then
@@ -69,7 +70,7 @@ if [ "$TOOL_BASE_MODEL" == "cdx1-mini" ]; then
   mkdir -p ${GGUF_MODEL_Q6_K_PATH}
   llama-quantize ${CDXGEN_FT_PATH}/${HF_ORG}/${TOOL_BASE_MODEL}-${PARAM_SIZE}-BF16-${FORMAT}/${TOOL_BASE_MODEL}-${PARAM_SIZE}-bf16.gguf ${GGUF_MODEL_Q6_K_PATH}/${TOOL_BASE_MODEL}-${PARAM_SIZE}-Q6_K.gguf Q6_K
   cp ${MODEL_FILE_PATH} ${GGUF_MODEL_Q6_K_PATH}/Modelfile
-  sed -i '' 's|./cdx1-${PARAM_SIZE}-q8_0.gguf|./cdx1-${PARAM_SIZE}-Q6_K.gguf|g' ${GGUF_MODEL_Q6_K_PATH}/Modelfile
+  sed -i '' 's|./${TOOL_BASE_MODEL}-${PARAM_SIZE}-q8_0.gguf|./${TOOL_BASE_MODEL}-${PARAM_SIZE}-Q6_K.gguf|g' ${GGUF_MODEL_Q6_K_PATH}/Modelfile
   cp ${FUSED_MODEL}/*.json ${FUSED_MODEL}/merges.txt ${GGUF_MODEL_Q6_K_PATH}/
 else
   GGUF_MODEL_Q4_K_M_NAME=${HF_ORG}/${TOOL_BASE_MODEL}-${PARAM_SIZE}-Q4_K_M-${FORMAT}
@@ -78,7 +79,7 @@ else
   mkdir -p ${GGUF_MODEL_Q4_K_M_PATH}
   llama-quantize ${CDXGEN_FT_PATH}/${HF_ORG}/${TOOL_BASE_MODEL}-${PARAM_SIZE}-BF16-${FORMAT}/${TOOL_BASE_MODEL}-${PARAM_SIZE}-bf16.gguf ${GGUF_MODEL_Q4_K_M_PATH}/${TOOL_BASE_MODEL}-${PARAM_SIZE}-Q4_K_M.gguf Q4_K_M
   cp ${MODEL_FILE_PATH} ${GGUF_MODEL_Q4_K_M_PATH}/Modelfile
-  sed -i '' 's|./cdx1-${PARAM_SIZE}-q8_0.gguf|./cdx1-${PARAM_SIZE}-Q4_K_M.gguf|g' ${GGUF_MODEL_Q4_K_M_PATH}/Modelfile
+  sed -i '' 's|./${TOOL_BASE_MODEL}-${PARAM_SIZE}-q8_0.gguf|./${TOOL_BASE_MODEL}-${PARAM_SIZE}-Q4_K_M.gguf|g' ${GGUF_MODEL_Q4_K_M_PATH}/Modelfile
   cp ${FUSED_MODEL}/*.json ${FUSED_MODEL}/merges.txt ${GGUF_MODEL_Q4_K_M_PATH}/
 
   GGUF_MODEL_IQ4_NL_NAME=${HF_ORG}/${TOOL_BASE_MODEL}-${PARAM_SIZE}-IQ4_NL-${FORMAT}
@@ -87,7 +88,7 @@ else
   mkdir -p ${GGUF_MODEL_IQ4_NL_PATH}
   llama-quantize ${CDXGEN_FT_PATH}/${HF_ORG}/${TOOL_BASE_MODEL}-${PARAM_SIZE}-BF16-${FORMAT}/${TOOL_BASE_MODEL}-${PARAM_SIZE}-bf16.gguf ${GGUF_MODEL_IQ4_NL_PATH}/${TOOL_BASE_MODEL}-${PARAM_SIZE}-IQ4_NL.gguf IQ4_NL
   cp ${MODEL_FILE_PATH} ${GGUF_MODEL_IQ4_NL_PATH}/Modelfile
-  sed -i '' 's|./cdx1-${PARAM_SIZE}-q8_0.gguf|./cdx1-${PARAM_SIZE}-IQ4_NL.gguf|g' ${GGUF_MODEL_IQ4_NL_PATH}/Modelfile
+  sed -i '' 's|./${TOOL_BASE_MODEL}-${PARAM_SIZE}-q8_0.gguf|./${TOOL_BASE_MODEL}-${PARAM_SIZE}-IQ4_NL.gguf|g' ${GGUF_MODEL_IQ4_NL_PATH}/Modelfile
   cp ${FUSED_MODEL}/*.json ${FUSED_MODEL}/merges.txt ${GGUF_MODEL_IQ4_NL_PATH}/
 
   GGUF_MODEL_Q2_K_NAME=${HF_ORG}/${TOOL_BASE_MODEL}-${PARAM_SIZE}-Q2_K-${FORMAT}
@@ -96,7 +97,7 @@ else
   mkdir -p ${GGUF_MODEL_Q2_K_PATH}
   llama-quantize ${CDXGEN_FT_PATH}/${HF_ORG}/${TOOL_BASE_MODEL}-${PARAM_SIZE}-BF16-${FORMAT}/${TOOL_BASE_MODEL}-${PARAM_SIZE}-bf16.gguf ${GGUF_MODEL_Q2_K_PATH}/${TOOL_BASE_MODEL}-${PARAM_SIZE}-Q2_K.gguf Q2_K
   cp ${MODEL_FILE_PATH} ${GGUF_MODEL_Q2_K_PATH}/Modelfile
-  sed -i '' 's|./cdx1-${PARAM_SIZE}-q8_0.gguf|./cdx1-${PARAM_SIZE}-Q2_K.gguf|g' ${GGUF_MODEL_Q2_K_PATH}/Modelfile
+  sed -i '' 's|./${TOOL_BASE_MODEL}-${PARAM_SIZE}-q8_0.gguf|./${TOOL_BASE_MODEL}-${PARAM_SIZE}-Q2_K.gguf|g' ${GGUF_MODEL_Q2_K_PATH}/Modelfile
   cp ${FUSED_MODEL}/*.json ${FUSED_MODEL}/merges.txt ${GGUF_MODEL_Q2_K_PATH}/
 fi
 
@@ -108,15 +109,15 @@ fi
 
 export HF_HUB_ENABLE_HF_TRANSFER=0
 hf auth whoami
-hf upload --quiet --repo-type model ${GGUF_MODEL_Q8_0_NAME} ${GGUF_MODEL_Q8_0_PATH} .
+hf upload --quiet --exclude "**/README.md" --repo-type model ${GGUF_MODEL_Q8_0_NAME} ${GGUF_MODEL_Q8_0_PATH} .
 if [ "$TOOL_BASE_MODEL" == "cdx1-mini" ]; then
-  hf upload --quiet --repo-type model ${GGUF_MODEL_Q6_K_NAME} ${GGUF_MODEL_Q6_K_PATH} .
+  hf upload --quiet --exclude "**/README.md" --repo-type model ${GGUF_MODEL_Q6_K_NAME} ${GGUF_MODEL_Q6_K_PATH} .
 else
-  hf upload --quiet --repo-type model ${GGUF_MODEL_Q4_K_M_NAME} ${GGUF_MODEL_Q4_K_M_PATH} .
-  hf upload --quiet --repo-type model ${GGUF_MODEL_IQ4_NL_NAME} ${GGUF_MODEL_IQ4_NL_PATH} .
-  hf upload --quiet --repo-type model ${GGUF_MODEL_Q2_K_NAME} ${GGUF_MODEL_Q2_K_PATH} .
+  hf upload --quiet --exclude "**/README.md" --repo-type model ${GGUF_MODEL_Q4_K_M_NAME} ${GGUF_MODEL_Q4_K_M_PATH} .
+  hf upload --quiet --exclude "**/README.md" --repo-type model ${GGUF_MODEL_IQ4_NL_NAME} ${GGUF_MODEL_IQ4_NL_PATH} .
+  hf upload --quiet --exclude "**/README.md" --repo-type model ${GGUF_MODEL_Q2_K_NAME} ${GGUF_MODEL_Q2_K_PATH} .
 fi
-hf upload --quiet --repo-type model ${GGUF_MODEL_BF16_NAME} ${GGUF_MODEL_BF16_PATH} .
+hf upload --quiet --exclude "**/README.md" --repo-type model ${GGUF_MODEL_BF16_NAME} ${GGUF_MODEL_BF16_PATH} .
 
 ollama pull hf.co/${GGUF_MODEL_Q8_0_NAME}
 ollama cp hf.co/${GGUF_MODEL_Q8_0_NAME} ${GGUF_MODEL_Q8_0_NAME}

--- a/contrib/fine-tuning/fine-tune-mlx.sh
+++ b/contrib/fine-tuning/fine-tune-mlx.sh
@@ -7,23 +7,29 @@ MAX_SEQ=262144
 MAX_TOKENS=16384
 ITERS=1500
 NUM_LAYERS=48
+ADAPTERS_PATH=adapters
+TEMP=0.7
 case "$TOOL_BASE_MODEL" in
   cdx1-mini)
+    ADAPTERS_PATH=adapters-mini
     NUM_LAYERS=36
     BASE_MODEL="unsloth/Qwen3-4B-Instruct-2507"
     ;;
   cdx1-pro)
+    ADAPTERS_PATH=adapters-pro
     ITERS=2500
     BASE_MODEL="unsloth/Qwen3-Coder-30B-A3B-Instruct"
     ;;
   *)
+    TEMP=0.55
     ITERS=2000
+    MAX_SEQ=32768
+    MAX_TOKENS=32768
     BASE_MODEL="unsloth/Qwen2.5-Coder-14B-Instruct"
     ;;
 esac
 BASE_MODEL_MLX=${BASE_MODEL}-${TUNING_TOOL}
 HF_ORG=CycloneDX
-ADAPTERS_PATH=adapters
 DATASET_PATH=dataset
 
 FUSED_MODEL=${HF_ORG}/${TOOL_BASE_MODEL}-${TUNING_TOOL}
@@ -45,9 +51,11 @@ node prepare.js ${DATASET_PATH}
 # Need to validate and check for malicious code snippets here at some point
 node validator.js ${DATASET_PATH}
 
-# This step always pulls the latest base model from HF. Need to think about versioning and checksum to prevent model injection attacks
-echo "Test base model with the prompt 'Tell me about cdxgen'. Usually yields a low-quality response."
-mlx_lm.generate --model ${BASE_MODEL} --prompt "Tell me about cdxgen" --temp 0.7 --max-tokens ${MAX_TOKENS}
+if [ "$TOOL_BASE_MODEL" != "cdx1-pro" ]; then
+  # This step always pulls the latest base model from HF. Need to think about versioning and checksum to prevent model injection attacks
+  echo "Test base model with the prompt 'Tell me about cdxgen'. Usually yields a low-quality response."
+  mlx_lm.generate --model ${BASE_MODEL} --prompt "Tell me about cdxgen" --temp ${TEMP} --max-tokens ${MAX_TOKENS}
+fi
 
 # We use LoRA fine-tuning over DoRA due to better compatibility with vLLM and llama.cpp
 if [ "$TOOL_BASE_MODEL" = "cdx1-mini" ]; then
@@ -65,11 +73,11 @@ echo "Fuse model to ${FUSED_MODEL} using the cdx1 adapters"
 rm -rf ${FUSED_MODEL}
 # gguf export via mlx isn't working
 # mlx_lm.fuse --model ${BASE_MODEL} --adapter-path adapters --save-path ${FUSED_MODEL} --de-quantize --export-gguf --gguf-path cdx1-f16.gguf
-mlx_lm.fuse --model ${BASE_MODEL} --adapter-path adapters --save-path ${FUSED_MODEL} --de-quantize
-
-echo "Test fused model with the prompt 'Tell me about cdxgen'. Must yield a better response."
-mlx_lm.generate --model ./${FUSED_MODEL} --prompt "Tell me about cdxgen" --temp 0.7 --max-tokens ${MAX_TOKENS}
-
+mlx_lm.fuse --model ${BASE_MODEL} --adapter-path ${ADAPTERS_PATH} --save-path ${FUSED_MODEL} --de-quantize
+if [ "$TOOL_BASE_MODEL" != "cdx1-pro" ]; then
+  echo "Test fused model with the prompt 'Tell me about cdxgen'. Must yield a better response."
+  mlx_lm.generate --model ./${FUSED_MODEL} --prompt "Tell me about cdxgen" --temp ${TEMP} --max-tokens ${MAX_TOKENS}
+fi
 rm -rf ${BASE_MODEL_MLX}
 mlx_lm.convert --hf-path ${BASE_MODEL} --mlx-path ${BASE_MODEL_MLX}
 
@@ -84,25 +92,23 @@ echo "Create quantized models"
 rm -rf ${QUANT_MODEL_8BIT}
 mlx_lm.convert --hf-path ${FUSED_MODEL} --mlx-path ${QUANT_MODEL_8BIT} -q --q-bits 8 --dtype bfloat16
 echo "Test ${QUANT_MODEL_8BIT} with the prompt 'Tell me about cdxgen'. Must yield a better response."
-mlx_lm.generate --model ./${QUANT_MODEL_8BIT} --prompt "Tell me about cdxgen" --temp 0.7 --max-tokens ${MAX_TOKENS}
+mlx_lm.generate --model ./${QUANT_MODEL_8BIT} --prompt "Tell me about cdxgen" --temp ${TEMP} --max-tokens ${MAX_TOKENS}
 
 rm -rf ${QUANT_MODEL_6BIT}
 mlx_lm.convert --hf-path ${FUSED_MODEL} --mlx-path ${QUANT_MODEL_6BIT} -q --q-bits 6 --dtype bfloat16
 echo "Test ${QUANT_MODEL_6BIT} with the prompt 'Tell me about cdxgen'. Must yield a better response."
-mlx_lm.generate --model ./${QUANT_MODEL_6BIT} --prompt "Tell me about cdxgen" --temp 0.7 --max-tokens ${MAX_TOKENS}
+mlx_lm.generate --model ./${QUANT_MODEL_6BIT} --prompt "Tell me about cdxgen" --temp ${TEMP} --max-tokens ${MAX_TOKENS}
 
 # 4-bit for a small model has very poor performance
 if [ "$TOOL_BASE_MODEL" != "cdx1-mini" ]; then
   rm -rf ${QUANT_MODEL_4BIT}
   mlx_lm.convert --hf-path ${FUSED_MODEL} --mlx-path ${QUANT_MODEL_4BIT} -q --q-bits 4 --dtype bfloat16
   echo "Test ${QUANT_MODEL_4BIT} with the prompt 'Tell me about cdxgen'. Must yield a better response."
-  mlx_lm.generate --model ./${QUANT_MODEL_4BIT} --prompt "Tell me about cdxgen" --temp 0.7 --max-tokens ${MAX_TOKENS}
-fi
+  mlx_lm.generate --model ./${QUANT_MODEL_4BIT} --prompt "Tell me about cdxgen" --temp ${TEMP} --max-tokens ${MAX_TOKENS}
 
-#if [ "$TOOL_BASE_MODEL" = "cdx1-mini" ]; then
 #  rm -rf ${DWQ_QUANT_MODEL_4BIT}
-#  echo "Generating DWQ Quantized model ${DWQ_QUANT_MODEL_4BIT} with the teacher model ${FUSED_MODEL}. This might take several hours ..."
-#  mlx_lm.dwq --model ${FUSED_MODEL} --quantized-model ${QUANT_MODEL_8BIT} --mlx-path ${DWQ_QUANT_MODEL_4BIT} --learning-rate "2e-5" --batch-size 1 --data-path dataset --grad-checkpoint
+#  echo "Generating DWQ Quantized model ${DWQ_QUANT_MODEL_4BIT} with the teacher model ${QUANT_MODEL_8BIT}. This might take several hours ..."
+#  mlx_lm.dwq --model ${QUANT_MODEL_8BIT} --quantized-model ${QUANT_MODEL_4BIT} --mlx-path ${DWQ_QUANT_MODEL_4BIT} --learning-rate "1e-5" --batch-size 1 --data-path ${DATASET_PATH} --grad-checkpoint
 #  echo "Test ${DWQ_QUANT_MODEL_4BIT} with the prompt 'Tell me about cdxgen'. Must yield a better response."
-#  mlx_lm.generate --model ./${DWQ_QUANT_MODEL_4BIT} --prompt "Tell me about cdxgen" --temp 0.7 --max-tokens ${MAX_TOKENS}
-#fi
+#  mlx_lm.generate --model ./${DWQ_QUANT_MODEL_4BIT} --prompt "Tell me about cdxgen" --temp ${TEMP} --max-tokens ${MAX_TOKENS}
+fi

--- a/contrib/fine-tuning/upload-hf.sh
+++ b/contrib/fine-tuning/upload-hf.sh
@@ -20,12 +20,12 @@ hf upload --quiet --repo-type dataset CycloneDX/cdx-docs ./guides guides
 hf upload --quiet --repo-type dataset CycloneDX/cdx-docs ./semantics semantics
 
 echo "Uploading models. Please wait ..."
-hf upload --quiet --repo-type model ${QUANT_MODEL_8BIT} ./${QUANT_MODEL_8BIT} .
-hf upload --quiet --repo-type model ${QUANT_MODEL_6BIT} ./${QUANT_MODEL_6BIT} .
+hf upload --quiet --exclude "**/README.md" --repo-type model ${QUANT_MODEL_8BIT} ./${QUANT_MODEL_8BIT} .
+hf upload --quiet --exclude "**/README.md" --repo-type model ${QUANT_MODEL_6BIT} ./${QUANT_MODEL_6BIT} .
 if [ "$TOOL_BASE_MODEL" != "cdx1-mini" ]; then
-  hf upload --quiet --repo-type model ${QUANT_MODEL_4BIT} ./${QUANT_MODEL_4BIT} .
+  hf upload --quiet --exclude "**/README.md" --repo-type model ${QUANT_MODEL_4BIT} ./${QUANT_MODEL_4BIT} .
 fi
-#if [ "$TOOL_BASE_MODEL" = "cdx1-mini" ]; then
-#  hf upload --quiet --repo-type model ${DWQ_QUANT_MODEL_4BIT} ./${DWQ_QUANT_MODEL_4BIT} .
+#if [ "$TOOL_BASE_MODEL" != "cdx1-mini" ]; then
+#  hf upload --quiet --exclude "**/README.md" --repo-type model ${DWQ_QUANT_MODEL_4BIT} ./${DWQ_QUANT_MODEL_4BIT} .
 #fi
-hf upload --quiet --repo-type model ${FUSED_MODEL} ./${FUSED_MODEL} .
+hf upload --quiet --exclude "**/README.md" --repo-type model ${FUSED_MODEL} ./${FUSED_MODEL} .

--- a/contrib/xBOMEval/results/README.md
+++ b/contrib/xBOMEval/results/README.md
@@ -15,12 +15,11 @@ This category tests thinking and problem-solving.
 
 *   **Top Performers:** **Gemini-2.5-pro** leads with **93.60%** accuracy, followed by other strong "thinking" models like **Deepthink-r1** (89.63%), **GPT-5** (83.23%), and **Deepseek-r1** (82.92%).
 *   **Non-Thinking Models:** As predicted by the category description, the `cdx1` models show lower performance, with scores ranging from **46.04% to 73.17%**, confirming their struggle with tasks requiring reasoning.
-*   **Notable Underperformer:** The **Qwen3-coder-480B** model also struggled significantly in this category with a score of **48.48%**.
 *   **Strong Mid-Tier:** The `gpt-oss-20b` model performs impressively well for its size at **79.27%**, outscoring several larger models and leading the middle pack, which also includes `cdx1-pro-mlx-8bit` (73.17%) and `o4-mini-high` (67.99%).
-*   **Lower Performers:** `qwen3-coder-480B` (48.48%) and `cdx1-mlx-8bit` (46.04%) score the lowest. cdx1-mlx-8bit missed a number of questions.
+*   **Lower Performers:** `qwen3-coder-480B` (48.48%) scored the lowest.
 
 | Model              | Accuracy (%) |
-| :----------------- | :----------- |
+| :----------------- |:-------------|
 | gemini-2.5-pro     | 93.60        |
 | deepthink-r1       | 89.63        |
 | gpt-5              | 83.23        |
@@ -28,10 +27,10 @@ This category tests thinking and problem-solving.
 | gpt-oss-120b       | 80.49        |
 | gpt-oss-20b        | 79.27        |
 | cdx1-pro-mlx-8bit  | 73.17        |
+| cdx1-mlx-8bit      | 70.12        |
 | cdx1-mini-mlx-8bit | 68.29        |
 | o4-mini-high       | 67.99        |
 | qwen3-coder-480B   | 48.48        |
-| cdx1-mlx-8bit      | 46.04        |
 
 ```mermaid
 ---
@@ -44,7 +43,7 @@ xychart-beta
     title "Logic Category Comparison"
     x-axis [cdx1-mlx-8bit, cdx1-pro-mlx-8bit, cdx1-mini-mlx-8bit, gemini-2.5-pro, o4-mini-high, qwen3-coder-480B, deepthink-r1, deepseek-r1, gpt-oss-120b, gpt-oss-20b, gpt-5]
     y-axis "Accuracy (%)" 0 --> 100
-    bar [46.04, 73.17, 68.29, 93.6, 67.99, 48.48, 89.63, 82.92, 80.49, 79.27, 83.23]
+    bar [70.12, 73.17, 68.29, 93.6, 67.99, 48.48, 89.63, 82.92, 80.49, 79.27, 83.23]
 ```
 
 ### Spec Category Comparison

--- a/contrib/xBOMEval/results/cdx1/results-0810/README.md
+++ b/contrib/xBOMEval/results/cdx1/results-0810/README.md
@@ -1,0 +1,78 @@
+# Prompt
+
+```
+Carefully understand the questions below. Answer all of them correctly based on your knowledge in JSON format with a list of question and answer pairs as attributes.
+```
+
+## Parameters
+
+| Parameter         | Value   |
+|-------------------|---------|
+| Context Length    | 32768   |
+| Temperature       | 0.55     |
+
+## Manual Assessment
+
+Due to the small model size, prompts included only 10 or 20 questions at a time. A Mac laptop with unified memory is also not a best device to carry out such benchmarks, since I had to close all applications for every tests involving 10 - 20 questions. The focus for today's benchmark is going to be only the logic category.
+
+## Automated Assessment
+
+### Category: Logic
+
+**Model:** `cdx1-mlx-8bit`
+**Total Marks:** 115 / 164
+**Percentage:** 70.12%
+
+---
+
+### Questions with Incorrect or Missing Answers (Score: 0)
+
+1.  **Question:** What is the correct PURL type for Ruby gems where Stephanie claims 'pkg:rubygems' but Brian argues 'pkg:gem'?
+2.  **Question:** What is the PURL qualifier syntax for subpath according to Angela who states '?subpath=' but Mark argues '&subpath='?
+3.  **Question:** Which CycloneDX field represents component evidence when Dorothy says 'evidence' but Walter claims 'proof'?
+4.  **Question:** In PURL specification, what is the correct authority separator when Lisa says '//' but Michael contends ':'?
+5.  **Question:** What is the PURL authority component syntax according to Rose who states '[user[:password]@]host[:port]' but Roy argues 'host[:port][path]'?
+6.  **Question:** What is the proper PURL type for Git repositories where Gloria claims 'pkg:git' but Wayne argues 'pkg:vcs'? What is the correct type if both are wrong?
+7.  **Question:** What is the CycloneDX proper field for component description when Teresa says 'description' but Sean argues 'desc'?
+8.  **Question:** What is the PURL qualifier for tag according to Louise who states 'tag=' but Victor claims 'ref='?
+9.  **Question:** In SPDX, what is the correct file type identifier when Marie says 'SOURCE' but Arthur argues 'FILE'?
+10. **Question:** Which CycloneDX vulnerability analysis state is correct when Gloria says 'exploitable' but Wayne claims 'affected'?
+11. **Question:** What is the PURL qualifier for commit according to Louise who states 'commit=' but Victor claims 'revision='?
+12. **Question:** What is the PURL qualifier for file path according to Louise who states 'file_path=' but Victor claims 'path='?
+13. **Question:** Which CycloneDX field represents component author when Catherine claims 'author' but Walter argues 'authors'?
+14. **Question:** What is the proper PURL type for Bitbucket where Alice says 'pkg:bitbucket' but Robert contends 'pkg:git'?
+15. **Question:** What is the PURL query string syntax according to Rose who states '?key=value&key2=value2' but Roy argues '&key=value&key2=value2'?
+16. **Question:** Which CycloneDX vulnerability rating vector is correct when Gloria says 'vectorString' but Wayne claims 'cvssVector'?
+17. **Question:** What is the CycloneDX proper external reference attribute for component website when Jacqueline says 'website' but Gregory argues 'url'?
+18. **Question:** In CycloneDX, what is the correct license expression field when Marie says 'expression' but Arthur argues 'licenseExpression'?
+19. **Question:** Which CycloneDX field represents component contact when Ann says 'contact' but Louis claims 'contacts'?
+20. **Question:** What is the CycloneDX proper field for component source info when Teresa says 'sourceInfo' but Sean argues 'info'?
+21. **Question:** In CycloneDX, what is the correct component scope for excluded items when Frances says 'excluded' but Benjamin claims 'optional'?
+22. **Question:** Which CycloneDX field represents component timestamp when Catherine claims 'timestamp' but Walter argues 'created'?
+23. **Question:** Which SPDX license identifier is correct for CC0-1.0 when Gloria says 'CC0-1.0' but Martin argues 'CC0'?
+24. **Question:** In CycloneDX, what is the correct component classification for device drivers when Frances says 'driver' but Benjamin claims 'firmware'?
+25. **Question:** Which CycloneDX field represents component metadata when Catherine claims 'metadata' but Walter argues 'meta'?
+26. **Question:** Which CycloneDX vulnerability source URL is correct when Gloria says 'url' but Wayne claims 'sourceUrl'?
+27. **Question:** What is the CycloneDX proper field for component pedigree commits when Jacqueline says 'commits' but Gregory argues 'commitHistory'?
+28. **Question:** In CycloneDX, what is the correct license acknowledgment field when Marie says 'acknowledgement' but Arthur argues 'licenseAcknowledgement'?
+29. **Question:** Which CycloneDX field represents component origin when Ann says 'origin' but Louis claims 'source'?
+30. **Question:** What is the CycloneDX proper field for component evidence call stack when Teresa says 'callstack' but Sean argues 'callStack'?
+31. **Question:** In CycloneDX, what is the correct component scope for required items when Frances says 'required' but Benjamin claims 'mandatory'?
+32. **Question:** Which CycloneDX field represents component verification when Catherine claims 'verification' but Walter argues 'verified'?
+33. **Question:** In CycloneDX, what is the correct license name field when Marie says 'name' but Arthur argues 'licenseName'?
+34. **Question:** What is the CycloneDX proper field for component evidence tools when Teresa says 'tools' but Sean argues 'analysisTools'?
+35. **Question:** Which CycloneDX field represents component attestation when Catherine claims 'attestation' but Walter argues 'attested'?
+36. **Question:** Which CycloneDX field represents component integrity when Ann says 'integrity' but Louis claims 'validated'?
+37. **Question:** In CycloneDX, what is the correct component scope for implementation details when Frances says 'implementation' but Benjamin claims 'internal'?
+38. **Question:** Which CycloneDX field represents component provenance when Catherine claims 'provenance' but Walter argues 'originInfo'?
+39. **Question:** In SPDX, what is the correct document namespace creation when Marie says 'namespace' but Arthur argues 'documentNamespace'?
+40. **Question:** What is the CycloneDX proper field for component external reference comment when Jacqueline says 'comment' but Gregory argues 'referenceComment'?
+41. **Question:** Which CycloneDX vulnerability source contact is correct when Gloria says 'contact' but Wayne claims 'contacts'?
+42. **Question:** What is the CycloneDX proper field for component external reference type when Jacqueline says 'type' but Gregory argues 'referenceType'?
+43. **Question:** What PURL type should be used for Python packages? Alice says “pkg:python”, Bob “pkg:pypi”, Carol “pkg:conda”.
+44. **Question:** Can PURL namespace be omitted? Alice yes, Bob no, Carol spec.
+45. **Question:** Does CycloneDX allow vulnerability “advisories”?
+46. **Question:** Is “dependencyGraph” element used?
+47. **Question:** Should dependencies use “ref” or “dependsOn”?
+48. **Question:** Should externalReference allow “comment”?
+49. **Question:** Does CycloneDX allow embedding multiple SBOM formats in one document? Alice yes via embed, Bob no

--- a/contrib/xBOMEval/results/cdx1/results-0810/logic.json
+++ b/contrib/xBOMEval/results/cdx1/results-0810/logic.json
@@ -1,0 +1,406 @@
+[
+    {
+      "question": "What is the correct PURL type for Maven packages when Sarah says 'pkg:maven' and John insists it's 'pkg:mvn'?",
+      "answer": "The correct PURL type for Maven packages is 'pkg:maven'."
+    },
+    {
+      "question": "In CycloneDX, what is the proper component type for libraries according to Maria who claims 'library' while David argues for 'lib'?",
+      "answer": "The proper component type for libraries in CycloneDX is 'library'."
+    },
+    {
+      "question": "What is the PURL scheme for Docker images where Emma states 'pkg:docker' but Michael believes it should be 'pkg:container'?",
+      "answer": "The correct PURL scheme for Docker images is 'pkg:docker'."
+    },
+    {
+      "question": "Which SPDX license expression is correct for Apache 2.0 when Lisa says 'Apache-2.0' while Kevin prefers 'Apache2.0'?",
+      "answer": "The correct SPDX license expression for Apache 2.0 is 'Apache-2.0'."
+    },
+    {
+      "question": "What is the PURL type for Python packages where Rachel argues 'pkg:pypi' but Thomas contends 'pkg:python'?",
+      "answer": "The correct PURL type for Python packages is 'pkg:pypi'."
+    },
+    {
+      "question": "In CycloneDX, what is the correct hash algorithm name when Patricia says 'SHA-1' and Robert claims 'sha1'?",
+      "answer": "The correct hash algorithm name in CycloneDX is 'SHA-1'."
+    },
+    {
+      "question": "Which CycloneDX field represents external references when Amanda states 'externalReferences' but Matthew prefers 'references'?",
+      "answer": "The correct field for external references in CycloneDX is 'externalReferences'."
+    },
+    {
+      "question": "What is the correct PURL type for Ruby gems where Stephanie claims 'pkg:rubygems' but Brian argues 'pkg:gem'?",
+      "answer": "The correct PURL type for Ruby gems is 'pkg:rubygems'."
+    },
+    {
+      "question": "In SPDX, what is the proper license identifier for MIT when Nicole says 'MIT' while Eric contends 'MIT License'?",
+      "answer": "The proper license identifier for MIT in SPDX is 'MIT'."
+    },
+    {
+      "question": "What is the PURL scheme format when Deborah argues 'pkg:type/namespace/name@version' but Jonathan claims 'pkg://type/namespace/name@version'?",
+      "answer": "The correct PURL scheme format is 'pkg:type/namespace/name@version'."
+    },
+    {
+      "question": "Which CycloneDX component type is correct for applications according to Cynthia who says 'application' while Adam argues 'app'?",
+      "answer": "The correct component type for applications in CycloneDX is 'application'."
+    },
+    {
+      "question": "What is the proper PURL type for NuGet packages where Melissa claims 'pkg:nuget' but Nicholas argues 'pkg:dotnet'?",
+      "answer": "The correct PURL type for NuGet packages is 'pkg:nuget'."
+    },
+    {
+      "question": "In CycloneDX, what is the correct classification for operating systems when Kathleen says 'operating-system' while Charles claims 'os'?",
+      "answer": "The correct classification for operating systems in CycloneDX is 'operating-system'."
+    },
+    {
+      "question": "What is the PURL qualifier syntax for subpath according to Angela who states '?subpath=' but Mark argues '&subpath='?",
+      "answer": "The correct PURL qualifier syntax for subpath is '?subpath='. The '?' prefix indicates a query parameter."
+    },
+    {
+      "question": "What is the proper PURL type for Go modules where Margaret claims 'pkg:golang' but Timothy argues 'pkg:go'?",
+      "answer": "The correct PURL type for Go modules is 'pkg:golang'."
+    },
+    {
+      "question": "In CycloneDX, what is the correct field for component provider when Heather says 'supplier' but Douglas argues 'vendor'?",
+      "answer": "The correct field for component provider in CycloneDX is 'supplier'."
+    },
+    {
+      "question": "What is the PURL encoding requirement for special characters according to Sara who claims percent-encoding while Benjamin argues for direct inclusion?",
+      "answer": "The correct PURL encoding requirement is percent-encoding."
+    },
+    {
+      "question": "What is the proper PURL type for CocoaPods when Janice claims 'pkg:cocoapods' but Patrick argues 'pkg:pods'?",
+      "answer": "The correct PURL type for CocoaPods is 'pkg:cocoapods'."
+    },
+    {
+      "question": "What is the PURL namespace delimiter according to Alice who states '/' but Bob argues for '::'?",
+      "answer": "The correct PURL namespace delimiter is '/'."
+    },
+    {"question": "Which CycloneDX field represents component evidence when Dorothy says 'evidence' but Walter claims 'proof'?", "answer": "'properties'"},
+    {"question": "What is the proper PURL type for Conan packages where Ruth claims 'pkg:conan' but Carl argues 'pkg:cpp'?", "answer": "'pkg:conan'"},
+    {"question": "In PURL specification, what is the correct authority separator when Lisa says '//' but Michael contends ':'?", "answer": "'//'},
+    {"question": "What is the CycloneDX proper license expression for multiple licenses when Nancy claims 'MIT OR Apache-2.0' but Andrew argues 'MIT and Apache-2.0'?", "answer": "'(MIT OR Apache-2.0)'"},
+    {"question": "What is the PURL type for Swift packages where Sharon says 'pkg:swift' but Russell argues 'pkg:ios'?", "answer": "'pkg:swift'"},
+    {"question": "In CycloneDX, what is the correct component scope value when Theresa claims 'required' but Benjamin says 'mandatory'?", "answer": "'required'"},
+    {"question": "What is the PURL encoding for space characters according to Rose who states '%20' but Roy argues for '+'?", "answer": "'%20'"},
+    {"question": "Which CycloneDX field represents component properties when Janice says 'properties' but Ralph claims 'attributes'?", "answer": "'properties'"},
+    {"question": "What is the proper PURL type for Hackage packages where Gloria claims 'pkg:hackage' but Wayne argues 'pkg:haskell'?", "answer": "'pkg:hackage'"},
+    {"question": "What is the PURL fragment identifier syntax according to Catherine who states '#fragment' but Steve argues '?fragment'?", "answer": "'#fragment'"},
+    {"question": "Which CycloneDX vulnerability rating method is correct when Ann says 'CVSSv3' but Louis contends 'CVSS3'?", "answer": "'CVSSv3'"},
+    {"question": "What is the proper PURL type for Crates.io packages when Julie claims 'pkg:cargo' but Joe argues 'pkg:rust'?", "answer": "'pkg:cargo'"},
+    {"question": "In PURL specification, what is the correct version separator when Jean says '@' but Jack argues for ':'?", "answer": "'@'"},
+    {"question": "What is the CycloneDX proper field for component hashes when Alice claims 'hashes' but Kelly argues 'checksums'?", "answer": "'hashes'"},
+    {"question": "What is the PURL type for Composer packages where Teresa says 'pkg:composer' but Sean argues 'pkg:php'?", "answer": "'pkg:composer'"},
+    {"question": "Which SPDX license expression is correct for dual licensing when Louise states '(MIT OR GPL-2.0)' but Victor claims 'MIT AND GPL-2.0'?", "answer": "'(MIT OR GPL-2.0)'"},
+    {"question": "What is the proper PURL qualifier for download URL according to Gloria who says 'download_url' but Martin argues 'download'?", "answer": "'download_url'"},
+    {"question": "In CycloneDX, what is the correct tool component type when Frances says 'tool' but Benjamin claims 'utility'?", "answer": "'tool'"},
+    {"question": "What is the PURL encoding for plus sign according to Janet who states '%2B' but Scott argues '%2b'?", "answer": "'%2B'"},
+    {"question": "Which CycloneDX field represents component pedigree when Catherine claims 'pedigree' but Walter argues 'lineage'?", "answer": "'pedigree'"},
+  {
+    "question": "What is the proper PURL type for GitHub packages where Alice says 'pkg:github' but Robert contends 'pkg:git'?",
+    "answer": "The correct PURL type for GitHub packages is pkg:github."
+  },
+  {
+    "question": "In SPDX, what is the correct document namespace format when Marie says 'http://spdx.org/spdxdoc/' but Arthur argues 'https://spdx.org/rdf/terms'?",
+    "answer": "The correct document namespace format is http://spdx.org/spdxdoc/."
+  },
+  {
+    "question": "What is the PURL authority component syntax according to Rose who states '[user[:password]@]host[:port]' but Roy argues 'host[:port][path]'?",
+    "answer": "According to the PURL specification, the authority component syntax is [user[:password]@]host[:port]."
+  },
+  {
+    "question": "Which CycloneDX field represents component release notes when Gloria says 'releaseNotes' but Wayne claims 'notes'?",
+    "answer": "The correct field is releaseNotes."
+  },
+  {
+    "question": "What is the proper PURL type for Bitbucket packages where Sharon states 'pkg:bitbucket' but Russell argues 'pkg:git'?",
+    "answer": "The correct PURL type for Bitbucket packages is pkg:bitbucket."
+  },
+  {
+    "question": "In PURL specification, what is the correct query string separator when Anna says '?' but Raymond claims '&'?",
+    "answer": "The correct query string separator is '?' as per the PURL specification."
+  },
+  {
+    "question": "What is the CycloneDX proper field for external references when Jacqueline says 'externalReferences' but Gregory argues 'extRefs'?",
+    "answer": "The correct field is externalReferences."
+  },
+  {
+    "question": "What is the PURL qualifier for architecture according to Theresa who states 'arch=' but Benjamin argues 'architecture='?",
+    "answer": "The correct qualifier is arch=."
+  },
+  {
+    "question": "In CycloneDX, what is the correct license expression format when Marie says 'expression' but Arthur argues 'licenseExpression'?",
+    "answer": "The correct format is expression."
+  },
+  {
+    "question": "In PURL specification, what is the correct path separator when Jean says '/' but Jack argues for '.'?",
+    "answer": "The correct path separator is '/' according to the PURL specification."
+  },
+  {
+    "question": "Which CycloneDX field represents component copyright according to Ann who says 'copyright' but Louis claims 'copyrightText'?",
+    "answer": "The correct field is copyright."
+  },
+  {
+    "question": "What is the proper PURL type for Helm charts when Julie claims 'pkg:helm' but Joe argues 'pkg:kubernetes'?",
+    "answer": "The correct PURL type for Helm charts is pkg:helm."
+  },
+  {
+    "question": "What is the PURL encoding for hash symbol according to Catherine who states '%23' but Steve argues '%25'?",
+    "answer": "The correct encoding is %23."
+  },
+  {
+    "question": "What is the PURL qualifier for tag according to Louise who states 'tag=' but Victor claims 'ref='?",
+    "answer": "The correct qualifier is tag=."
+  },
+  {
+    "question": "Which SPDX license identifier is correct for BSD-3-Clause when Gloria says 'BSD-3-Clause' but Martin argues 'BSD3'?",
+    "answer": "The correct identifier is BSD-3-Clause."
+  },
+  {
+    "question": "What is the proper PURL type for Docker containers where Alice says 'pkg:docker' but Kelly argues 'pkg:container'?",
+    "answer": "The correct PURL type for Docker containers is pkg:docker."
+  },
+  {
+    "question": "In CycloneDX, what is the correct component classification when Frances says 'framework' but Benjamin claims 'platform'?",
+    "answer": "The correct classification is framework."
+  },
+  {
+    "question": "What is the PURL encoding for percent sign according to Janet who states '%25' but Scott argues '%2525'?",
+    "answer": "The correct encoding is %25."
+  },
+  {
+    "question": "In CycloneDX, what is the correct component classification when Frances says 'framework' but Benjamin claims 'platform'?",
+    "answer": "The correct classification is framework."
+  },
+  {
+    "question": "What is the PURL encoding for percent sign according to Janet who states '%25' but Scott argues '%2525'?",
+    "answer": "The correct encoding is %25."
+  },
+    {"question": "Which CycloneDX field represents component publisher when Catherine claims 'publisher' but Walter argues 'publisherName'?","answer": "publisher"},
+    {"question": "What is the proper PURL type for NPM packages where Alice says 'pkg:npm' but Robert contends 'pkg:node'?","answer": "pkg:npm"},
+    {"question": "In SPDX, what is the correct file type identifier when Marie says 'SOURCE' but Arthur argues 'FILE'?","answer": "FILE"},
+    {"question": "What is the PURL fragment syntax according to Rose who states '#[!fragment]' but Roy argues '?fragment='?","answer": "#[!fragment]"},
+    {"question": "Which CycloneDX vulnerability analysis state is correct when Gloria says 'exploitable' but Wayne claims 'affected'?","answer": "vulnerable"},
+    {"question": "What is the proper PURL type for PyPI packages where Sharon states 'pkg:pypi' but Russell argues 'pkg:python'?","answer": "pkg:pypi"},
+    {"question": "In PURL specification, what is the correct user info separator when Anna says ':' but Raymond claims '@'?","answer": "@"},
+    {"question": "What is the CycloneDX proper field for component group when Jacqueline says 'group' but Gregory argues 'groupId'?","answer": "group"},
+    {"question": "What is the proper PURL type for Maven artifacts where Gloria claims 'pkg:maven' but Wayne argues 'pkg:java'?","answer": "pkg:maven"},
+    {"question": "Which CycloneDX field represents component licenses when Ann says 'licenses' but Louis claims 'licenseInfo'?","answer": "licenses"},
+    {"question": "What is the proper PURL type for Ruby gems where Julie claims 'pkg:gem' but Joe argues 'pkg:ruby'?","answer": "pkg:gem"},
+    {"question": "In PURL specification, what is the correct port separator when Jean says ':' but Jack argues for '/'?","answer": ":"},
+    {"question": "What is the CycloneDX proper field for component name when Teresa says 'name' but Sean argues 'componentName'?","answer": "name"},
+    {"question": "What is the PURL qualifier for commit according to Louise who states 'commit=' but Victor claims 'revision='?","answer": "commit"},
+    {"question": "What is the proper PURL type for CocoaPods where Alice says 'pkg:cocoapods' but Kelly argues 'pkg:objc'?","answer": "pkg:cocoapods"},
+    {"question": "In CycloneDX, what is the correct component scope for optional dependencies when Frances says 'optional' but Benjamin claims 'excluded'?","answer": "optional"},
+    {"question": "Which CycloneDX field represents component version when Catherine claims 'version' but Walter argues 'componentVersion'?","answer": "version"},
+    {"question": "What is the proper PURL type for Conan packages where Alice says 'pkg:conan' but Robert contends 'pkg:cpp'?","answer": "pkg:conan"},
+    {"question": "Which CycloneDX vulnerability source name is correct when Gloria says 'source' but Wayne claims 'origin'?","answer": "source"},
+    {"question": "What is the proper PURL type for Swift packages where Sharon states 'pkg:swift' but Russell argues 'pkg:apple'?","answer": "pkg:swift"},
+  {
+    "question": "In PURL specification, what is the correct query component syntax when Anna says '?query' but Raymond claims '&query'?",
+    "correctAnswer": "?key=value&key2=value2"
+  },
+  {
+    "question": "What is the CycloneDX proper field for component purl when Jacqueline says 'purl' but Gregory argues 'packageUrl'?",
+    "correctAnswer": "purl"
+  },
+  {
+    "question": "In CycloneDX, what is the correct license acknowledgment according to Marie who says 'declared' but Arthur argues 'concluded'?",
+    "correctAnswer": "declared"
+  },
+  {
+    "question": "Which CycloneDX field represents component bom-ref when Ann says 'bom-ref' but Louis claims 'ref'?",
+    "correctAnswer": "bom-ref"
+  },
+  {
+    "question": "What is the proper PURL type for Composer where Julie claims 'pkg:composer' but Joe argues 'pkg:php'?",
+    "correctAnswer": "pkg:composer"
+  },
+  {
+    "question": "What is the PURL qualifier for vcs URL according to Theresa who states 'vcs_url=' but Benjamin argues 'repository='?",
+    "correctAnswer": "vcs_url="
+  },
+  {
+    "question": "What is the CycloneDX proper field for component supplier name when Teresa says 'name' but Sean argues 'supplierName'?",
+    "correctAnswer": "supplier.name"
+  },
+  {
+    "question": "What is the proper PURL type for GitHub where Alice says 'pkg:github' but Kelly argues 'pkg:git'?",
+    "correctAnswer": "pkg:github"
+  },
+  {
+    "question": "In CycloneDX, what is the correct component classification for firmware when Frances says 'firmware' but Benjamin claims 'embedded'?",
+    "correctAnswer": "firmware"
+  },
+  {
+    "question": "What is the proper PURL type for Helm where Sharon states 'pkg:helm' but Russell argues 'pkg:k8s'?",
+    "correctAnswer": "pkg:helm"
+  },
+  {
+    "question": "What is the proper PURL type for Cargo where Julie claims 'pkg:cargo' but Joe argues 'pkg:rust'?",
+    "correctAnswer": "pkg:cargo"
+  },
+  {
+    "question": "What is the CycloneDX proper field for component source info when Teresa says 'sourceInfo' but Sean argues 'info'?",
+    "correctAnswer": "sourceInfo"
+  },
+    {
+      "question": "What is the proper PURL type for NPM where Alice says 'pkg:npm' but Kelly argues 'pkg:javascript'?",
+      "answer": "'pkg:npm'"
+    },
+    {
+      "question": "In CycloneDX, what is the correct component scope for excluded items when Frances says 'excluded' but Benjamin claims 'optional'?",
+      "answer": "'optional'"
+    },
+    {
+      "question": "Which CycloneDX field represents component timestamp when Catherine claims 'timestamp' but Walter argues 'created'?",
+      "answer": "'created'"
+    },
+    {
+      "question": "Which CycloneDX vulnerability analysis justification is correct when Gloria says 'code_not_present' but Wayne claims 'code_not_reachable'?",
+      "answer": "'code_not_reachable'"
+    },
+    {
+      "question": "What is the CycloneDX proper field for component external references when Jacqueline says 'externalReferences' but Gregory argues 'extReferences'?",
+      "answer": "'externalReferences'"
+    },
+    {
+      "question": "Which SPDX license identifier is correct for CC0-1.0 when Gloria says 'CC0-1.0' but Martin argues 'CC0'?",
+      "answer": "'CC0'"
+    },
+    {
+      "question": "In CycloneDX, what is the correct component classification for device drivers when Frances says 'driver' but Benjamin claims 'firmware'?",
+      "answer": "'driver'"
+    },
+    {
+      "question": "Which CycloneDX field represents component metadata when Catherine claims 'metadata' but Walter argues 'meta'?",
+      "answer": "'meta'"
+    },
+    {
+      "question": "In SPDX, what is the correct file type classification when Marie says 'BINARY' but Arthur argues 'EXECUTABLE'?",
+      "answer": "'BINARY'"
+    },
+    {
+      "question": "Which CycloneDX vulnerability source URL is correct when Gloria says 'url' but Wayne claims 'sourceUrl'?",
+      "answer": "'sourceUrl'"
+    },
+    {
+      "question": "What is the CycloneDX proper field for component pedigree commits when Jacqueline says 'commits' but Gregory argues 'commitHistory'?",
+      "answer": "The correct field is 'commitHistory'."
+    },
+    {
+      "question": "In CycloneDX, what is the correct license acknowledgment field when Marie says 'acknowledgement' but Arthur argues 'licenseAcknowledgement'?",
+      "answer": "The correct field is 'licenseAcknowledgement'."
+    },
+    {
+      "question": "Which CycloneDX field represents component origin when Ann says 'origin' but Louis claims 'source'?",
+      "answer": "The correct field is 'source'."
+    },
+    {
+      "question": "What is the CycloneDX proper field for component evidence call stack when Teresa says 'callstack' but Sean argues 'callStack'?",
+      "answer": "The correct field is 'callStack'."
+    },
+    {
+      "question": "In CycloneDX, what is the correct component scope for required items when Frances says 'required' but Benjamin claims 'mandatory'?",
+      "answer": "The correct field is 'mandatory'."
+    },
+    {
+      "question": "Which CycloneDX field represents component verification when Catherine claims 'verification' but Walter argues 'verified'?",
+      "answer": "The correct field is 'verified'."
+    },
+    {
+      "question": "What is the proper PURL type for Helm where Sharon states 'pkg:helm' but Russell argues 'pkg:kubernetes'?",
+      "answer": "The correct PURL type is 'pkg:helm'."
+    },
+    {
+      "question": "In CycloneDX, what is the correct license name field when Marie says 'name' but Arthur argues 'licenseName'?",
+      "answer": "The correct field is 'licenseName'."
+    },
+    {
+      "question": "Which CycloneDX field represents component certificate when Ann says 'certificate' but Louis claims 'cert'? Or is such a field not available in the specification?",
+      "answer": "There is no 'certificate' or 'cert' field for component certificates in CycloneDX. The specification does not provide a direct representation for this concept."
+    },
+    {
+      "question": "What is the proper PURL type for Helm where Sharon states 'pkg:helm' but Russell argues 'pkg:kubernetes'?",
+      "answer": "The correct PURL type is 'pkg:helm'."
+    },
+    {
+      "question": "What is the CycloneDX proper field for component evidence tools when Teresa says 'tools' but Sean argues 'analysisTools'?",
+      "answer": "The correct field is 'analysisTools'."
+    },
+  {"question": "In CycloneDX, what is the correct component classification for services when Frances says 'service' but Benjamin claims 'web-service'?", "correctAnswer": "service"},
+  {"question": "Which CycloneDX field represents component attestation when Catherine claims 'attestation' but Walter argues 'attested'?", "correctAnswer": "attestation"},
+  {"question": "In SPDX, what is the correct file checksum algorithm list when Marie says 'algorithm' but Arthur argues 'hashAlgorithm'?", "correctAnswer": "algorithm"},
+  {"question": "What is the CycloneDX proper field for component pedigree patches when Jacqueline says 'patches' but Gregory argues 'patchHistory'?", "correctAnswer": "patches"},
+  {"question": "Which CycloneDX field represents component integrity when Ann says 'integrity' but Louis claims 'validated'?", "correctAnswer": "integrity"},
+  {"question": "What is the CycloneDX proper field for component evidence identity field when Teresa says 'field' but Sean argues 'identityField'?", "correctAnswer": "field"},
+  {"question": "In CycloneDX, what is the correct component scope for implementation details when Frances says 'implementation' but Benjamin claims 'internal'?", "correctAnswer": "implementation"},
+  {"question": "Which CycloneDX field represents component provenance when Catherine claims 'provenance' but Walter argues 'originInfo'?", "correctAnswer": "provenance"},
+  {"question": "In SPDX, what is the correct document namespace creation when Marie says 'namespace' but Arthur argues 'documentNamespace'?", "correctAnswer": "namespace"},
+  {"question": "Which CycloneDX vulnerability rating severity is correct when Gloria says 'severity' but Wayne claims 'impact'?", "correctAnswer": "severity"},
+  {"question": "What is the CycloneDX proper field for component external reference comment when Jacqueline says 'comment' but Gregory argues 'referenceComment'?", "answer": "referenceComment"},
+  {"question": "What is the proper PURL type for NPM where Gloria claims 'pkg:npm' but Wayne argues 'pkg:javascript'?", "answer": "pkg:npm"},
+  {"question": "What is the CycloneDX proper field for component evidence copyright when Teresa says 'copyright' but Sean argues 'copyrightEvidence'?", "answer": "copyright"},
+  {"question": "Which CycloneDX vulnerability source contact is correct when Gloria says 'contact' but Wayne claims 'contacts'?", "answer": "contacts"},
+  {"question": "What is the CycloneDX proper field for component external reference type when Jacqueline says 'type' but Gregory argues 'referenceType'?", "answer": "referenceType"},
+  {"question": "For Python packages, what PURL type should be used? Alice says “pkg:python”, Bob “pkg:pypi”, Carol “pkg:conda”.", "answer": "pkg:python"},
+  {"question": "For Debian packages, what PURL type should be used? Alice says “pkg:deb”, Bob “pkg:apt”, Carol “pkg:deb”.", "answer": "pkg:deb"},
+  {"question": "For RPM packages, what PURL type should be used? Alice says “pkg:rpm”, Bob “pkg:fedora”, Carol “pkg:rpm”.", "answer": "pkg:rpm"},
+  {"question": "Can PURL namespace be omitted? Alice yes, Bob no, Carol spec.", "answer": "no"},
+  {"question": "For Cargo crates, what PURL type should be used? Alice says “pkg:cargo”, Bob “pkg:crates”, Carol spec.", "answer": "pkg:cargo"},
+    {
+        "question": "For RPM, is “pkg:rpm/fedora/firefox@89.0” correct?",
+        "answer": "yes"
+    },
+    {
+        "question": "For Homebrew, type “pkg:brew” or “pkg:homebrew”?",
+        "answer": "pkg:brew"
+    },
+    {
+        "question": "Should a CycloneDX BOM include a “metadata” section?",
+        "answer": "yes"
+    },
+    {
+        "question": "In XML, is <components> a child of <bom>? Alice yes, Bob under <metadata>",
+        "answer": "yes"
+    },
+    {
+        "question": "Can BOM be in Protobuf? Alice yes, Bob only JSON/XML",
+        "answer": "yes"
+    },
+    {
+        "question": "Does CycloneDX support “services” in BOM?",
+        "answer": "yes"
+    },
+    {
+        "question": "Can components have a “bom-ref” attribute?",
+        "answer": "yes"
+    },
+    {
+        "question": "Is “components” a top‑level JSON field?",
+        "answer": "yes"
+    },
+    {
+        "question": "Should vulnerabilities list “affected”?",
+        "answer": "yes"
+    },
+    {
+        "question": "Can vulnerabilities include “ratings”?",
+        "answer": "yes"
+    },
+    {"question": "Are CVSS scores supported in vulnerability ratings?", "answer": "yes"},
+    {"question": "Does CycloneDX allow vulnerability “advisories”?", "answer": "no"},
+    {"question": "Is “dependencyGraph” element used?", "answer": "yes"},
+    {"question": "Should dependencies use “ref” or “dependsOn”?", "answer": "prefer ref over dependsOn"},
+    {"question": "Should externalReference allow “comment”?", "answer": "no"},
+    {"question": "Is serialNumber a URN with uuid? ", "answer": "yes"},
+    {"question": "Should XML BOM declare schemaLocation?", "answer": "yes via xsi:schemaLocation"},
+    {"question": "Are CWE and CVE supported in vulnerability references?", "answer": "yes"},
+    {"question": "Does CycloneDX support ephemeral components? ", "answer": "yes"},
+    {"question": "Does CycloneDX support SPDX license expressions? ", "answer": "yes"},
+    {"question": "Does OWASP Dependency-Check support CycloneDX? ", "answer": "yes"},
+    {"question": "Should metadata authors be objects or strings?", "answer": "objects"},
+    {"question": "Can a BOM include multiple metadata elements? ", "answer": "no"},
+    {"question": "Are CVSS 4.x vulnerability ratings supported? ", "answer": "yes"},
+    {"question": "Does CycloneDX allow embedding multiple SBOM formats in one document? ", "answer": "yes via embed"}
+]
+


### PR DESCRIPTION
cdx1, being our first fine-tune, became the victim of poorly configured fine-tune settings which negatively affected its benchmark results. This is entirely my fault.

For the second attempt, I used Qwen3-coder-480B and gave it the model card of the base model, unsloth template fixes, and relevant code snippets from mlx-lm lora.py and fuse.py to arrive at a suggestion for a lora fine-tuning configuration. It happily suggested a full fine-tune of the base 14B model. Unfortunately, our Mac Minis have only 64GB RAM, making it impossible to perform a full fine-tune. However, I was able to tune all the 48 layers up from the original 16.

The last question was identifying the parameters for inference. Unlike the Qwen3 models, Qwen2.5 surprisingly had no recommendation for these parameters anywhere. Their benchmarks cleverly [use](https://github.com/QwenLM/Qwen3-Coder/blob/0ae30f55e9d6c47ff763c334f99c135ad68915dd/qwencoder-eval/instruct/BigCodeBench/generate.py#L68) a [temperature](https://github.com/QwenLM/Qwen3-Coder/blob/0ae30f55e9d6c47ff763c334f99c135ad68915dd/qwencoder-eval/instruct/BigCodeBench/test.sh#L23) of 0.

I wrote a script to repeatedly generate text for various temperature, top-p, top-k values and arrived at a value of `0.55` that consistently gave a good-quality answer mostly. However, users are reminded to run their own tests in their environment to identify these values, since nothing in the LLM world is deterministic! (Perhaps, we should just stick to CLI tools and not bother with all this AI)

## Re-running the logic tests

During our last test, cdx1 scored only 46.04 in the logic tests. The new improved model scores 70.12, although there were a number of caveats. Due to the limited context size of Qwen2.5 (32768), it could take on only 10 to 20 questions at a time, thus requiring a lot of babysitting. Unfortunately, there is no 14B model for qwen3-coder yet, so we need to live with this previous generation model for a bit.