### PR TITLE
Add missing `retMap?.pkgList?.length` guard

### DIFF
--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -6679,7 +6679,7 @@ export async function createCsharpBom(path, options) {
         console.log(`Parsing ${nf}`);
       }
       const retMap = await parseNupkg(nf);
-      if (retMap?.pkgList.length) {
+      if (retMap?.pkgList?.length) {
         pkgList = pkgList.concat(retMap.pkgList);
         for (const d of retMap.pkgList) {
           parentDependsOn.add(d["bom-ref"]);


### PR DESCRIPTION
Add missing `retMap?.pkgList?.length` guard. Without this sometimes cdxgen will fail with:
```js
if (retMap?.pkgList.length) {
                         ^

TypeError: Cannot read properties of undefined (reading 'length')
    at createCsharpBom 
 ```