### PR TITLE
Fix undefined SrcFile for root pyproject.toml causing crash in postgen.js (#2236)

### DIFF
--- a/contrib/jupyter-notebook-example/README.md
+++ b/contrib/jupyter-notebook-example/README.md
@@ -1,0 +1,37 @@
+# Mixed Python/JavaScript Project Example (Jupyter Notebook case)
+
+This contrib example demonstrates how `cdxgen` handles mixed-language projects.
+It reproduces the bug reported in [#2236](https://github.com/CycloneDX/cdxgen/issues/2236),
+where the root `pyproject.toml` caused a crash due to a missing `SrcFile` property.
+
+## File Structure That Triggers the Bug
+
+jupyter-notebook/
+├── pyproject.toml                           # ← Root file (caused crash)
+├── package.json                             # Node.js dependencies
+├── node_modules/
+│   └── node-gyp/
+│       └── gyp/
+│           └── pyproject.toml
+└── ...
+
+## How to Reproduce
+
+### Quick Setup
+```
+chmod +x setup.sh
+./setup.sh
+```
+
+
+## Manual Steps
+
+`git clone --branch v7.4.5 --depth 1 https://github.com/jupyter/notebook.git`
+`cd notebook`
+`npm install node-gyp --no-audit --no-fund --legacy-peer-deps`
+`cdxgen -r . --type python --output bom.json --no-install-deps`
+
+## Expected Behavior
+Before fix → TypeError: Cannot read properties of undefined (reading 'startsWith')
+
+After fix → SBOM successfully generated (bom.json)

--- a/contrib/jupyter-notebook-example/setup.sh
+++ b/contrib/jupyter-notebook-example/setup.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -e
+
+# Simple setup script to reproduce issue #2236 with the Jupyter Notebook project.
+# It clones the repo, checks for the relevant pyproject.toml files,
+# and runs cdxgen to verify SBOM generation.
+
+REPO=https://github.com/jupyter/notebook.git
+BRANCH=v7.4.5
+DIR=notebook
+
+if [ ! -d "$DIR" ]; then
+  echo "Cloning Jupyter Notebook ($BRANCH)..."
+  git clone --branch $BRANCH --depth 1 $REPO $DIR
+fi
+
+cd $DIR
+echo "Installing Node.js dependencies (this may take a minute)..."
+npm install node-gyp --no-audit --no-fund --legacy-peer-deps
+
+echo "Checking project structure..."
+[ -f pyproject.toml ] && echo "  Found root pyproject.toml" || echo "  Missing root pyproject.toml"
+[ -f package.json ] && echo "  Found package.json" || echo "  Missing package.json"
+[ -f node_modules/node-gyp/gyp/pyproject.toml ] && echo "  Found nested pyproject.toml" || echo "  Missing nested pyproject.toml"
+
+echo "Running cdxgen..."
+cdxgen -r . --type python --output bom.json --no-install-deps
+
+if [ -f bom.json ]; then
+  echo "SBOM successfully generated (bom.json)"
+  if command -v jq >/dev/null; then
+    echo "Components: $(jq '.components | length' bom.json)"
+  fi
+else
+  echo "Error: SBOM not generated"
+  exit 1
+fi
+

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -3694,8 +3694,8 @@ export async function createPythonBom(path, options) {
       }
       tmpParentComponent.properties = tmpParentComponent.properties || [];
       tmpParentComponent.properties.push({
-      name: "SrcFile",
-      value: pyProjectFile
+        name: "SrcFile",
+        value: pyProjectFile,
       });
       parentComponent = tmpParentComponent;
       delete parentComponent.homepage;

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -3692,6 +3692,11 @@ export async function createPythonBom(path, options) {
       if (!tmpParentComponent.version && parentComponent.version) {
         tmpParentComponent.version = parentComponent.version;
       }
+      tmpParentComponent.properties = tmpParentComponent.properties || [];
+      tmpParentComponent.properties.push({
+      name: "SrcFile",
+      value: pyProjectFile
+      });
       parentComponent = tmpParentComponent;
       delete parentComponent.homepage;
       delete parentComponent.repository;


### PR DESCRIPTION
**This PR fixes a `TypeError` in `postgen.js` when analyzing mixed Python/JavaScript projects with `--type python`.**

## Root cause
- When processing the root `pyproject.toml`, a component is created in `lib/cli/index.js` without setting the `SrcFile` property.  

- Later, this component reaches `relativeDir()` in `postgen.js`,  where `SrcFile` is `undefined` , causing: 
 `TypeError: Cannot read properties of undefined (reading 'startsWith')`

## Fix

- Add the `SrcFile` property when creating the parent component for the root `pyproject.toml`.
```tmpParentComponent.properties = tmpParentComponent.properties || [];
tmpParentComponent.properties.push({
  name: "SrcFile",
  value: pyProjectFile,
});
```
- This mirrors how workspace `pyproject.toml` files are handled in lib/helpers/utils.js.


## Testing

Reproduced the crash with the jupyter-notebook repo (v7.4.5) which has both a root `pyproject.toml` and a `node_modules/node-gyp/gyp/pyproject.toml`.

Before fix --> cdxgen crashes when run with `--type python`.

After fix --> SBOM is generated successfully.

cmd: `cdxgen -r . --type python --output bom.json --no-install-deps`


## Notes
- The fix ensures SBOM generation is valid before reaching postgen.
- Does not change the behavior of whether `node_modules` Python deps are included, it only prevents a crash due to missing `SrcFile`.
- Addresses #2236.