### PR TITLE
ci: adjust tests

### DIFF
--- a/.pokurc.jsonc
+++ b/.pokurc.jsonc
@@ -1,22 +1,7 @@
 {
   "$schema": "https://poku.io/schemas/configs.json",
-  "include": [
-    "lib/helpers/dotnetutils.poku.js",
-    "lib/helpers/protobom.poku.js",
-    "lib/helpers/utils.poku.js",
-    "lib/helpers/display.poku.js",
-    "lib/stages/postgen/postgen.poku.js",
-    "lib/evinser/evinser.poku.js",
-    "lib/evinser/swiftsem.poku.js",
-    "lib/server/server.poku.js",
-    "lib/parsers/iri.poku.js"
-  ],
-  "sequential": false,
-  "debug": false,
+  "include": ["lib"],
   "filter": ".poku.js",
-  "failFast": false,
   "concurrency": 0,
-  "quiet": false,
-  "platform": "node",
   "reporter": "verbose"
 }

--- a/.pokurc.jsonc
+++ b/.pokurc.jsonc
@@ -2,6 +2,5 @@
   "$schema": "https://poku.io/schemas/configs.json",
   "include": ["lib"],
   "filter": ".poku.js",
-  "concurrency": 0,
   "reporter": "verbose"
 }

--- a/lib/helpers/envcontext.poku.js
+++ b/lib/helpers/envcontext.poku.js
@@ -3,6 +3,7 @@ import process from "node:process";
 
 import { assert, it } from "poku";
 
+import { isWin } from "../managers/docker.js";
 import {
   collectDotnetInfo,
   collectGccInfo,
@@ -22,6 +23,8 @@ import {
   listFiles,
 } from "./envcontext.js";
 
+const isDarwin = process.platform === "darwin";
+
 it("git tests", () => {
   assert.ok(getBranch());
   assert.ok(getOriginUrl());
@@ -30,14 +33,18 @@ it("git tests", () => {
 });
 
 it("tools tests", () => {
-  assert.ok(collectJavaInfo());
   assert.ok(collectDotnetInfo());
   assert.ok(collectPythonInfo());
   assert.ok(collectNodeInfo());
   assert.ok(collectGccInfo());
   assert.ok(collectRustInfo());
-  assert.ok(collectGoInfo());
-  assert.ok(collectSwiftInfo());
+  if (!isWin) {
+    assert.ok(collectSwiftInfo());
+    assert.ok(collectJavaInfo());
+  }
+  if (!isDarwin) {
+    assert.ok(collectGoInfo());
+  }
 });
 
 it("sdkman tests", () => {
@@ -62,16 +69,16 @@ it("nvm tests", () => {
 
       // expected to be run in CircleCi, where node version is 22.8.0
       // as defined in our Dockerfile
-      assert.deepStrictEqual(getNvmToolDirectory(22), true);
-      assert.deepStrictEqual(getNvmToolDirectory(14)).toBeFalsy();
+      assert.ok(typeof getNvmToolDirectory(22) === "string");
+      assert.deepStrictEqual(getNvmToolDirectory(14), false);
 
       // now we install nvm tool for a specific verison
-      assert.deepStrictEqual(getOrInstallNvmTool(14), true);
-      assert.deepStrictEqual(getNvmToolDirectory(14), true);
+      assert.ok(getOrInstallNvmTool(14));
+      assert.ok(typeof getNvmToolDirectory(14) === "string");
     } else {
       // if this test is failing it would be due to an error in isNvmAvailable()
-      assert.deepStrictEqual(getNvmToolDirectory(22)).toBeFalsy();
-      assert.deepStrictEqual(getOrInstallNvmTool(14)).toBeFalsy();
+      assert.deepStrictEqual(getNvmToolDirectory(22), undefined);
+      assert.deepStrictEqual(getOrInstallNvmTool(14), false);
     }
   }
 });

--- a/lib/managers/docker.poku.js
+++ b/lib/managers/docker.poku.js
@@ -1,6 +1,6 @@
 import process from "node:process";
 
-import { assert, beforeEach, describe, it } from "poku";
+import { assert, beforeEach, describe, it, skip } from "poku";
 
 import {
   addSkippedSrcFiles,
@@ -12,12 +12,14 @@ import {
   removeImage,
 } from "./docker.js";
 
-it("docker connection", async () => {
-  if (!(isWin && process.env.CI === "true")) {
-    const dockerConn = await getConnection();
-    if (dockerConn) {
-      assert.ok(dockerConn);
-    }
+if (process.env.CI === "true" && (isWin || process.platform === "darwin")) {
+  skip("Skipping Docker tests on Windows and Mac");
+}
+
+await it("docker connection", async () => {
+  const dockerConn = await getConnection();
+  if (dockerConn) {
+    assert.ok(dockerConn);
   }
 });
 
@@ -123,9 +125,9 @@ it("parseImageName tests", () => {
       name: "scan-java",
     },
   );
-}, 120000);
+});
 
-it("docker getImage", async () => {
+await it("docker getImage", async () => {
   if (isWin && process.env.CI === "true") {
     return;
   }
@@ -136,15 +138,15 @@ it("docker getImage", async () => {
       assert.ok(removeData);
     }
   }
-}, 120000);
+});
 
-it("docker getImage", async () => {
+await it("docker getImage", async () => {
   if (isWin && process.env.CI === "true") {
     return;
   }
   const imageData = await exportImage("hello-world:latest");
   assert.ok(imageData);
-}, 120000);
+});
 
 describe("addSkippedSrcFiles tests", () => {
   let testComponents;
@@ -213,4 +215,4 @@ describe("addSkippedSrcFiles tests", () => {
 
     assert.deepStrictEqual(testComponents[0].properties.length, 2);
   });
-}, 120000);
+});

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "cdx-verify": "bin/verify.js"
   },
   "scripts": {
-    "test": "poku --parallel",
+    "test": "poku",
     "watch": "poku --watch",
     "lint:check": "biome check",
     "lint": "biome check --fix",


### PR DESCRIPTION
Hey! First of all, really thanks for using **Poku** (#2181) 🐷✨

I've made some small adjustments to the tests to make sure they all run properly 🙋🏻‍♂️

---

Currently, these tests are being completely ignored due to manual inclusion in _.pokurc.jsonc_:

- _lib/helpers/envcontext.poku.js_
- _lib/managers/docker.poku.js_

Instead, I just updated it to `"include": ["lib"]`, allowing dynamic searching from the `.poku.js` filter.

---

By ensuring that the two tests mentioned were performed, they were pointing out some failures for specific behaviors of **Windows** and **macOS**, for example:

- **Windows**
  - **Java** and **Swift** are not available in the CI.
- **macOS**
  - **Go** are not available in the CI
- For both **Windows** and **macOS**, **Docker** is not available in **GitHub Actions** CI.

---

Unlike other test runners for **JavaScript**, [**Poku** preserves the `async/await` behavior for tests in `describe`, `it`, and `test` methods](https://poku.io/docs/philosophy#javascript-essence-for-tests-).

---

- I also adjusted some non-existent method calls in the **nvpm** tests.
- By actually running all the tests, I noticed that unlimited concurrency was causing **Node.js** version 20 to crash on **macOS**. I just kept the default behavior that dynamically checks for the available parallelism number.

---

Please feel free to ask and review these changes in the tests 🤝

> [!NOTE]
>
> About #2176, I didn't look into it too deeply, but the `FATAL ERROR: invalid array length Allocation failed - JavaScript heap out of memory` error seems to be related to the extensive number of _symlinks_ found when the test runner is searching for tests in directories recursively (more specifically, in the `"/"` directory).