### PR TITLE
Added support for changed (bug?) format with oras 1.3.0

### DIFF
--- a/lib/managers/oci.js
+++ b/lib/managers/oci.js
@@ -35,12 +35,26 @@ export function getBomWithOras(image, platform = undefined) {
     const out = Buffer.from(result.stdout).toString();
     try {
       const manifestObj = JSON.parse(out);
-      if (
-        manifestObj?.manifests?.length &&
-        Array.isArray(manifestObj.manifests) &&
-        manifestObj.manifests[0]?.reference
-      ) {
-        const imageRef = manifestObj.manifests[0].reference;
+      let manifest;
+      if (manifestObj?.manifests) {
+        if (
+          manifestObj?.manifests?.length &&
+          Array.isArray(manifestObj.manifests) &&
+          manifestObj.manifests[0]?.reference
+        ) {
+          manifest = manifestObj.manifests[0];
+        }
+      } else if (manifestObj?.referrers) {
+        if (
+          manifestObj?.referrers?.length &&
+          Array.isArray(manifestObj.referrers) &&
+          manifestObj.referrers[0]?.reference
+        ) {
+          manifest = manifestObj.referrers[0];
+        }
+      }
+      if (manifest != null) {
+        const imageRef = manifest.reference;
         const tmpDir = getTmpDir();
         result = safeSpawnSync("oras", ["pull", imageRef, "-o", tmpDir], {
           shell: isWin,


### PR DESCRIPTION
The update to the GH action 'oras-project/setup-oras' brought with it v1.3.0 of oras. This version gives a different output for `oras discover` compared to the previous version(s).

The question is, if this output it correct, because the [official documentation](https://oras.land/docs/how_to_guides/format_output/#oras-discover) still shows the old output!

Old:
```
oras discover --format json --platform linux/amd64 ghcr.io/cyclonedx/opensuse-lang@sha256:84b639892598fb3c92e4511e9d0ecf348b9ece28bef3f40ca25fc0d002867be6 
{
  "manifests": [
    {
      "reference": "ghcr.io/cyclonedx/opensuse-lang@sha256:21868b1158e16efc9fbafce612f4fa610917b47767bb0f814ba717f06ce96c88",
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "digest": "sha256:21868b1158e16efc9fbafce612f4fa610917b47767bb0f814ba717f06ce96c88",
      "size": 777,
      "annotations": {
        "org.opencontainers.image.created": "2025-09-10T18:40:31Z"
      },
      "artifactType": "sbom/cyclonedx"
    }
  ]
}
```
New:
```
oras discover --format json --platform linux/amd64 ghcr.io/cyclonedx/opensuse-lang@sha256:84b639892598fb3c92e4511e9d0ecf348b9ece28bef3f40ca25fc0d002867be6  
{
  "reference": "ghcr.io/cyclonedx/opensuse-lang@sha256:84b639892598fb3c92e4511e9d0ecf348b9ece28bef3f40ca25fc0d002867be6",
  "mediaType": "application/vnd.oci.image.manifest.v1+json",
  "digest": "sha256:84b639892598fb3c92e4511e9d0ecf348b9ece28bef3f40ca25fc0d002867be6",
  "size": 678,
  "referrers": [
    {
      "reference": "ghcr.io/cyclonedx/opensuse-lang@sha256:21868b1158e16efc9fbafce612f4fa610917b47767bb0f814ba717f06ce96c88",
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "digest": "sha256:21868b1158e16efc9fbafce612f4fa610917b47767bb0f814ba717f06ce96c88",
      "size": 777,
      "annotations": {
        "org.opencontainers.image.created": "2025-09-10T18:40:31Z"
      },
      "artifactType": "sbom/cyclonedx",
      "referrers": []
    }
  ]
}
```
