### PR TITLE
Fix validate-iri hanging on malformed percent-encoding

### DIFF
--- a/lib/helpers/utils.js
+++ b/lib/helpers/utils.js
@@ -11143,7 +11143,15 @@ export function parseComposerLock(pkgLockFile, rootRequires) {
             },
           };
           if (pkg?.dist?.url) {
-            apkg.distribution = { url: pkg.dist.url };
+            // Replace placeholders like %prettyVersion% with actual version
+            let distUrl = pkg.dist.url;
+            if (distUrl.includes('%prettyVersion%') || distUrl.includes('%version%')) {
+              const version = pkg.version || 'unknown';
+              distUrl = distUrl
+                .replace(/%prettyVersion%/g, version)
+                .replace(/%version%/g, version);
+            }
+            apkg.distribution = { url: distUrl };
           }
           if (pkg?.authors?.length) {
             apkg.authors = pkg.authors.map((a) => {
@@ -16163,6 +16171,12 @@ export function isValidIriReference(iri) {
   let iriIsValid = true;
   // See issue #1264
   if (iri && /[${}]/.test(iri)) {
+    return false;
+  }
+  // Check for malformed percent-encoding sequences
+  // Valid: %20, %2F, etc. Invalid: %p, %prettyVersion%, lone %, etc.
+  // This prevents validate-iri from hanging on malformed URLs
+  if (iri && /%(?![0-9A-Fa-f]{2})/.test(iri)) {
     return false;
   }
   const validateIriResult = validateIri(iri, IriValidationStrategy.Strict);

--- a/lib/helpers/utils.js
+++ b/lib/helpers/utils.js
@@ -11145,8 +11145,11 @@ export function parseComposerLock(pkgLockFile, rootRequires) {
           if (pkg?.dist?.url) {
             // Replace placeholders like %prettyVersion% with actual version
             let distUrl = pkg.dist.url;
-            if (distUrl.includes('%prettyVersion%') || distUrl.includes('%version%')) {
-              const version = pkg.version || 'unknown';
+            if (
+              distUrl.includes("%prettyVersion%") ||
+              distUrl.includes("%version%")
+            ) {
+              const version = pkg.version || "unknown";
               distUrl = distUrl
                 .replace(/%prettyVersion%/g, version)
                 .replace(/%version%/g, version);


### PR DESCRIPTION
Changelog:
- Add check for malformed percent-encoding sequences before calling validate-iri
- Replace %prettyVersion% placeholders with actual versions in composer.lock
- Prevents cdxgen from hanging when processing BookStack and similar PHP projects

The validate-iri library hangs indefinitely on URLs with invalid percent-encoding like %prettyVersion% where %pr is not a valid hex sequence. This fix detects such malformed sequences early and also replaces known placeholders with actual version strings.

Fixes issue with packages from Codeberg that use URL placeholders.
See issue #2174 