### PR TITLE
Removed labels from Dockerfiles

### DIFF
--- a/.github/actions/build-docker-image/action.yml
+++ b/.github/actions/build-docker-image/action.yml
@@ -9,9 +9,6 @@ inputs:
     required: true
   labels:
     description: Labels to add to the image
-  language:
-    description: The language and version that is included in this image
-    required: true
   output:
     description: Controls what should be done with the image(s) after building
     required: true
@@ -31,10 +28,6 @@ runs:
     - name: Build Docker image
       uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
       with:
-        build-args: |
-          LANGUAGE=${{ inputs.language }}
-          TAG=${{ inputs.tags[0] }}
-          VERSION=${{ github.ref_name }}
         context: .
         file: ${{ inputs.dockerfile }}
         labels: ${{ inputs.labels }}

--- a/.github/actions/build-docker-images-generate-attach-sboms/action.yml
+++ b/.github/actions/build-docker-images-generate-attach-sboms/action.yml
@@ -39,11 +39,18 @@ runs:
       with:
         flavor: latest=${{ inputs.latest }}
         images: ${{ inputs.images }}
+        labels: |
+          org.opencontainers.image.authors=Team AppThreat <cloud@appthreat.com>
+          org.opencontainers.image.vendor=CycloneDX
+          ${{ inputs.main-tag && format('org.opencontainers.docker.cmd=docker run --rm -v /tmp:/tmp -p 9090:9090 -v $(pwd):/app:rw -t {0} -r /app --server', inputs.main-tag) || '' }}
+          ${{ inputs.main-tag && inputs.language == 'rolling' && 'org.opencontainers.image.description=Rolling image with cdxgen SBOM generator based on tumbleweed'
+           || inputs.main-tag && format('org.opencontainers.image.description=Image with cdxgen SBOM generator for {0} apps', inputs.language)
+           || ''
+          }}
     - name: Build and push image
       uses: ./.github/actions/build-docker-image
       with:
         dockerfile: ${{ inputs.dockerfile }}
-        language: ${{ inputs.language }}
         labels: ${{ steps.metadata.outputs.labels }}
         output: registry
         platforms: linux/amd64${{ inputs.build-arm == 'true' && ',linux/arm64' || '' }}
@@ -53,7 +60,6 @@ runs:
       uses: ./.github/actions/generate-attach-sbom
       with:
         dockerfile: ${{ inputs.dockerfile }}
-        language: ${{ inputs.language }}
         platform: linux/amd64
         signing-key: ${{ inputs.signing-key }}
         tag: ${{ inputs.main-tag || fromJSON(steps.metadata.outputs.json).tags[0] }}
@@ -63,7 +69,6 @@ runs:
       uses: ./.github/actions/generate-attach-sbom
       with:
         dockerfile: ${{ inputs.dockerfile }}
-        language: ${{ inputs.language }}
         platform: linux/arm64
         signing-key: ${{ inputs.signing-key }}
         tag: ${{ inputs.main-tag || fromJSON(steps.metadata.outputs.json).tags[0] }}

--- a/.github/actions/generate-attach-sbom/action.yml
+++ b/.github/actions/generate-attach-sbom/action.yml
@@ -7,9 +7,6 @@ inputs:
   dockerfile:
     description: Dockerfile that describes the image
     required: true
-  language:
-    description: The language and version that is included in this image
-    required: true
   platform:
     description: The platforms for which to build the image
     required: true
@@ -30,7 +27,6 @@ runs:
       uses: ./.github/actions/build-docker-image
       with:
         dockerfile: ${{ inputs.dockerfile }}
-        language: ${{ inputs.language }}
         output: docker,dest=${{ runner.temp }}/image.tar
         platforms: ${{ inputs.platform }}
         tags: ${{ inputs.tag }}

--- a/ci/images/Dockerfile.dotnet7
+++ b/ci/images/Dockerfile.dotnet7
@@ -49,19 +49,6 @@ CMD ["/bin/bash"]
 # cdxgen-image
 FROM base AS cdxgen
 
-ARG VERSION=master
-
-LABEL maintainer="CycloneDX" \
-      org.opencontainers.docker.cmd="docker run --rm -v /tmp:/tmp -p 9090:9090 -v $(pwd):/app:rw -t $TAG -r /app --server" \
-      org.opencontainers.image.authors="Team AppThreat <cloud@appthreat.com>" \
-      org.opencontainers.image.description="Image with cdxgen SBOM generator for $LANGUAGE apps" \
-      org.opencontainers.image.licenses="Apache-2.0" \
-      org.opencontainers.image.source="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.title="cdxgen" \
-      org.opencontainers.image.url="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.vendor="CycloneDX" \
-      org.opencontainers.image.version="$VERSION"
-
 ENV CDXGEN_IN_CONTAINER=true \
     DOSAI_CMD=/usr/local/bin/dosai \
     NODE_COMPILE_CACHE="/opt/cdxgen-node-cache" \

--- a/ci/images/Dockerfile.dotnet8
+++ b/ci/images/Dockerfile.dotnet8
@@ -50,19 +50,6 @@ CMD ["/bin/bash"]
 # cdxgen-image
 FROM base AS cdxgen
 
-ARG VERSION=master
-
-LABEL maintainer="CycloneDX" \
-      org.opencontainers.docker.cmd="docker run --rm -v /tmp:/tmp -p 9090:9090 -v $(pwd):/app:rw -t $TAG -r /app --server" \
-      org.opencontainers.image.authors="Team AppThreat <cloud@appthreat.com>" \
-      org.opencontainers.image.description="Image with cdxgen SBOM generator for $LANGUAGE apps" \
-      org.opencontainers.image.licenses="Apache-2.0" \
-      org.opencontainers.image.source="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.title="cdxgen" \
-      org.opencontainers.image.url="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.vendor="CycloneDX" \
-      org.opencontainers.image.version="$VERSION"
-
 ENV CDXGEN_IN_CONTAINER=true \
     DOSAI_CMD=/usr/local/bin/dosai \
     NODE_COMPILE_CACHE="/opt/cdxgen-node-cache" \

--- a/ci/images/Dockerfile.dotnet9
+++ b/ci/images/Dockerfile.dotnet9
@@ -50,19 +50,6 @@ CMD ["/bin/bash"]
 # cdxgen-image
 FROM base AS cdxgen
 
-ARG VERSION=master
-
-LABEL maintainer="CycloneDX" \
-      org.opencontainers.docker.cmd="docker run --rm -v /tmp:/tmp -p 9090:9090 -v $(pwd):/app:rw -t $TAG -r /app --server" \
-      org.opencontainers.image.authors="Team AppThreat <cloud@appthreat.com>" \
-      org.opencontainers.image.description="Image with cdxgen SBOM generator for $LANGUAGE apps" \
-      org.opencontainers.image.licenses="Apache-2.0" \
-      org.opencontainers.image.source="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.title="cdxgen" \
-      org.opencontainers.image.url="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.vendor="CycloneDX" \
-      org.opencontainers.image.version="$VERSION"
-
 ENV CDXGEN_IN_CONTAINER=true \
     NODE_COMPILE_CACHE="/opt/cdxgen-node-cache" \
     PATH=${PATH}:${PYTHONPATH}/bin:/opt/cdxgen/node_modules/.bin

--- a/ci/images/Dockerfile.java11
+++ b/ci/images/Dockerfile.java11
@@ -75,19 +75,6 @@ CMD ["/bin/bash"]
 # cdxgen-image
 FROM base AS cdxgen
 
-ARG VERSION=master
-
-LABEL maintainer="CycloneDX" \
-      org.opencontainers.docker.cmd="docker run --rm -v /tmp:/tmp -p 9090:9090 -v $(pwd):/app:rw -t $TAG -r /app --server" \
-      org.opencontainers.image.authors="Team AppThreat <cloud@appthreat.com>" \
-      org.opencontainers.image.description="Image with cdxgen SBOM generator for $LANGUAGE apps" \
-      org.opencontainers.image.licenses="Apache-2.0" \
-      org.opencontainers.image.source="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.title="cdxgen" \
-      org.opencontainers.image.url="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.vendor="CycloneDX" \
-      org.opencontainers.image.version="$VERSION"
-
 ENV CDXGEN_IN_CONTAINER=true \
     NODE_COMPILE_CACHE="/opt/cdxgen-node-cache" \
     PATH=${PATH}:/opt/cdxgen/node_modules/.bin

--- a/ci/images/Dockerfile.java17
+++ b/ci/images/Dockerfile.java17
@@ -85,19 +85,6 @@ CMD ["/bin/bash"]
 # cdxgen-image
 FROM base AS cdxgen
 
-ARG VERSION=master
-
-LABEL maintainer="CycloneDX" \
-      org.opencontainers.docker.cmd="docker run --rm -v /tmp:/tmp -p 9090:9090 -v $(pwd):/app:rw -t $TAG -r /app --server" \
-      org.opencontainers.image.authors="Team AppThreat <cloud@appthreat.com>" \
-      org.opencontainers.image.description="Image with cdxgen SBOM generator for $LANGUAGE apps" \
-      org.opencontainers.image.licenses="Apache-2.0" \
-      org.opencontainers.image.source="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.title="cdxgen" \
-      org.opencontainers.image.url="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.vendor="CycloneDX" \
-      org.opencontainers.image.version="$VERSION"
-
 ENV CDXGEN_IN_CONTAINER=true \
     NODE_COMPILE_CACHE="/opt/cdxgen-node-cache" \
     PATH=${PATH}:/opt/cdxgen/node_modules/.bin

--- a/ci/images/Dockerfile.java17-slim
+++ b/ci/images/Dockerfile.java17-slim
@@ -74,19 +74,6 @@ CMD ["/bin/bash"]
 # cdxgen-image
 FROM base AS cdxgen
 
-ARG VERSION=master
-
-LABEL maintainer="CycloneDX" \
-      org.opencontainers.docker.cmd="docker run --rm -v /tmp:/tmp -p 9090:9090 -v $(pwd):/app:rw -t $TAG -r /app --server" \
-      org.opencontainers.image.authors="Team AppThreat <cloud@appthreat.com>" \
-      org.opencontainers.image.description="Image with cdxgen SBOM generator for $LANGUAGE apps" \
-      org.opencontainers.image.licenses="Apache-2.0" \
-      org.opencontainers.image.source="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.title="cdxgen" \
-      org.opencontainers.image.url="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.vendor="CycloneDX" \
-      org.opencontainers.image.version="$VERSION"
-
 ENV CDXGEN_IN_CONTAINER=true \
     NODE_COMPILE_CACHE="/opt/cdxgen-node-cache" \
     PATH=${PATH}:/opt/cdxgen/node_modules/.bin

--- a/ci/images/Dockerfile.node20
+++ b/ci/images/Dockerfile.node20
@@ -80,19 +80,6 @@ CMD ["/bin/bash"]
 # cdxgen-image
 FROM base AS cdxgen
 
-ARG VERSION=master
-
-LABEL maintainer="CycloneDX" \
-      org.opencontainers.docker.cmd="docker run --rm -v /tmp:/tmp -p 9090:9090 -v $(pwd):/app:rw -t $TAG -r /app --server" \
-      org.opencontainers.image.authors="Team AppThreat <cloud@appthreat.com>" \
-      org.opencontainers.image.description="Image with cdxgen SBOM generator for $LANGUAGE apps" \
-      org.opencontainers.image.licenses="Apache-2.0" \
-      org.opencontainers.image.source="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.title="cdxgen" \
-      org.opencontainers.image.url="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.vendor="CycloneDX" \
-      org.opencontainers.image.version="$VERSION"
-
 ENV ATOM_CMD=/usr/local/bin/atom \
     CDXGEN_IN_CONTAINER=true \
     NODE_COMPILE_CACHE="/opt/cdxgen-node-cache" \

--- a/ci/images/Dockerfile.python311
+++ b/ci/images/Dockerfile.python311
@@ -107,19 +107,6 @@ CMD ["/bin/bash"]
 # cdxgen-image
 FROM base AS cdxgen
 
-ARG VERSION=master
-
-LABEL maintainer="CycloneDX" \
-      org.opencontainers.docker.cmd="docker run --rm -v /tmp:/tmp -p 9090:9090 -v $(pwd):/app:rw -t $TAG -r /app --server" \
-      org.opencontainers.image.authors="Team AppThreat <cloud@appthreat.com>" \
-      org.opencontainers.image.description="Image with cdxgen SBOM generator for $LANGUAGE apps" \
-      org.opencontainers.image.licenses="Apache-2.0" \
-      org.opencontainers.image.source="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.title="cdxgen" \
-      org.opencontainers.image.url="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.vendor="CycloneDX" \
-      org.opencontainers.image.version="$VERSION"
-
 ENV CDXGEN_IN_CONTAINER=true \
     CRYPTOGRAPHY_DONT_BUILD_RUST=1 \
     LANG=en_US.UTF-8 \

--- a/ci/images/Dockerfile.python312
+++ b/ci/images/Dockerfile.python312
@@ -100,19 +100,6 @@ CMD ["/bin/bash"]
 # cdxgen-image
 FROM base AS cdxgen
 
-ARG VERSION=master
-
-LABEL maintainer="CycloneDX" \
-      org.opencontainers.docker.cmd="docker run --rm -v /tmp:/tmp -p 9090:9090 -v $(pwd):/app:rw -t $TAG -r /app --server" \
-      org.opencontainers.image.authors="Team AppThreat <cloud@appthreat.com>" \
-      org.opencontainers.image.description="Image with cdxgen SBOM generator for $LANGUAGE apps" \
-      org.opencontainers.image.licenses="Apache-2.0" \
-      org.opencontainers.image.source="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.title="cdxgen" \
-      org.opencontainers.image.url="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.vendor="CycloneDX" \
-      org.opencontainers.image.version="$VERSION"
-
 ENV CDXGEN_IN_CONTAINER=true \
     LANG=en_US.UTF-8 \
     LANGUAGE=en_US.UTF-8 \

--- a/ci/images/Dockerfile.python313
+++ b/ci/images/Dockerfile.python313
@@ -92,19 +92,6 @@ CMD ["/bin/bash"]
 # cdxgen-image
 FROM base AS cdxgen
 
-ARG VERSION=master
-
-LABEL maintainer="CycloneDX" \
-      org.opencontainers.docker.cmd="docker run --rm -v /tmp:/tmp -p 9090:9090 -v $(pwd):/app:rw -t $TAG -r /app --server" \
-      org.opencontainers.image.authors="Team AppThreat <cloud@appthreat.com>" \
-      org.opencontainers.image.description="Image with cdxgen SBOM generator for $LANGUAGE apps" \
-      org.opencontainers.image.licenses="Apache-2.0" \
-      org.opencontainers.image.source="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.title="cdxgen" \
-      org.opencontainers.image.url="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.vendor="CycloneDX" \
-      org.opencontainers.image.version="$VERSION"
-
 ENV CDXGEN_IN_CONTAINER=true \
     CRYPTOGRAPHY_DONT_BUILD_RUST=1 \
     LANG=en_US.UTF-8 \

--- a/ci/images/Dockerfile.python36
+++ b/ci/images/Dockerfile.python36
@@ -97,19 +97,6 @@ CMD ["/bin/bash"]
 # cdxgen-image
 FROM base AS cdxgen
 
-ARG VERSION=master
-
-LABEL maintainer="CycloneDX" \
-      org.opencontainers.docker.cmd="docker run --rm -v /tmp:/tmp -p 9090:9090 -v $(pwd):/app:rw -t $TAG -r /app --server" \
-      org.opencontainers.image.authors="Team AppThreat <cloud@appthreat.com>" \
-      org.opencontainers.image.description="Image with cdxgen SBOM generator for $LANGUAGE apps" \
-      org.opencontainers.image.licenses="Apache-2.0" \
-      org.opencontainers.image.source="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.title="cdxgen" \
-      org.opencontainers.image.url="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.vendor="CycloneDX" \
-      org.opencontainers.image.version="$VERSION"
-
 ENV CDXGEN_IN_CONTAINER=true \
     CRYPTOGRAPHY_DONT_BUILD_RUST=1 \
     LANG=en_US.UTF-8 \

--- a/ci/images/Dockerfile.ruby25
+++ b/ci/images/Dockerfile.ruby25
@@ -74,19 +74,6 @@ CMD ["/bin/bash"]
 # cdxgen-image
 FROM base AS cdxgen
 
-ARG VERSION=master
-
-LABEL maintainer="CycloneDX" \
-      org.opencontainers.docker.cmd="docker run --rm -v /tmp:/tmp -p 9090:9090 -v $(pwd):/app:rw -t $TAG -r /app --server" \
-      org.opencontainers.image.authors="Team AppThreat <cloud@appthreat.com>" \
-      org.opencontainers.image.description="Image with cdxgen SBOM generator for $LANGUAGE apps" \
-      org.opencontainers.image.licenses="Apache-2.0" \
-      org.opencontainers.image.source="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.title="cdxgen" \
-      org.opencontainers.image.url="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.vendor="CycloneDX" \
-      org.opencontainers.image.version="$VERSION"
-
 ENV CDXGEN_GEM_HOME="/tmp/gems" \
     CDXGEN_IN_CONTAINER=true \
     NODE_COMPILE_CACHE="/opt/cdxgen-node-cache" \

--- a/ci/images/alpine/Dockerfile.dotnet9
+++ b/ci/images/alpine/Dockerfile.dotnet9
@@ -18,19 +18,6 @@ RUN set -e; \
 # cdxgen-image
 FROM base AS cdxgen
 
-ARG VERSION=master
-
-LABEL maintainer="CycloneDX" \
-      org.opencontainers.docker.cmd="docker run --rm -v /tmp:/tmp -p 9090:9090 -v $(pwd):/app:rw -t $TAG -r /app --server" \
-      org.opencontainers.image.authors="Team AppThreat <cloud@appthreat.com>" \
-      org.opencontainers.image.description="Image with cdxgen SBOM generator for $LANGUAGE apps" \
-      org.opencontainers.image.licenses="Apache-2.0" \
-      org.opencontainers.image.source="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.title="cdxgen" \
-      org.opencontainers.image.url="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.vendor="CycloneDX" \
-      org.opencontainers.image.version="$VERSION"
-
 ENV CDXGEN_IN_CONTAINER=true \
     NODE_COMPILE_CACHE="/opt/cdxgen-node-cache" \
     PATH=${PATH}:/opt/cdxgen/node_modules/.bin

--- a/ci/images/alpine/Dockerfile.golang123
+++ b/ci/images/alpine/Dockerfile.golang123
@@ -18,19 +18,6 @@ RUN set -e; \
 # cdxgen-image
 FROM base AS cdxgen
 
-ARG VERSION=master
-
-LABEL maintainer="CycloneDX" \
-      org.opencontainers.docker.cmd="docker run --rm -v /tmp:/tmp -p 9090:9090 -v $(pwd):/app:rw -t $TAG -r /app --server" \
-      org.opencontainers.image.authors="Team AppThreat <cloud@appthreat.com>" \
-      org.opencontainers.image.description="Image with cdxgen SBOM generator for $LANGUAGE apps" \
-      org.opencontainers.image.licenses="Apache-2.0" \
-      org.opencontainers.image.source="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.title="cdxgen" \
-      org.opencontainers.image.url="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.vendor="CycloneDX" \
-      org.opencontainers.image.version="$VERSION"
-
 ENV CDXGEN_IN_CONTAINER=true \
     NODE_COMPILE_CACHE="/opt/cdxgen-node-cache" \
     PATH=${PATH}:/opt/cdxgen/node_modules/.bin

--- a/ci/images/alpine/Dockerfile.golang124
+++ b/ci/images/alpine/Dockerfile.golang124
@@ -18,19 +18,6 @@ RUN set -e; \
 # cdxgen-image
 FROM base AS cdxgen
 
-ARG VERSION=master
-
-LABEL maintainer="CycloneDX" \
-      org.opencontainers.docker.cmd="docker run --rm -v /tmp:/tmp -p 9090:9090 -v $(pwd):/app:rw -t $TAG -r /app --server" \
-      org.opencontainers.image.authors="Team AppThreat <cloud@appthreat.com>" \
-      org.opencontainers.image.description="Image with cdxgen SBOM generator for $LANGUAGE apps" \
-      org.opencontainers.image.licenses="Apache-2.0" \
-      org.opencontainers.image.source="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.title="cdxgen" \
-      org.opencontainers.image.url="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.vendor="CycloneDX" \
-      org.opencontainers.image.version="$VERSION"
-
 ENV CDXGEN_IN_CONTAINER=true \
     NODE_COMPILE_CACHE="/opt/cdxgen-node-cache" \
     PATH=${PATH}:/opt/cdxgen/node_modules/.bin

--- a/ci/images/alpine/Dockerfile.java21
+++ b/ci/images/alpine/Dockerfile.java21
@@ -44,19 +44,6 @@ RUN set -e; \
 # cdxgen-image
 FROM base AS cdxgen
 
-ARG VERSION=master
-
-LABEL maintainer="CycloneDX" \
-      org.opencontainers.docker.cmd="docker run --rm -v /tmp:/tmp -p 9090:9090 -v $(pwd):/app:rw -t $TAG -r /app --server" \
-      org.opencontainers.image.authors="Team AppThreat <cloud@appthreat.com>" \
-      org.opencontainers.image.description="Image with cdxgen SBOM generator for $LANGUAGE apps" \
-      org.opencontainers.image.licenses="Apache-2.0" \
-      org.opencontainers.image.source="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.title="cdxgen" \
-      org.opencontainers.image.url="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.vendor="CycloneDX" \
-      org.opencontainers.image.version="$VERSION"
-
 ENV CDXGEN_IN_CONTAINER=true \
     NODE_COMPILE_CACHE="/opt/cdxgen-node-cache" \
     PATH=${PATH}:${PYTHONPATH}/bin:/opt/cdxgen/node_modules/.bin

--- a/ci/images/alpine/Dockerfile.java24
+++ b/ci/images/alpine/Dockerfile.java24
@@ -44,19 +44,6 @@ RUN set -e; \
 # cdxgen-image
 FROM base AS cdxgen
 
-ARG VERSION=master
-
-LABEL maintainer="CycloneDX" \
-      org.opencontainers.docker.cmd="docker run --rm -v /tmp:/tmp -p 9090:9090 -v $(pwd):/app:rw -t $TAG -r /app --server" \
-      org.opencontainers.image.authors="Team AppThreat <cloud@appthreat.com>" \
-      org.opencontainers.image.description="Image with cdxgen SBOM generator for $LANGUAGE apps" \
-      org.opencontainers.image.licenses="Apache-2.0" \
-      org.opencontainers.image.source="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.title="cdxgen" \
-      org.opencontainers.image.url="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.vendor="CycloneDX" \
-      org.opencontainers.image.version="$VERSION"
-
 ENV CDXGEN_IN_CONTAINER=true \
     NODE_COMPILE_CACHE="/opt/cdxgen-node-cache" \
     PATH=${PATH}:${PYTHONPATH}/bin:/opt/cdxgen/node_modules/.bin

--- a/ci/images/alpine/Dockerfile.node20
+++ b/ci/images/alpine/Dockerfile.node20
@@ -35,19 +35,6 @@ RUN set -e; \
 # cdxgen-image
 FROM base AS cdxgen
 
-ARG VERSION=master
-
-LABEL maintainer="CycloneDX" \
-      org.opencontainers.docker.cmd="docker run --rm -v /tmp:/tmp -p 9090:9090 -v $(pwd):/app:rw -t $TAG -r /app --server" \
-      org.opencontainers.image.authors="Team AppThreat <cloud@appthreat.com>" \
-      org.opencontainers.image.description="Image with cdxgen SBOM generator for $LANGUAGE apps" \
-      org.opencontainers.image.licenses="Apache-2.0" \
-      org.opencontainers.image.source="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.title="cdxgen" \
-      org.opencontainers.image.url="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.vendor="CycloneDX" \
-      org.opencontainers.image.version="$VERSION"
-
 ENV CDXGEN_IN_CONTAINER=true \
     NODE_COMPILE_CACHE="/opt/cdxgen-node-cache" \
     PATH=${PATH}:${PYTHONPATH}/bin:/opt/cdxgen/node_modules/.bin

--- a/ci/images/alpine/Dockerfile.node24
+++ b/ci/images/alpine/Dockerfile.node24
@@ -35,19 +35,6 @@ RUN set -e; \
 # cdxgen-image
 FROM base AS cdxgen
 
-ARG VERSION=master
-
-LABEL maintainer="CycloneDX" \
-      org.opencontainers.docker.cmd="docker run --rm -v /tmp:/tmp -p 9090:9090 -v $(pwd):/app:rw -t $TAG -r /app --server" \
-      org.opencontainers.image.authors="Team AppThreat <cloud@appthreat.com>" \
-      org.opencontainers.image.description="Image with cdxgen SBOM generator for $LANGUAGE apps" \
-      org.opencontainers.image.licenses="Apache-2.0" \
-      org.opencontainers.image.source="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.title="cdxgen" \
-      org.opencontainers.image.url="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.vendor="CycloneDX" \
-      org.opencontainers.image.version="$VERSION"
-
 ENV CDXGEN_IN_CONTAINER=true \
     NODE_COMPILE_CACHE="/opt/cdxgen-node-cache" \
     PATH=${PATH}:${PYTHONPATH}/bin:/opt/cdxgen/node_modules/.bin

--- a/ci/images/alpine/Dockerfile.php84
+++ b/ci/images/alpine/Dockerfile.php84
@@ -61,19 +61,6 @@ RUN set -e; \
 # cdxgen-image
 FROM base AS cdxgen
 
-ARG VERSION=master
-
-LABEL maintainer="CycloneDX" \
-    org.opencontainers.docker.cmd="docker run --rm -v /tmp:/tmp -p 9090:9090 -v $(pwd):/app:rw -t $TAG -r /app --server" \
-    org.opencontainers.image.authors="Team AppThreat <cloud@appthreat.com>" \
-    org.opencontainers.image.description="Image with cdxgen SBOM generator for $LANGUAGE apps" \
-    org.opencontainers.image.licenses="Apache-2.0" \
-    org.opencontainers.image.source="https://github.com/CycloneDX/cdxgen" \
-    org.opencontainers.image.title="cdxgen" \
-    org.opencontainers.image.url="https://github.com/CycloneDX/cdxgen" \
-    org.opencontainers.image.vendor="CycloneDX" \
-    org.opencontainers.image.version="$VERSION"
-
 ENV CDXGEN_IN_CONTAINER=true \
     NODE_COMPILE_CACHE="/opt/cdxgen-node-cache" \
     PATH=${PATH}:${PYTHONPATH}/bin:/opt/cdxgen/node_modules/.bin

--- a/ci/images/alpine/Dockerfile.ruby345
+++ b/ci/images/alpine/Dockerfile.ruby345
@@ -42,19 +42,6 @@ RUN set -e; \
 # cdxgen-image
 FROM base AS cdxgen
 
-ARG VERSION=master
-
-LABEL maintainer="CycloneDX" \
-      org.opencontainers.docker.cmd="docker run --rm -v /tmp:/tmp -p 9090:9090 -v $(pwd):/app:rw -t $TAG -r /app --server" \
-      org.opencontainers.image.authors="Team AppThreat <cloud@appthreat.com>" \
-      org.opencontainers.image.description="Image with cdxgen SBOM generator for $LANGUAGE apps" \
-      org.opencontainers.image.licenses="Apache-2.0" \
-      org.opencontainers.image.source="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.title="cdxgen" \
-      org.opencontainers.image.url="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.vendor="CycloneDX" \
-      org.opencontainers.image.version="$VERSION"
-
 ENV CDXGEN_GEM_HOME="/tmp/gems" \
     CDXGEN_IN_CONTAINER=true \
     NODE_COMPILE_CACHE="/opt/cdxgen-node-cache" \

--- a/ci/images/debian/Dockerfile.dotnet10
+++ b/ci/images/debian/Dockerfile.dotnet10
@@ -83,19 +83,6 @@ CMD ["/bin/bash"]
 # cdxgen-image
 FROM base AS cdxgen
 
-ARG VERSION=latest
-
-LABEL maintainer="CycloneDX" \
-      org.opencontainers.docker.cmd="docker run --rm -v /tmp:/tmp -p 9090:9090 -v $(pwd):/app:rw -t $TAG -r /app --server" \
-      org.opencontainers.image.authors="Team AppThreat <cloud@appthreat.com>" \
-      org.opencontainers.image.description="Image with cdxgen SBOM generator for $LANGUAGE apps" \
-      org.opencontainers.image.licenses="Apache-2.0" \
-      org.opencontainers.image.source="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.title="cdxgen" \
-      org.opencontainers.image.url="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.vendor="CycloneDX" \
-      org.opencontainers.image.version="$VERSION"
-
 ENV CDXGEN_IN_CONTAINER=true \
     NODE_COMPILE_CACHE="/opt/cdxgen-node-cache" \
     PATH=${PATH}:${PYTHONPATH}/bin:/opt/cdxgen/node_modules/.bin

--- a/ci/images/debian/Dockerfile.dotnet6
+++ b/ci/images/debian/Dockerfile.dotnet6
@@ -68,19 +68,6 @@ CMD ["/bin/bash"]
 # cdxgen-image
 FROM base AS cdxgen
 
-ARG VERSION=master
-
-LABEL maintainer="CycloneDX" \
-      org.opencontainers.docker.cmd="docker run --rm -v /tmp:/tmp -p 9090:9090 -v $(pwd):/app:rw -t $TAG -r /app --server" \
-      org.opencontainers.image.authors="Team AppThreat <cloud@appthreat.com>" \
-      org.opencontainers.image.description="Image with cdxgen SBOM generator for $LANGUAGE apps" \
-      org.opencontainers.image.licenses="Apache-2.0" \
-      org.opencontainers.image.source="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.title="cdxgen" \
-      org.opencontainers.image.url="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.vendor="CycloneDX" \
-      org.opencontainers.image.version="$VERSION"
-
 ENV CDXGEN_IN_CONTAINER=true \
     DOSAI_CMD=/usr/local/bin/dosai \
     NODE_COMPILE_CACHE="/opt/cdxgen-node-cache" \

--- a/ci/images/debian/Dockerfile.dotnet8
+++ b/ci/images/debian/Dockerfile.dotnet8
@@ -93,19 +93,6 @@ CMD ["/bin/bash"]
 # cdxgen-image
 FROM base AS cdxgen
 
-ARG VERSION=master
-
-LABEL maintainer="CycloneDX" \
-      org.opencontainers.docker.cmd="docker run --rm -v /tmp:/tmp -p 9090:9090 -v $(pwd):/app:rw -t $TAG -r /app --server" \
-      org.opencontainers.image.authors="Team AppThreat <cloud@appthreat.com>" \
-      org.opencontainers.image.description="Image with cdxgen SBOM generator for $LANGUAGE apps" \
-      org.opencontainers.image.licenses="Apache-2.0" \
-      org.opencontainers.image.source="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.title="cdxgen" \
-      org.opencontainers.image.url="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.vendor="CycloneDX" \
-      org.opencontainers.image.version="$VERSION"
-
 ENV CDXGEN_IN_CONTAINER=true \
     DOSAI_CMD=/usr/local/bin/dosai \
     NODE_COMPILE_CACHE="/opt/cdxgen-node-cache" \

--- a/ci/images/debian/Dockerfile.dotnet9
+++ b/ci/images/debian/Dockerfile.dotnet9
@@ -91,19 +91,6 @@ CMD ["/bin/bash"]
 # cdxgen-image
 FROM base AS cdxgen
 
-ARG VERSION=master
-
-LABEL maintainer="CycloneDX" \
-      org.opencontainers.docker.cmd="docker run --rm -v /tmp:/tmp -p 9090:9090 -v $(pwd):/app:rw -t $TAG -r /app --server" \
-      org.opencontainers.image.authors="Team AppThreat <cloud@appthreat.com>" \
-      org.opencontainers.image.description="Image with cdxgen SBOM generator for $LANGUAGE apps" \
-      org.opencontainers.image.licenses="Apache-2.0" \
-      org.opencontainers.image.source="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.title="cdxgen" \
-      org.opencontainers.image.url="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.vendor="CycloneDX" \
-      org.opencontainers.image.version="$VERSION"
-
 ENV CDXGEN_IN_CONTAINER=true \
     DOSAI_CMD=/usr/local/bin/dosai \
     NODE_COMPILE_CACHE="/opt/cdxgen-node-cache" \

--- a/ci/images/debian/Dockerfile.golang123
+++ b/ci/images/debian/Dockerfile.golang123
@@ -49,19 +49,6 @@ CMD ["/bin/bash"]
 # cdxgen-image
 FROM base AS cdxgen
 
-ARG VERSION=master
-
-LABEL maintainer="CycloneDX" \
-      org.opencontainers.docker.cmd="docker run --rm -v /tmp:/tmp -p 9090:9090 -v $(pwd):/app:rw -t $TAG -r /app --server" \
-      org.opencontainers.image.authors="Team AppThreat <cloud@appthreat.com>" \
-      org.opencontainers.image.description="Image with cdxgen SBOM generator for $LANGUAGE apps" \
-      org.opencontainers.image.licenses="Apache-2.0" \
-      org.opencontainers.image.source="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.title="cdxgen" \
-      org.opencontainers.image.url="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.vendor="CycloneDX" \
-      org.opencontainers.image.version="$VERSION"
-
 ENV CDXGEN_IN_CONTAINER=true \
     NODE_COMPILE_CACHE="/opt/cdxgen-node-cache" \
     PATH=${PATH}:${PYTHONPATH}/bin:/opt/cdxgen/node_modules/.bin

--- a/ci/images/debian/Dockerfile.golang124
+++ b/ci/images/debian/Dockerfile.golang124
@@ -49,19 +49,6 @@ CMD ["/bin/bash"]
 # cdxgen-image
 FROM base AS cdxgen
 
-ARG VERSION=master
-
-LABEL maintainer="CycloneDX" \
-      org.opencontainers.docker.cmd="docker run --rm -v /tmp:/tmp -p 9090:9090 -v $(pwd):/app:rw -t $TAG -r /app --server" \
-      org.opencontainers.image.authors="Team AppThreat <cloud@appthreat.com>" \
-      org.opencontainers.image.description="Image with cdxgen SBOM generator for $LANGUAGE apps" \
-      org.opencontainers.image.licenses="Apache-2.0" \
-      org.opencontainers.image.source="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.title="cdxgen" \
-      org.opencontainers.image.url="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.vendor="CycloneDX" \
-      org.opencontainers.image.version="$VERSION"
-
 ENV CDXGEN_IN_CONTAINER=true \
     NODE_COMPILE_CACHE="/opt/cdxgen-node-cache" \
     PATH=${PATH}:${PYTHONPATH}/bin:/opt/cdxgen/node_modules/.bin

--- a/ci/images/debian/Dockerfile.php83
+++ b/ci/images/debian/Dockerfile.php83
@@ -71,19 +71,6 @@ CMD ["/bin/bash"]
 # cdxgen-image
 FROM base AS cdxgen
 
-ARG VERSION=master
-
-LABEL maintainer="CycloneDX" \
-      org.opencontainers.docker.cmd="docker run --rm -v /tmp:/tmp -p 9090:9090 -v $(pwd):/app:rw -t $TAG -r /app --server" \
-      org.opencontainers.image.authors="Team AppThreat <cloud@appthreat.com>" \
-      org.opencontainers.image.description="Image with cdxgen SBOM generator for $LANGUAGE apps" \
-      org.opencontainers.image.licenses="Apache-2.0" \
-      org.opencontainers.image.source="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.title="cdxgen" \
-      org.opencontainers.image.url="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.vendor="CycloneDX" \
-      org.opencontainers.image.version="$VERSION"
-
 ENV CDXGEN_IN_CONTAINER=true \
     NODE_COMPILE_CACHE="/opt/cdxgen-node-cache" \
     PATH=${PATH}:${PYTHONPATH}/bin:/opt/cdxgen/node_modules/.bin

--- a/ci/images/debian/Dockerfile.php84
+++ b/ci/images/debian/Dockerfile.php84
@@ -71,19 +71,6 @@ CMD ["/bin/bash"]
 # cdxgen-image
 FROM base AS cdxgen
 
-ARG VERSION=master
-
-LABEL maintainer="CycloneDX" \
-      org.opencontainers.docker.cmd="docker run --rm -v /tmp:/tmp -p 9090:9090 -v $(pwd):/app:rw -t $TAG -r /app --server" \
-      org.opencontainers.image.authors="Team AppThreat <cloud@appthreat.com>" \
-      org.opencontainers.image.description="Image with cdxgen SBOM generator for $LANGUAGE apps" \
-      org.opencontainers.image.licenses="Apache-2.0" \
-      org.opencontainers.image.source="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.title="cdxgen" \
-      org.opencontainers.image.url="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.vendor="CycloneDX" \
-      org.opencontainers.image.version="$VERSION"
-
 ENV CDXGEN_IN_CONTAINER=true \
     NODE_COMPILE_CACHE="/opt/cdxgen-node-cache" \
     PATH=${PATH}:${PYTHONPATH}/bin:/opt/cdxgen/node_modules/.bin

--- a/ci/images/debian/Dockerfile.ruby26
+++ b/ci/images/debian/Dockerfile.ruby26
@@ -57,19 +57,6 @@ CMD ["/bin/bash"]
 # cdxgen-image
 FROM base AS cdxgen
 
-ARG VERSION=master
-
-LABEL maintainer="CycloneDX" \
-      org.opencontainers.docker.cmd="docker run --rm -v /tmp:/tmp -p 9090:9090 -v $(pwd):/app:rw -t $TAG -r /app --server" \
-      org.opencontainers.image.authors="Team AppThreat <cloud@appthreat.com>" \
-      org.opencontainers.image.description="Image with cdxgen SBOM generator for $LANGUAGE apps" \
-      org.opencontainers.image.licenses="Apache-2.0" \
-      org.opencontainers.image.source="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.title="cdxgen" \
-      org.opencontainers.image.url="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.vendor="CycloneDX" \
-      org.opencontainers.image.version="$VERSION"
-
 ENV ATOM_RUBY_HOME=/root/.rbenv/versions/${ATOM_RUBY_VERSION} \
     CDXGEN_GEM_HOME="/tmp/gems" \
     CDXGEN_IN_CONTAINER=true \

--- a/ci/images/debian/Dockerfile.ruby33
+++ b/ci/images/debian/Dockerfile.ruby33
@@ -61,19 +61,6 @@ CMD ["/bin/bash"]
 # cdxgen-image
 FROM base AS cdxgen
 
-ARG VERSION=master
-
-LABEL maintainer="CycloneDX" \
-      org.opencontainers.docker.cmd="docker run --rm -v /tmp:/tmp -p 9090:9090 -v $(pwd):/app:rw -t $TAG -r /app --server" \
-      org.opencontainers.image.authors="Team AppThreat <cloud@appthreat.com>" \
-      org.opencontainers.image.description="Image with cdxgen SBOM generator for $LANGUAGE apps" \
-      org.opencontainers.image.licenses="Apache-2.0" \
-      org.opencontainers.image.source="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.title="cdxgen" \
-      org.opencontainers.image.url="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.vendor="CycloneDX" \
-      org.opencontainers.image.version="$VERSION"
-
 ENV ATOM_RUBY_HOME=/root/.rbenv/versions/${ATOM_RUBY_VERSION} \
     CDXGEN_GEM_HOME="/tmp/gems" \
     CDXGEN_IN_CONTAINER=true \

--- a/ci/images/debian/Dockerfile.ruby34
+++ b/ci/images/debian/Dockerfile.ruby34
@@ -59,19 +59,6 @@ CMD ["/bin/bash"]
 # cdxgen-image
 FROM base AS cdxgen
 
-ARG VERSION=master
-
-LABEL maintainer="CycloneDX" \
-      org.opencontainers.docker.cmd="docker run --rm -v /tmp:/tmp -p 9090:9090 -v $(pwd):/app:rw -t $TAG -r /app --server" \
-      org.opencontainers.image.authors="Team AppThreat <cloud@appthreat.com>" \
-      org.opencontainers.image.description="Image with cdxgen SBOM generator for $LANGUAGE apps" \
-      org.opencontainers.image.licenses="Apache-2.0" \
-      org.opencontainers.image.source="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.title="cdxgen" \
-      org.opencontainers.image.url="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.vendor="CycloneDX" \
-      org.opencontainers.image.version="$VERSION"
-
 ENV CDXGEN_GEM_HOME="/tmp/gems" \
     CDXGEN_IN_CONTAINER=true \
     NODE_COMPILE_CACHE="/opt/cdxgen-node-cache" \

--- a/ci/images/debian/Dockerfile.rust1
+++ b/ci/images/debian/Dockerfile.rust1
@@ -55,19 +55,6 @@ CMD ["/bin/bash"]
 # cdxgen-image
 FROM base AS cdxgen
 
-ARG VERSION=master
-
-LABEL maintainer="CycloneDX" \
-      org.opencontainers.docker.cmd="docker run --rm -v /tmp:/tmp -p 9090:9090 -v $(pwd):/app:rw -t $TAG -r /app --server" \
-      org.opencontainers.image.authors="Team AppThreat <cloud@appthreat.com>" \
-      org.opencontainers.image.description="Image with cdxgen SBOM generator for $LANGUAGE apps" \
-      org.opencontainers.image.licenses="Apache-2.0" \
-      org.opencontainers.image.source="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.title="cdxgen" \
-      org.opencontainers.image.url="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.vendor="CycloneDX" \
-      org.opencontainers.image.version="$VERSION"
-
 ENV CDXGEN_IN_CONTAINER=true \
     NODE_COMPILE_CACHE="/opt/cdxgen-node-cache" \
     PATH=${PATH}:${PYTHONPATH}/bin:/opt/cdxgen/node_modules/.bin

--- a/ci/images/debian/Dockerfile.swift6
+++ b/ci/images/debian/Dockerfile.swift6
@@ -99,19 +99,6 @@ CMD ["/bin/bash"]
 # cdxgen-image
 FROM base AS cdxgen
 
-ARG VERSION=master
-
-LABEL maintainer="CycloneDX" \
-      org.opencontainers.docker.cmd="docker run --rm -v /tmp:/tmp -p 9090:9090 -v $(pwd):/app:rw -t $TAG -r /app --server" \
-      org.opencontainers.image.authors="Team AppThreat <cloud@appthreat.com>" \
-      org.opencontainers.image.description="Image with cdxgen SBOM generator for $LANGUAGE apps" \
-      org.opencontainers.image.licenses="Apache-2.0" \
-      org.opencontainers.image.source="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.title="cdxgen" \
-      org.opencontainers.image.url="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.vendor="CycloneDX" \
-      org.opencontainers.image.version="$VERSION"
-
 ENV CDXGEN_IN_CONTAINER=true \
     NODE_COMPILE_CACHE="/opt/cdxgen-node-cache" \
     PATH=${PATH}:${PYTHONPATH}/bin:/opt/cdxgen/node_modules/.bin

--- a/ci/images/opensuse/Dockerfile.python310
+++ b/ci/images/opensuse/Dockerfile.python310
@@ -103,19 +103,6 @@ CMD ["/bin/bash"]
 # cdxgen-image
 FROM base AS cdxgen
 
-ARG VERSION=master
-
-LABEL maintainer="CycloneDX" \
-      org.opencontainers.docker.cmd="docker run --rm -v /tmp:/tmp -p 9090:9090 -v $(pwd):/app:rw -t $TAG -r /app --server" \
-      org.opencontainers.image.authors="Team AppThreat <cloud@appthreat.com>" \
-      org.opencontainers.image.description="Image with cdxgen SBOM generator for $LANGUAGE apps" \
-      org.opencontainers.image.licenses="Apache-2.0" \
-      org.opencontainers.image.source="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.title="cdxgen" \
-      org.opencontainers.image.url="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.vendor="CycloneDX" \
-      org.opencontainers.image.version="$VERSION"
-
 ENV CDXGEN_IN_CONTAINER=true \
     CRYPTOGRAPHY_DONT_BUILD_RUST=1 \
     NODE_COMPILE_CACHE="/opt/cdxgen-node-cache" \

--- a/ci/images/opensuse/Dockerfile.python39
+++ b/ci/images/opensuse/Dockerfile.python39
@@ -91,19 +91,6 @@ CMD ["/bin/bash"]
 # cdxgen-image
 FROM base AS cdxgen
 
-ARG VERSION=master
-
-LABEL maintainer="CycloneDX" \
-      org.opencontainers.docker.cmd="docker run --rm -v /tmp:/tmp -p 9090:9090 -v $(pwd):/app:rw -t $TAG -r /app --server" \
-      org.opencontainers.image.authors="Team AppThreat <cloud@appthreat.com>" \
-      org.opencontainers.image.description="Image with cdxgen SBOM generator for $LANGUAGE apps" \
-      org.opencontainers.image.licenses="Apache-2.0" \
-      org.opencontainers.image.source="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.title="cdxgen" \
-      org.opencontainers.image.url="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.vendor="CycloneDX" \
-      org.opencontainers.image.version="$VERSION"
-
 ENV CDXGEN_IN_CONTAINER=true \
     CRYPTOGRAPHY_DONT_BUILD_RUST=1 \
     NODE_COMPILE_CACHE="/opt/cdxgen-node-cache" \

--- a/ci/images/opensuse/Dockerfile.rolling
+++ b/ci/images/opensuse/Dockerfile.rolling
@@ -128,18 +128,6 @@ CMD ["/bin/bash"]
 # cdxgen-image
 FROM base AS cdxgen
 
-
-LABEL maintainer="CycloneDX" \
-      org.opencontainers.docker.cmd="docker run --rm -v /tmp:/tmp -p 9090:9090 -v $(pwd):/app:rw -t $TAG -r /app --server" \
-      org.opencontainers.image.authors="Team AppThreat <cloud@appthreat.com>" \
-      org.opencontainers.image.description="Rolling image with cdxgen SBOM generator based on tumbleweed" \
-      org.opencontainers.image.licenses="Apache-2.0" \
-      org.opencontainers.image.source="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.title="cdxgen" \
-      org.opencontainers.image.url="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.vendor="CycloneDX" \
-      org.opencontainers.image.version="rolling"
-
 ENV CDXGEN_DEBUG_MODE=debug \
     CDXGEN_IN_CONTAINER=true \
     NODE_COMPILE_CACHE="/opt/cdxgen-node-cache" \

--- a/ci/images/temurin/Dockerfile.java21
+++ b/ci/images/temurin/Dockerfile.java21
@@ -112,19 +112,6 @@ CMD ["/bin/bash"]
 # cdxgen-image
 FROM base AS cdxgen
 
-ARG VERSION=master
-
-LABEL maintainer="CycloneDX" \
-      org.opencontainers.docker.cmd="docker run --rm -v /tmp:/tmp -p 9090:9090 -v $(pwd):/app:rw -t $TAG -r /app --server" \
-      org.opencontainers.image.authors="Team AppThreat <cloud@appthreat.com>" \
-      org.opencontainers.image.description="Image with cdxgen SBOM generator for $LANGUAGE apps" \
-      org.opencontainers.image.licenses="Apache-2.0" \
-      org.opencontainers.image.source="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.title="cdxgen" \
-      org.opencontainers.image.url="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.vendor="CycloneDX" \
-      org.opencontainers.image.version="$VERSION"
-
 ENV CDXGEN_IN_CONTAINER=true \
     PATH=${PATH}:/opt/cdxgen/node_modules/.bin
 

--- a/ci/images/temurin/Dockerfile.java24
+++ b/ci/images/temurin/Dockerfile.java24
@@ -112,19 +112,6 @@ CMD ["/bin/bash"]
 # cdxgen-image
 FROM base AS cdxgen
 
-ARG VERSION=master
-
-LABEL maintainer="CycloneDX" \
-      org.opencontainers.docker.cmd="docker run --rm -v /tmp:/tmp -p 9090:9090 -v $(pwd):/app:rw -t $TAG -r /app --server" \
-      org.opencontainers.image.authors="Team AppThreat <cloud@appthreat.com>" \
-      org.opencontainers.image.description="Image with cdxgen SBOM generator for $LANGUAGE apps" \
-      org.opencontainers.image.licenses="Apache-2.0" \
-      org.opencontainers.image.source="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.title="cdxgen" \
-      org.opencontainers.image.url="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.vendor="CycloneDX" \
-      org.opencontainers.image.version="$VERSION"
-
 ENV CDXGEN_IN_CONTAINER=true \
     PATH=${PATH}:/opt/cdxgen/node_modules/.bin
 

--- a/ci/images/temurin/Dockerfile.java8
+++ b/ci/images/temurin/Dockerfile.java8
@@ -108,19 +108,6 @@ CMD ["/bin/bash"]
 # cdxgen-image
 FROM base AS cdxgen
 
-ARG VERSION=master
-
-LABEL maintainer="CycloneDX" \
-      org.opencontainers.docker.cmd="docker run --rm -v /tmp:/tmp -p 9090:9090 -v $(pwd):/app:rw -t $TAG -r /app --server" \
-      org.opencontainers.image.authors="Team AppThreat <cloud@appthreat.com>" \
-      org.opencontainers.image.description="Image with cdxgen SBOM generator for $LANGUAGE apps" \
-      org.opencontainers.image.licenses="Apache-2.0" \
-      org.opencontainers.image.source="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.title="cdxgen" \
-      org.opencontainers.image.url="https://github.com/CycloneDX/cdxgen" \
-      org.opencontainers.image.vendor="CycloneDX" \
-      org.opencontainers.image.version="$VERSION"
-
 ENV CDXGEN_IN_CONTAINER=true \
     PATH=${PATH}:/opt/cdxgen/node_modules/.bin
 


### PR DESCRIPTION
Not all labels were set, because they were overridden by metadata-action. Now using this action to set all other labels and override those we want to be different from the default.