### PR TITLE
fix: postProcess dependencies to correct root deps

### DIFF
--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -321,58 +321,6 @@ const determineParentComponent = (options) => {
  * @param {Object} parentComponent The enforced parent component (may be undefined)
  * @param {Array} dependencies Mutable dependencies array to update
  */
-function unifyParentRefAndDependencies(
-  options,
-  parentComponent,
-  dependencies,
-  components,
-) {
-  if (!(options.projectName && options.projectVersion)) return; // Only enforce when explicitly identified
-  const parentRef = parentComponent?.["bom-ref"];
-  if (!parentRef) return;
-  // Build set of component bom-refs (include parentRef)
-  const componentRefs = new Set([parentRef]);
-  for (const c of components || []) {
-    if (c?.["bom-ref"]) componentRefs.add(c["bom-ref"]);
-  }
-  // Collect all child refs once
-  const childRefs = new Set();
-  for (const dep of dependencies) {
-    if (Array.isArray(dep?.dependsOn)) {
-      for (const c of dep.dependsOn) childRefs.add(c);
-    }
-  }
-  // Ensure parent dependency entry exists
-  let parentDep = dependencies.find((d) => d.ref === parentRef);
-  if (!parentDep) {
-    parentDep = { ref: parentRef, dependsOn: [] };
-    dependencies.push(parentDep);
-  }
-  const parentDepends = new Set(parentDep.dependsOn || []);
-  const removeRefs = new Set();
-  for (const dep of dependencies) {
-    const ref = dep.ref;
-    if (!ref || ref === parentRef) continue; // skip parent / invalid
-    if (childRefs.has(ref)) continue; // not a top-level root
-    if (componentRefs.has(ref)) {
-      // Legit root component; just add reference
-      parentDepends.add(ref);
-    } else {
-      // Orphan synthetic root: absorb its edges then drop
-      if (Array.isArray(dep.dependsOn)) {
-        for (const c of dep.dependsOn) parentDepends.add(c);
-      }
-      removeRefs.add(ref);
-    }
-  }
-  parentDep.dependsOn = Array.from(parentDepends).sort();
-  if (removeRefs.size) {
-    for (let i = dependencies.length - 1; i >= 0; i--) {
-      const r = dependencies[i].ref;
-      if (r && removeRefs.has(r)) dependencies.splice(i, 1);
-    }
-  }
-}
 
 const addToolsSection = (options, context = {}) => {
   if (options.specVersion === 1.4) {
@@ -1436,13 +1384,7 @@ const buildBomNSData = (options, pkgInfo, ptype, context) => {
     determineParentComponent(options) || context.parentComponent;
   const metadata = addMetadata(parentComponent, options, context);
   const components = listComponents(options, allImports, pkgInfo, ptype);
-  // Now that components are known, unify root dependencies (absorb orphan roots, link legitimate ones)
-  unifyParentRefAndDependencies(
-    options,
-    parentComponent,
-    dependencies,
-    components,
-  );
+  
   if (components && (components.length || parentComponent)) {
     // CycloneDX Json Template
     const jsonTpl = {

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -1384,7 +1384,7 @@ const buildBomNSData = (options, pkgInfo, ptype, context) => {
     determineParentComponent(options) || context.parentComponent;
   const metadata = addMetadata(parentComponent, options, context);
   const components = listComponents(options, allImports, pkgInfo, ptype);
-  
+
   if (components && (components.length || parentComponent)) {
     // CycloneDX Json Template
     const jsonTpl = {

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -321,7 +321,7 @@ const determineParentComponent = (options) => {
  * @param {Object} parentComponent The enforced parent component (may be undefined)
  * @param {Array} dependencies Mutable dependencies array to update
  */
-function ensureCanonicalRoot(
+function unifyParentRefAndDependencies(
   options,
   parentComponent,
   dependencies,
@@ -1437,7 +1437,12 @@ const buildBomNSData = (options, pkgInfo, ptype, context) => {
   const metadata = addMetadata(parentComponent, options, context);
   const components = listComponents(options, allImports, pkgInfo, ptype);
   // Now that components are known, unify root dependencies (absorb orphan roots, link legitimate ones)
-  ensureCanonicalRoot(options, parentComponent, dependencies, components);
+  unifyParentRefAndDependencies(
+    options,
+    parentComponent,
+    dependencies,
+    components,
+  );
   if (components && (components.length || parentComponent)) {
     // CycloneDX Json Template
     const jsonTpl = {

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -327,56 +327,50 @@ function ensureCanonicalRoot(
   dependencies,
   components,
 ) {
-  if (!(options.projectName && options.projectVersion)) return;
-  if (!parentComponent?.["bom-ref"]) return;
-  const parentRef = parentComponent["bom-ref"];
-  // Build set of valid component refs (including parentRef)
+  if (!(options.projectName && options.projectVersion)) return; // Only enforce when explicitly identified
+  const parentRef = parentComponent?.["bom-ref"];
+  if (!parentRef) return;
+  // Build set of component bom-refs (include parentRef)
   const componentRefs = new Set([parentRef]);
-  if (Array.isArray(components)) {
-    for (const c of components) {
-      if (c?.["bom-ref"]) componentRefs.add(c["bom-ref"]);
-    }
+  for (const c of components || []) {
+    if (c?.["bom-ref"]) componentRefs.add(c["bom-ref"]);
   }
-  // Collect child refs (appear in dependsOn)
+  // Collect all child refs once
   const childRefs = new Set();
   for (const dep of dependencies) {
     if (Array.isArray(dep?.dependsOn)) {
       for (const c of dep.dependsOn) childRefs.add(c);
     }
   }
-  // Identify root dependency entries (never a child)
-  const rootDeps = dependencies.filter((d) => d?.ref && !childRefs.has(d.ref));
-  if (!rootDeps.length) return;
   // Ensure parent dependency entry exists
   let parentDep = dependencies.find((d) => d.ref === parentRef);
   if (!parentDep) {
     parentDep = { ref: parentRef, dependsOn: [] };
     dependencies.push(parentDep);
   }
-  const mergedDepends = new Set(parentDep.dependsOn || []);
-  const depsToRemove = new Set();
-  for (const rd of rootDeps) {
-    if (rd.ref === parentRef) continue; // skip parent itself
-    if (!componentRefs.has(rd.ref)) {
-      // Orphan root (no matching component) - absorb its edges and remove
-      if (Array.isArray(rd.dependsOn)) {
-        for (const c of rd.dependsOn) mergedDepends.add(c);
-      }
-      depsToRemove.add(rd.ref);
+  const parentDepends = new Set(parentDep.dependsOn || []);
+  const removeRefs = new Set();
+  for (const dep of dependencies) {
+    const ref = dep.ref;
+    if (!ref || ref === parentRef) continue; // skip parent / invalid
+    if (childRefs.has(ref)) continue; // not a top-level root
+    if (componentRefs.has(ref)) {
+      // Legit root component; just add reference
+      parentDepends.add(ref);
     } else {
-      // Legit component root - just depend on it
-      mergedDepends.add(rd.ref);
+      // Orphan synthetic root: absorb its edges then drop
+      if (Array.isArray(dep.dependsOn)) {
+        for (const c of dep.dependsOn) parentDepends.add(c);
+      }
+      removeRefs.add(ref);
     }
   }
-  parentDep.dependsOn = Array.from(mergedDepends).sort();
-  if (depsToRemove.size) {
-    const filtered = [];
-    for (const d of dependencies) {
-      if (d.ref && depsToRemove.has(d.ref)) continue;
-      filtered.push(d);
+  parentDep.dependsOn = Array.from(parentDepends).sort();
+  if (removeRefs.size) {
+    for (let i = dependencies.length - 1; i >= 0; i--) {
+      const r = dependencies[i].ref;
+      if (r && removeRefs.has(r)) dependencies.splice(i, 1);
     }
-    dependencies.length = 0;
-    dependencies.push(...filtered);
   }
 }
 

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -312,6 +312,74 @@ const determineParentComponent = (options) => {
   return parentComponent;
 };
 
+/**
+ * Ensure a single canonical root dependency entry lists all other top-level root refs.
+ * A top-level root ref is one that never appears as a child in any dependency.dependsOn list.
+ * Only runs when both projectName and projectVersion are provided (explicit user intent).
+ *
+ * @param {Object} options CLI options
+ * @param {Object} parentComponent The enforced parent component (may be undefined)
+ * @param {Array} dependencies Mutable dependencies array to update
+ */
+function ensureCanonicalRoot(
+  options,
+  parentComponent,
+  dependencies,
+  components,
+) {
+  if (!(options.projectName && options.projectVersion)) return;
+  if (!parentComponent?.["bom-ref"]) return;
+  const parentRef = parentComponent["bom-ref"];
+  // Build set of valid component refs (including parentRef)
+  const componentRefs = new Set([parentRef]);
+  if (Array.isArray(components)) {
+    for (const c of components) {
+      if (c?.["bom-ref"]) componentRefs.add(c["bom-ref"]);
+    }
+  }
+  // Collect child refs (appear in dependsOn)
+  const childRefs = new Set();
+  for (const dep of dependencies) {
+    if (Array.isArray(dep?.dependsOn)) {
+      for (const c of dep.dependsOn) childRefs.add(c);
+    }
+  }
+  // Identify root dependency entries (never a child)
+  const rootDeps = dependencies.filter((d) => d?.ref && !childRefs.has(d.ref));
+  if (!rootDeps.length) return;
+  // Ensure parent dependency entry exists
+  let parentDep = dependencies.find((d) => d.ref === parentRef);
+  if (!parentDep) {
+    parentDep = { ref: parentRef, dependsOn: [] };
+    dependencies.push(parentDep);
+  }
+  const mergedDepends = new Set(parentDep.dependsOn || []);
+  const depsToRemove = new Set();
+  for (const rd of rootDeps) {
+    if (rd.ref === parentRef) continue; // skip parent itself
+    if (!componentRefs.has(rd.ref)) {
+      // Orphan root (no matching component) - absorb its edges and remove
+      if (Array.isArray(rd.dependsOn)) {
+        for (const c of rd.dependsOn) mergedDepends.add(c);
+      }
+      depsToRemove.add(rd.ref);
+    } else {
+      // Legit component root - just depend on it
+      mergedDepends.add(rd.ref);
+    }
+  }
+  parentDep.dependsOn = Array.from(mergedDepends).sort();
+  if (depsToRemove.size) {
+    const filtered = [];
+    for (const d of dependencies) {
+      if (d.ref && depsToRemove.has(d.ref)) continue;
+      filtered.push(d);
+    }
+    dependencies.length = 0;
+    dependencies.push(...filtered);
+  }
+}
+
 const addToolsSection = (options, context = {}) => {
   if (options.specVersion === 1.4) {
     return [
@@ -1374,6 +1442,8 @@ const buildBomNSData = (options, pkgInfo, ptype, context) => {
     determineParentComponent(options) || context.parentComponent;
   const metadata = addMetadata(parentComponent, options, context);
   const components = listComponents(options, allImports, pkgInfo, ptype);
+  // Now that components are known, unify root dependencies (absorb orphan roots, link legitimate ones)
+  ensureCanonicalRoot(options, parentComponent, dependencies, components);
   if (components && (components.length || parentComponent)) {
     // CycloneDX Json Template
     const jsonTpl = {

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -312,7 +312,6 @@ const determineParentComponent = (options) => {
   return parentComponent;
 };
 
-
 const addToolsSection = (options, context = {}) => {
   if (options.specVersion === 1.4) {
     return [

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -312,15 +312,6 @@ const determineParentComponent = (options) => {
   return parentComponent;
 };
 
-/**
- * Ensure a single canonical root dependency entry lists all other top-level root refs.
- * A top-level root ref is one that never appears as a child in any dependency.dependsOn list.
- * Only runs when both projectName and projectVersion are provided (explicit user intent).
- *
- * @param {Object} options CLI options
- * @param {Object} parentComponent The enforced parent component (may be undefined)
- * @param {Array} dependencies Mutable dependencies array to update
- */
 
 const addToolsSection = (options, context = {}) => {
   if (options.specVersion === 1.4) {
@@ -1384,7 +1375,6 @@ const buildBomNSData = (options, pkgInfo, ptype, context) => {
     determineParentComponent(options) || context.parentComponent;
   const metadata = addMetadata(parentComponent, options, context);
   const components = listComponents(options, allImports, pkgInfo, ptype);
-
   if (components && (components.length || parentComponent)) {
     // CycloneDX Json Template
     const jsonTpl = {

--- a/lib/stages/postgen/postgen.js
+++ b/lib/stages/postgen/postgen.js
@@ -621,9 +621,9 @@ export function annotate(bomJson, options) {
 }
 
 /**
- * Ensures a single canonical root dependency entry lists all other top-level root refs.
- * A top-level root ref is one that never appears as a child in any dependency.dependsOn list.
- * Only runs when both projectName and projectVersion are provided (explicit user intent).
+ * Parse all BOM dependencies and ensure that
+ *     (1) there are no dangling dependencies
+ *     (2) that any root dependencies match the BOM parent ref
  *
  * @param {Object} bomJson BOM JSON Object
  * @returns {Object} Updated BOM JSON

--- a/lib/stages/postgen/postgen.js
+++ b/lib/stages/postgen/postgen.js
@@ -626,14 +626,13 @@ export function annotate(bomJson, options) {
  * Only runs when both projectName and projectVersion are provided (explicit user intent).
  *
  * @param {Object} bomJson BOM JSON Object
- * @param {Object} options CLI options
  * @returns {Object} Updated BOM JSON
  */
-export function normalizeRootDependency(bomJson, options) {
+export function normalizeRootDependency(bomJson) {
   const parentComponent = bomJson?.metadata?.component;
   const parentRef = parentComponent?.["bom-ref"];
 
-  let dependencies = bomJson?.dependencies;
+  const dependencies = bomJson?.dependencies;
 
   if (!parentRef) {
     return bomJson;
@@ -661,23 +660,26 @@ export function normalizeRootDependency(bomJson, options) {
   // Loop over dependencies and update/remove parentDeps as needed
   const newDependencies = [];
   for (const dep of dependencies) {
-    // If dep.ref is a parentDepsCandidate
-    if (parentDepsCandidates.includes(dep.ref)) {
-      if (Array.isArray(dep.dependsOn) && dep.dependsOn.length === 0) {
-        // Orphaned parent dependency, skip (remove)
-        continue;
-      }
-      if (Array.isArray(dep.dependsOn) && dep.dependsOn.length > 0) {
-        // Update its ref to parentRef
-        dep.ref = parentRef;
-      }
+    if (!parentDepsCandidates.includes(dep.ref)) {
+      continue;
     }
+
+    if (!Array.isArray(dep.dependsOn)) {
+      continue;
+    }
+
+    // Orphaned parent dependency, skip (remove)
+    if (dep.dependsOn.length === 0) {
+      continue;
+    }
+
+    // Update its ref to parentRef
+    dep.ref = parentRef;
+
     newDependencies.push(dep);
   }
 
-  dependencies = newDependencies;
-
-  bomJson.dependencies = dependencies;
+  bomJson.dependencies = newDependencies;
 
   return bomJson;
 }

--- a/lib/stages/postgen/postgen.js
+++ b/lib/stages/postgen/postgen.js
@@ -61,6 +61,8 @@ export function postProcess(bomNSData, options) {
   bomNSData.bomJson = filterBom(jsonPayload, options);
   bomNSData.bomJson = applyStandards(bomNSData.bomJson, options);
   bomNSData.bomJson = applyMetadata(bomNSData.bomJson, options);
+  bomNSData.bomJson = normalizeRootDependency(bomNSData.bomJson, options);
+
   // Support for automatic annotations
   if (options.specVersion >= 1.6) {
     bomNSData.bomJson = annotate(bomNSData.bomJson, options);
@@ -615,5 +617,67 @@ export function annotate(bomJson, options) {
     // Overwrite the dependencies
     bomJson.dependencies = newDeps;
   }
+  return bomJson;
+}
+
+/**
+ * Ensures a single canonical root dependency entry lists all other top-level root refs.
+ * A top-level root ref is one that never appears as a child in any dependency.dependsOn list.
+ * Only runs when both projectName and projectVersion are provided (explicit user intent).
+ *
+ * @param {Object} bomJson BOM JSON Object
+ * @param {Object} options CLI options
+ * @returns {Object} Updated BOM JSON
+ */
+export function normalizeRootDependency(bomJson, options) {
+  const parentComponent = bomJson?.metadata?.component;
+  const parentRef = parentComponent?.["bom-ref"];
+
+  let dependencies = bomJson?.dependencies;
+
+  if (!parentRef) {
+    return bomJson;
+  }
+
+  // Find all dependency dependsOn refs
+  const childRefs = new Set();
+  for (const dep of dependencies) {
+    for (const c of dep.dependsOn) {
+      childRefs.add(c);
+    }
+  }
+
+  // Find all dependency refs
+  const depRefs = new Set();
+  for (const dep of dependencies) {
+    depRefs.add(dep.ref);
+  }
+
+  // Find the parent dependency
+  const parentDepsCandidates = Array.from(depRefs).filter(
+    (ref) => !childRefs.has(ref),
+  );
+
+  // Loop over dependencies and update/remove parentDeps as needed
+  const newDependencies = [];
+  for (const dep of dependencies) {
+    // If dep.ref is a parentDepsCandidate
+    if (parentDepsCandidates.includes(dep.ref)) {
+      if (Array.isArray(dep.dependsOn) && dep.dependsOn.length === 0) {
+        // Orphaned parent dependency, skip (remove)
+        continue;
+      }
+      if (Array.isArray(dep.dependsOn) && dep.dependsOn.length > 0) {
+        // Update its ref to parentRef
+        dep.ref = parentRef;
+      }
+    }
+    newDependencies.push(dep);
+  }
+
+  dependencies = newDependencies;
+
+  bomJson.dependencies = dependencies;
+
   return bomJson;
 }

--- a/lib/stages/postgen/postgen.poku.js
+++ b/lib/stages/postgen/postgen.poku.js
@@ -1,4 +1,3 @@
-/* global describe, it, expect */
 import { readFileSync } from "node:fs";
 
 import { assert, it } from "poku";

--- a/lib/stages/postgen/postgen.poku.js
+++ b/lib/stages/postgen/postgen.poku.js
@@ -1,8 +1,9 @@
+/* global describe, it, expect */
 import { readFileSync } from "node:fs";
 
 import { assert, it } from "poku";
 
-import { filterBom } from "./postgen.js";
+import { filterBom, normalizeRootDependency } from "./postgen.js";
 
 it("filter bom tests", () => {
   const bomJson = JSON.parse(
@@ -68,4 +69,59 @@ it("filter bom tests2", () => {
       "bom-ref": "pkg:maven/sec/java-sec-code@1.0.0?type=jar",
     },
   ]);
+});
+
+it("normalizeRootDependency", () => {
+  it("removes orphaned parent dependencies and updates ref for root dependencies", () => {
+    const bomJson = {
+      metadata: { component: { "bom-ref": "root-ref" } },
+      dependencies: [
+        { ref: "A", dependsOn: [] }, // orphaned
+        { ref: "B", dependsOn: ["C"] }, // root
+        { ref: "C", dependsOn: [] },
+      ],
+    };
+    const result = normalizeRootDependency(bomJson);
+    assert.deepStrictEqual(result.dependencies, [
+      { ref: "root-ref", dependsOn: ["C"] },
+    ]);
+  });
+
+  it("does nothing if no parentRef is present", () => {
+    const bomJson = {
+      metadata: { component: {} },
+      dependencies: [
+        { ref: "A", dependsOn: [] },
+        { ref: "B", dependsOn: ["C"] },
+      ],
+    };
+    const result = normalizeRootDependency(bomJson);
+    assert.deepStrictEqual(result.dependencies, [
+      { ref: "A", dependsOn: [] },
+      { ref: "B", dependsOn: ["C"] },
+    ]);
+  });
+
+  it("handles empty dependencies array", () => {
+    const bomJson = {
+      metadata: { component: { "bom-ref": "root-ref" } },
+      dependencies: [],
+    };
+    const result = normalizeRootDependency(bomJson);
+    assert.deepStrictEqual(result.dependencies, []);
+  });
+
+  it("does not remove non-root dependencies", () => {
+    const bomJson = {
+      metadata: { component: { "bom-ref": "root-ref" } },
+      dependencies: [
+        { ref: "A", dependsOn: ["B"] },
+        { ref: "B", dependsOn: [] },
+      ],
+    };
+    const result = normalizeRootDependency(bomJson);
+    assert.deepStrictEqual(result.dependencies, [
+      { ref: "root-ref", dependsOn: ["B"] },
+    ]);
+  });
 });


### PR DESCRIPTION
Add a new postProcess step which will parse all dependencies and
* remove any orphaned dependencies (parent dependency with no `dependsOn`)
* correct any parent dependencies with mismatched `ref` / `bom-ref`

Should help with #489 in constructing a connected dependency graph