### PR TITLE
fix: ignore non-existing paths on post-build container image scans

### DIFF
--- a/lib/managers/binary.js
+++ b/lib/managers/binary.js
@@ -1089,7 +1089,12 @@ export function getBinaryBom(src, binaryBomFile, deepMode) {
   if (DEBUG_MODE) {
     console.log("Executing", BLINT_BIN, args.join(" "));
   }
-  const cwd = lstatSync(src).isDirectory() ? src : dirname(src);
+  const lstatResult = lstatSync(src, {throwIfNoEntry: false})
+  if (!lstatResult) {
+    console.log(`Source path ${src} does not exist`);
+    return false;
+  }
+  const cwd = lstatResult.isDirectory() ? src : dirname(src);
   const result = safeSpawnSync(BLINT_BIN, args, {
     cwd,
   });


### PR DESCRIPTION
Fixes #2254 (cdxgen fails to scan alpine-based docker images with lifecycle post-build) - by ignoring paths that are not present in the container image.