### PR TITLE
Using pnpm on Windows binaries as well

### DIFF
--- a/.github/workflows/binary-builds.yml
+++ b/.github/workflows/binary-builds.yml
@@ -92,11 +92,11 @@ jobs:
           - cmd: |
               # Prepare workspace
               rm -rf ADVANCED.md ci contrib devenv.* pyproject.toml renovate.json semicolon_delimited_script test tools_config uv.lock
-              pnpm install --config.strict-dep-builds=true --virtual-store-dir node_modules/pnpm --prod --package-import-method copy --frozen-lockfile
+              pnpm install:prod --config.node-linker=hoisted
 
               # Generate sbom
               node bin/cdxgen.js -t jar -t js -o sbom-postbuild.cdx.json --include-formulation
-              
+
               # Produce cdxgen binary
               pnpm --package=@appthreat/caxa dlx caxa --input . --output cdxgen -- "{{caxa}}/node_modules/.bin/node" "{{caxa}}/bin/cdxgen.js"
               chmod +x cdxgen
@@ -105,7 +105,7 @@ jobs:
 
               # Prepare for slim binaries
               rm -rf node_modules sbom-postbuild.cdx.json
-              pnpm install --config.strict-dep-builds=true --virtual-store-dir node_modules/pnpm --no-optional --prod --package-import-method copy --frozen-lockfile
+              pnpm install:prod --config.node-linker=hoisted --no-optional
 
               # Generate sbom
               node bin/cdxgen.js -t js --required-only --no-recurse -o sbom-postbuild-js.cdx.json --include-formulation
@@ -126,30 +126,30 @@ jobs:
             cmd: |
               # Prepare workspace
               Remove-Item -Path ADVANCED.md,ci,contrib,devenv.*,pyproject.toml,renovate.json,test,tools_config,uv.lock -Force -Recurse
-              npm install --omit=dev --no-package-lock --no-audit --no-fund --no-progress
+              pnpm install:prod --config.node-linker=hoisted
 
-              # Generate sbom (imprecise)
+              # Generate sbom
               node bin/cdxgen.js -t jar -t js -o sbom-postbuild.cdx.json --include-formulation
-              
+
               # Produce cdxgen binary
-              npx --no-progress --yes @appthreat/caxa --input . --output cdxgen.exe -- "{{caxa}}/node_modules/.bin/node" "{{caxa}}/bin/cdxgen.js"
+              pnpm --package=@appthreat/caxa dlx caxa --input . --output cdxgen.exe -- "{{caxa}}/node_modules/.bin/node" "{{caxa}}/bin/cdxgen.js"
               .\cdxgen.exe --version
               .\cdxgen.exe --help
 
               # Prepare for slim binaries
               Remove-Item node_modules,sbom-postbuild.cdx.json -Force -Recurse
-              npm install --omit=optional --omit=dev --no-package-lock --no-audit --no-fund --no-progress
+              pnpm install:prod --config.node-linker=hoisted --no-optional
 
-              # Generate sbom (imprecise)
+              # Generate sbom
               node bin/cdxgen.js -t js --required-only --no-recurse -o sbom-postbuild-js.cdx.json --include-formulation
 
               # Produce slim cdxgen binary
-              npx --no-progress --yes @appthreat/caxa --input . --output cdxgen-slim.exe -- "{{caxa}}/node_modules/.bin/node" "{{caxa}}/bin/cdxgen.js"
+              pnpm --package=@appthreat/caxa dlx caxa --input . --output cdxgen-slim.exe -- "{{caxa}}/node_modules/.bin/node" "{{caxa}}/bin/cdxgen.js"
               .\cdxgen-slim.exe --version
               .\cdxgen-slim.exe --help
 
               # Produce verify binary
-              npx --no-progress --yes @appthreat/caxa --input . --output cdx-verify.exe -- "{{caxa}}/node_modules/.bin/node" "{{caxa}}/bin/verify.js"
+              pnpm --package=@appthreat/caxa dlx caxa --input . --output cdx-verify.exe -- "{{caxa}}/node_modules/.bin/node" "{{caxa}}/bin/verify.js"
               .\cdx-verify.exe --version
               .\cdx-verify.exe --help
             ext: .exe
@@ -261,7 +261,6 @@ jobs:
             cdxgen-${{ matrix.os }}-${{ matrix.arch }}${{ matrix.libc-suffix }}-slim${{ matrix.ext }}
             cdxgen-${{ matrix.os }}-${{ matrix.arch }}${{ matrix.libc-suffix }}-slim${{ matrix.ext }}.sha256
             cdx-verify-${{ matrix.os }}-${{ matrix.arch }}${{ matrix.libc-suffix }}${{ matrix.ext }}
-
 
   retry:
     needs: binaries

--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     "ajv-formats": "3.0.1",
     "cheerio": "1.1.2",
     "edn-data": "1.1.2",
+    "encoding": "0.1.13",
     "glob": "11.0.3",
     "global-agent": "3.0.0",
     "got": "14.4.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,9 @@ importers:
       edn-data:
         specifier: 1.1.2
         version: 1.1.2
+      encoding:
+        specifier: 0.1.13
+        version: 0.1.13
       glob:
         specifier: 11.0.3
         version: 11.0.3
@@ -292,28 +295,28 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
-    libc: musl
+    libc: [musl]
 
   '@biomejs/cli-linux-arm64@2.2.3':
     resolution: {integrity: sha512-g/Uta2DqYpECxG+vUmTAmUKlVhnGEcY7DXWgKP8ruLRa8Si1QHsWknPY3B/wCo0KgYiFIOAZ9hjsHfNb9L85+g==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
-    libc: glibc
+    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@2.2.3':
     resolution: {integrity: sha512-y76Dn4vkP1sMRGPFlNc+OTETBhGPJ90jY3il6jAfur8XWrYBQV3swZ1Jo0R2g+JpOeeoA0cOwM7mJG6svDz79w==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
-    libc: musl
+    libc: [musl]
 
   '@biomejs/cli-linux-x64@2.2.3':
     resolution: {integrity: sha512-LEtyYL1fJsvw35CxrbQ0gZoxOG3oZsAjzfRdvRBRHxOpQ91Q5doRVjvWW/wepgSdgk5hlaNzfeqpyGmfSD0Eyw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
-    libc: glibc
+    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@2.2.3':
     resolution: {integrity: sha512-Ms9zFYzjcJK7LV+AOMYnjN3pV3xL8Prxf9aWdDVL74onLn5kcvZ1ZMQswE5XHtnd/r/0bnUd928Rpbs14BzVmA==}
@@ -582,13 +585,16 @@ packages:
   bare-events@2.6.1:
     resolution: {integrity: sha512-AuTJkq9XmE6Vk0FJVNq5QxETrSA/vKHarWVBG5l/JbdCL1prJemiyJqUS0jrlXO0MftuPq4m3YVYhoNc5+aE/g==}
 
-  bare-fs@4.2.3:
-    resolution: {integrity: sha512-1aGs5pRVLToMQ79elP+7cc0u0s/wXAzfBv/7hDloT7WFggLqECCas5qqPky7WHCFdsBH5WDq6sD4fAoz5sJbtA==}
+  bare-fs@4.3.1:
+    resolution: {integrity: sha512-UX6lTDlUxjfrwDpr3eShAlpOF3PRHwNSPU7gY6FZU0bY3XivPmbndKCU6P3V0wS3o4xdDKalXqZsyEhYP2l+DQ==}
     engines: {bare: '>=1.16.0'}
     peerDependencies:
       bare-buffer: '*'
+      bare-url: '*'
     peerDependenciesMeta:
       bare-buffer:
+        optional: true
+      bare-url:
         optional: true
 
   bare-os@3.6.2:
@@ -1740,6 +1746,7 @@ snapshots:
       node-gyp: 11.4.2
     transitivePeerDependencies:
       - bare-buffer
+      - bare-url
       - supports-color
     optional: true
 
@@ -2112,7 +2119,7 @@ snapshots:
   bare-events@2.6.1:
     optional: true
 
-  bare-fs@4.2.3:
+  bare-fs@4.3.1:
     dependencies:
       bare-events: 2.6.1
       bare-path: 3.0.0
@@ -2380,7 +2387,6 @@ snapshots:
   encoding@0.1.13:
     dependencies:
       iconv-lite: 0.7.0
-    optional: true
 
   end-of-stream@1.4.5:
     dependencies:
@@ -2942,6 +2948,7 @@ snapshots:
       tunnel-agent: 0.6.0
     transitivePeerDependencies:
       - bare-buffer
+      - bare-url
     optional: true
 
   prettify-xml@1.2.0: {}
@@ -3216,10 +3223,11 @@ snapshots:
       pump: 3.0.3
       tar-stream: 3.1.7
     optionalDependencies:
-      bare-fs: 4.2.3
+      bare-fs: 4.3.1
       bare-path: 3.0.0
     transitivePeerDependencies:
       - bare-buffer
+      - bare-url
     optional: true
 
   tar-stream@3.1.7:


### PR DESCRIPTION
The issue with not being able to use pnpm, was that pnpm links dependencies to its central store, which on Windows is done with 'junctions' -- which are full paths. This means that the packaged binary doesn't work, because it is linking to non-existing files! Hoisting the packages creates a flat node_modules folder without any links.

Also, the package 'encoding' can't be optional on MacOS and Windows.