### PR TITLE
fix: dont log mvn dependency:tree args

### DIFF
--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -1775,9 +1775,7 @@ export async function createJavaBom(path, options) {
           `**MAVEN**: Let's use Maven to collect packages from ${basePath}.`,
         );
         if (DEBUG_MODE) {
-          console.log(
-            `Executing 'mvn ${mvnTreeArgs.join(" ")}' in ${basePath}`,
-          );
+          console.log(`Executing 'mvn dependency:tree ...' in ${basePath}`);
         }
         // Prefer the built-in maven
         result = safeSpawnSync(


### PR DESCRIPTION
this debug log statement could disclose sensitive arguments passed via `MVN_ARGS`.  simplifying the log statement