### PR TITLE
Make parseNuspecData have a consistent return type

### DIFF
--- a/lib/helpers/utils.js
+++ b/lib/helpers/utils.js
@@ -9957,7 +9957,10 @@ export function parseNuspecData(nupkgFile, nuspecData) {
     }
   }
   if (!npkg) {
-    return pkgList;
+    return {
+      pkgList,
+      dependenciesMap,
+    };
   }
   const m = npkg.metadata;
   pkg.name = m.id._;


### PR DESCRIPTION
Make `parseNuspecData` have a consistent return type