### PR TITLE
Convert metadata/component to 1.5

### DIFF
--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -659,6 +659,16 @@ function addMetadata(parentComponent = {}, options = {}, context = {}) {
         parentComponent.components = undefined;
       }
     }
+    // Convert authors to author for specVersion < 1.6
+    const parentComponentCopy = { ...parentComponent };
+
+    if (options.specVersion < 1.6 && parentComponent?.authors) {
+      parentComponentCopy.author = parentComponentCopy.authors
+        .map((a) => (a.email ? `${a.name} <${a.email}>` : a.name))
+        .join(",");
+      delete parentComponentCopy.authors;
+    }
+
     metadata.component = parentComponent;
   }
   // Have we already captured the oci properties


### PR DESCRIPTION
Fixes #2157.
Spec before 1.6 only supports `author` attribute, so it had to be converted from modern format.