### PR TITLE
Removed unused overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,9 +2,6 @@
   "name": "@cyclonedx/cdxgen",
   "version": "11.8.0",
   "description": "Creates CycloneDX Software Bill of Materials (SBOM) from source or container image",
-  "homepage": "http://github.com/cyclonedx/cdxgen",
-  "author": "Prabhu Subramanian <prabhu@appthreat.com>",
-  "license": "Apache-2.0",
   "keywords": [
     "sbom",
     "bom",
@@ -18,6 +15,16 @@
     "appsec",
     "scrm"
   ],
+  "homepage": "http://github.com/cyclonedx/cdxgen",
+  "bugs": {
+    "url": "https://github.com/cyclonedx/cdxgen/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/CycloneDX/cdxgen.git"
+  },
+  "license": "Apache-2.0",
+  "author": "Prabhu Subramanian <prabhu@appthreat.com>",
   "contributors": [
     {
       "name": "Erlend Oftedal"
@@ -74,39 +81,78 @@
   },
   "types": "./types/lib/cli/index.d.ts",
   "bin": {
+    "cbom": "bin/cdxgen.js",
+    "cdx-verify": "bin/verify.js",
     "cdxgen": "bin/cdxgen.js",
     "cdxgen-secure": "bin/cdxgen.js",
-    "obom": "bin/cdxgen.js",
-    "cbom": "bin/cdxgen.js",
-    "saasbom": "bin/cdxgen.js",
     "cdxi": "bin/repl.js",
     "evinse": "bin/evinse.js",
-    "cdx-verify": "bin/verify.js"
+    "obom": "bin/cdxgen.js",
+    "saasbom": "bin/cdxgen.js"
   },
+  "files": [
+    "*.js",
+    "lib/**",
+    "bin/",
+    "data/",
+    "types/",
+    "index.cjs"
+  ],
   "scripts": {
-    "test": "poku",
-    "watch": "poku --watch",
-    "lint:check": "biome check",
-    "lint": "biome check --fix",
-    "lint:errors": "biome check --diagnostic-level=error",
     "gen-types": "npx -p typescript tsc",
     "install:frozen": "pnpm install --config.strict-dep-builds=true --frozen-lockfile --package-import-method copy",
-    "install:prod": "pnpm install --config.strict-dep-builds=true --frozen-lockfile --package-import-method copy --prod"
+    "install:prod": "pnpm install --config.strict-dep-builds=true --frozen-lockfile --package-import-method copy --prod",
+    "lint": "biome check --fix",
+    "lint:check": "biome check",
+    "lint:errors": "biome check --diagnostic-level=error",
+    "test": "poku",
+    "watch": "poku --watch"
   },
-  "engines": {
-    "node": ">=20",
-    "pnpm": "10.15.1"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/CycloneDX/cdxgen.git"
-  },
-  "bugs": {
-    "url": "https://github.com/cyclonedx/cdxgen/issues"
-  },
-  "packageManager": "pnpm@10.15.1",
   "lint-staged": {
     "*": "biome check --fix --no-errors-on-unmatched"
+  },
+  "overrides": {
+    "@npmcli/agent": "3.0.0",
+    "@npmcli/fs": "4.0.0",
+    "abbrev": "3.0.1",
+    "cacache": "20.0.0",
+    "chownr": "3.0.0",
+    "debug": "4.4.1",
+    "escape-string-regexp": "4.0.0",
+    "glob": "11.0.3",
+    "iconv-lite": "0.7.0",
+    "ini": "5.0.0",
+    "is-stream": "4.0.1",
+    "isexe": "3.1.1",
+    "json-parse-even-better-errors": "4.0.0",
+    "jwa": "2.0.1",
+    "lru-cache": "11.1.0",
+    "make-fetch-happen": "15.0.1",
+    "minimatch": "10.0.3",
+    "minizlib": "3.0.2",
+    "mkdirp": "3.0.1",
+    "ms": "2.1.3",
+    "negotiator": "0.6.4",
+    "node-gyp": "11.4.2",
+    "nopt": "8.1.0",
+    "on-finished": "2.4.1",
+    "pacote": "21.0.0",
+    "proc-log": "5.0.0",
+    "semver": "7.7.2",
+    "signal-exit": "4.1.0",
+    "sprintf-js": "1.1.3",
+    "ssri": "12.0.0",
+    "statuses": "2.0.1",
+    "strip-json-comments": "3.1.1",
+    "tar": "7.4.3",
+    "type-fest": "4.41.0",
+    "unique-filename": "4.0.0",
+    "unique-slug": "5.0.0",
+    "uuid": "11.1.0",
+    "which": "5.0.0",
+    "write-file-atomic": "6.0.0",
+    "yallist": "5.0.0",
+    "yargs": "17.7.2"
   },
   "dependencies": {
     "@babel/parser": "7.28.4",
@@ -137,6 +183,11 @@
     "yargs": "17.7.2",
     "yoctocolors": "2.1.2"
   },
+  "devDependencies": {
+    "@biomejs/biome": "2.2.3",
+    "poku": "3.0.2",
+    "typescript": "5.9.2"
+  },
   "optionalDependencies": {
     "@appthreat/atom": "2.3.0",
     "@appthreat/cdx-proto": "1.1.4",
@@ -159,18 +210,10 @@
     "sequelize": "6.37.7",
     "sqlite3": "npm:@appthreat/sqlite3@6.0.9"
   },
-  "files": [
-    "*.js",
-    "lib/**",
-    "bin/",
-    "data/",
-    "types/",
-    "index.cjs"
-  ],
-  "devDependencies": {
-    "@biomejs/biome": "2.2.3",
-    "poku": "3.0.2",
-    "typescript": "5.9.2"
+  "packageManager": "pnpm@10.15.1",
+  "engines": {
+    "node": ">=20",
+    "pnpm": "10.15.1"
   },
   "pnpm": {
     "onlyBuiltDependencies": [
@@ -178,36 +221,31 @@
       "@biomejs/biome"
     ],
     "overrides": {
-      "babel-plugin-istanbul": "7.0.0",
-      "brace-expansion": "2.0.2",
-      "jwa": "2.0.1",
-      "glob": "11.0.3",
-      "node-gyp": "11.4.2",
-      "prebuild": "13.0.1",
-      "pacote": "21.0.0",
-      "negotiator": "0.6.4",
       "@npmcli/agent": "3.0.0",
       "@npmcli/fs": "4.0.0",
       "abbrev": "3.0.1",
       "cacache": "20.0.0",
-      "camelcase": "6.3.0",
       "chownr": "3.0.0",
       "debug": "4.4.1",
       "escape-string-regexp": "4.0.0",
+      "glob": "11.0.3",
+      "iconv-lite": "0.7.0",
       "ini": "5.0.0",
       "is-stream": "4.0.1",
       "isexe": "3.1.1",
-      "istanbul-lib-instrument": "6.0.3",
       "json-parse-even-better-errors": "4.0.0",
-      "iconv-lite": "0.7.0",
+      "jwa": "2.0.1",
       "lru-cache": "11.1.0",
+      "make-fetch-happen": "15.0.1",
       "minimatch": "10.0.3",
       "minizlib": "3.0.2",
-      "make-fetch-happen": "15.0.1",
       "mkdirp": "3.0.1",
       "ms": "2.1.3",
+      "negotiator": "0.6.4",
+      "node-gyp": "11.4.2",
       "nopt": "8.1.0",
       "on-finished": "2.4.1",
+      "pacote": "21.0.0",
       "proc-log": "5.0.0",
       "semver": "7.7.2",
       "signal-exit": "4.1.0",
@@ -215,7 +253,6 @@
       "ssri": "12.0.0",
       "statuses": "2.0.1",
       "strip-json-comments": "3.1.1",
-      "supports-color": "8.1.1",
       "tar": "7.4.3",
       "tar-fs": "3.0.9",
       "type-fest": "4.41.0",
@@ -230,55 +267,6 @@
     "ignoredBuiltDependencies": [
       "unrs-resolver"
     ]
-  },
-  "overrides": {
-    "babel-plugin-istanbul": "7.0.0",
-    "brace-expansion": "2.0.2",
-    "jwa": "2.0.1",
-    "glob": "11.0.3",
-    "node-gyp": "11.4.2",
-    "prebuild": "13.0.1",
-    "pacote": "21.0.0",
-    "negotiator": "0.6.4",
-    "@npmcli/agent": "3.0.0",
-    "@npmcli/fs": "4.0.0",
-    "abbrev": "3.0.1",
-    "cacache": "20.0.0",
-    "camelcase": "6.3.0",
-    "chownr": "3.0.0",
-    "debug": "4.4.1",
-    "escape-string-regexp": "4.0.0",
-    "iconv-lite": "0.7.0",
-    "ini": "5.0.0",
-    "is-stream": "4.0.1",
-    "isexe": "3.1.1",
-    "istanbul-lib-instrument": "6.0.3",
-    "json-parse-even-better-errors": "4.0.0",
-    "lru-cache": "11.1.0",
-    "minimatch": "10.0.3",
-    "minizlib": "3.0.2",
-    "make-fetch-happen": "15.0.1",
-    "mkdirp": "3.0.1",
-    "ms": "2.1.3",
-    "nopt": "8.1.0",
-    "on-finished": "2.4.1",
-    "proc-log": "5.0.0",
-    "semver": "7.7.2",
-    "signal-exit": "4.1.0",
-    "sprintf-js": "1.1.3",
-    "ssri": "12.0.0",
-    "statuses": "2.0.1",
-    "strip-json-comments": "3.1.1",
-    "supports-color": "8.1.1",
-    "tar": "7.4.3",
-    "type-fest": "4.41.0",
-    "unique-filename": "4.0.0",
-    "unique-slug": "5.0.0",
-    "uuid": "11.1.0",
-    "which": "5.0.0",
-    "write-file-atomic": "6.0.0",
-    "yallist": "5.0.0",
-    "yargs": "17.7.2"
   },
   "devEngines": {
     "runtime": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,26 +5,21 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  babel-plugin-istanbul: 7.0.0
-  brace-expansion: 2.0.2
   jwa: 2.0.1
   glob: 11.0.3
   node-gyp: 11.4.2
-  prebuild: 13.0.1
   pacote: 21.0.0
   negotiator: 0.6.4
   '@npmcli/agent': 3.0.0
   '@npmcli/fs': 4.0.0
   abbrev: 3.0.1
   cacache: 20.0.0
-  camelcase: 6.3.0
   chownr: 3.0.0
   debug: 4.4.1
   escape-string-regexp: 4.0.0
   ini: 5.0.0
   is-stream: 4.0.1
   isexe: 3.1.1
-  istanbul-lib-instrument: 6.0.3
   json-parse-even-better-errors: 4.0.0
   iconv-lite: 0.7.0
   lru-cache: 11.1.0
@@ -42,7 +37,6 @@ overrides:
   ssri: 12.0.0
   statuses: 2.0.1
   strip-json-comments: 3.1.1
-  supports-color: 8.1.1
   tar: 7.4.3
   tar-fs: 3.0.9
   type-fest: 4.41.0


### PR DESCRIPTION
Noticed these override when renovate tried to update some. Because none of them is actually in our dependency-tree, I've removed them all from override, so renovate won't run unnecessarily.

Also ran 'sort-package-json' to get alphabetical order to dependencies, overrides and some (apparently?) more logical sorting of the package.json.