### PR TITLE
[build] Updated some more workflows to use Nexus when run on self-hosted runners

### DIFF
--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -18,7 +18,7 @@ on:
         type: boolean
 
 env:
-  NEXUS_URL: http://100.73.146.80:8081/repository/npm/ # IP for mini-dev-1, sometimes docker engine can't resolve names!
+  NEXUS_URL: http://pkg.cdxgen.net:8081/repository/npm/
   REPO: ghcr.io
   TAG: v11
   TEAM: cyclonedx

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -34,6 +34,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+env:
+  NEXUS_URL: http://100.73.146.80:8081/repository/npm/ # IP for mini-dev-1, sometimes docker engine can't resolve names!
+
 # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token
 permissions: {}
 
@@ -63,6 +66,8 @@ jobs:
       - name: Trim CI agent
         run: |
           rm -rf /tmp/docker-images-* /tmp/atom-usages-* /tmp/atom-reachables-*
+      - name: Setup Nexus usage
+        run: echo "registry=$NEXUS_URL" > .npmrc
       - name: pnpm install
         run: |
           corepack pnpm install --config.strict-dep-builds=true

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -35,7 +35,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  NEXUS_URL: http://100.73.146.80:8081/repository/npm/ # IP for mini-dev-1, sometimes docker engine can't resolve names!
+  NEXUS_URL: http://pkg.cdxgen.net:8081/repository/npm/
 
 # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token
 permissions: {}

--- a/.github/workflows/repotests.yml
+++ b/.github/workflows/repotests.yml
@@ -18,7 +18,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  NEXUS_URL: http://100.73.146.80:8081/repository/npm/ # IP for mini-dev-1, sometimes docker engine can't resolve names!
+  NEXUS_URL: http://pkg.cdxgen.net:8081/repository/npm/
   NODE_VERSION: 24.6.0
 
 # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token

--- a/.github/workflows/repotests.yml
+++ b/.github/workflows/repotests.yml
@@ -18,6 +18,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  NEXUS_URL: http://100.73.146.80:8081/repository/npm/ # IP for mini-dev-1, sometimes docker engine can't resolve names!
   NODE_VERSION: 24.6.0
 
 # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token
@@ -50,6 +51,8 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
+      - name: Setup Nexus usage
+        run: echo "registry=$NEXUS_URL" > .npmrc
       - name: npm install
         run: |
           corepack pnpm install --config.strict-dep-builds=true --package-import-method copy
@@ -134,6 +137,8 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
+      - name: Setup Nexus usage
+        run: echo "registry=$NEXUS_URL" > .npmrc
       - name: npm install
         run: |
           corepack pnpm install --config.strict-dep-builds=true --package-import-method copy
@@ -221,6 +226,9 @@ jobs:
       - name: Install bazelisk - windows
         if: matrix.os == 'windows-latest'
         run: choco install -y bazel
+      - name: Setup Nexus usage
+        if: matrix.os == 'self-hosted-ubuntu'
+        run: echo "registry=$NEXUS_URL" > .npmrc
       - name: npm install, build and test
         run: |
           npm install --global corepack@latest


### PR DESCRIPTION
Noticed another 2 workflows that are ran on self-hosted runners -- changed these to use the inhouse Nexus as well.

The internal network has been updated with a DNS entry for the Nexus server, so IPs have been replaced with the new DNS entry.