### PR TITLE
Bazel can also be downloaded from Nexus when running on self-hosted

### DIFF
--- a/ci/images/Dockerfile.java11
+++ b/ci/images/Dockerfile.java11
@@ -87,7 +87,7 @@ RUN set -e; \
  && curl -L --output /usr/bin/bazel \
       $GITHUB_URL/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-${GOBIN_VERSION} \
  && chmod +x /usr/bin/bazel \
- && bazel --version \
+ && BAZELISK_BASE_URL=$GITHUB_URL/bazelbuild/bazel/releases/download bazel --version \
  && npm install -g \
       corepack \
  && rm -rf $HOME/.npmrc $HOME/.pip \

--- a/ci/images/Dockerfile.java17
+++ b/ci/images/Dockerfile.java17
@@ -91,7 +91,7 @@ RUN set -e; \
  && curl -L --output /usr/bin/bazel \
       $GITHUB_URL/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-${GOBIN_VERSION} \
  && chmod +x /usr/bin/bazel \
- && bazel --version \
+ && BAZELISK_BASE_URL=$GITHUB_URL/bazelbuild/bazel/releases/download bazel --version \
  && pip install \
       --no-cache-dir \
       --target ${PYTHONPATH} \

--- a/ci/images/Dockerfile.java17-slim
+++ b/ci/images/Dockerfile.java17-slim
@@ -86,7 +86,7 @@ RUN set -e; \
  && curl -L --output /usr/bin/bazel \
       $GITHUB_URL/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-${GOBIN_VERSION} \
  && chmod +x /usr/bin/bazel \
- && bazel --version \
+ && BAZELISK_BASE_URL=$GITHUB_URL/bazelbuild/bazel/releases/download bazel --version \
  && npm install -g \
       corepack \
  && rm -rf $HOME/.npmrc $HOME/.pip \

--- a/ci/images/Dockerfile.node20
+++ b/ci/images/Dockerfile.node20
@@ -91,7 +91,7 @@ RUN set -e; \
  && curl -L --output /usr/bin/bazel \
       $GITHUB_URL/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-${GOBIN_VERSION} \
  && chmod +x /usr/bin/bazel \
- && bazel --version \
+ && BAZELISK_BASE_URL=$GITHUB_URL/bazelbuild/bazel/releases/download bazel --version \
  && rm -rf $HOME/.npmrc $HOME/.pip \
  && zypper clean -a \
  && if [ -n "$SUSE_REPO" ]; then \

--- a/ci/images/Dockerfile.python311
+++ b/ci/images/Dockerfile.python311
@@ -121,7 +121,7 @@ RUN set -e; \
  && curl -L --output /usr/bin/bazel \
       $GITHUB_URL/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-${GOBIN_VERSION} \
  && chmod +x /usr/bin/bazel \
- && bazel --version \
+ && BAZELISK_BASE_URL=$GITHUB_URL/bazelbuild/bazel/releases/download bazel --version \
  && rm -rf $HOME/.npmrc $HOME/.pip \
  && zypper clean -a \
  && if [ -n "$SUSE_REPO" ]; then \

--- a/ci/images/Dockerfile.python312
+++ b/ci/images/Dockerfile.python312
@@ -114,7 +114,7 @@ RUN set -e; \
  && curl -L --output /usr/bin/bazel \
       $GITHUB_URL/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-${GOBIN_VERSION} \
  && chmod +x /usr/bin/bazel \
- && bazel --version \
+ && BAZELISK_BASE_URL=$GITHUB_URL/bazelbuild/bazel/releases/download bazel --version \
  && rm -rf $HOME/.npmrc $HOME/.pip \
  && zypper clean -a \
  && if [ -n "$SUSE_REPO" ]; then \

--- a/ci/images/Dockerfile.python313
+++ b/ci/images/Dockerfile.python313
@@ -106,7 +106,7 @@ RUN set -e; \
  && curl -L --output /usr/bin/bazel \
       $GITHUB_URL/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-${GOBIN_VERSION} \
  && chmod +x /usr/bin/bazel \
- && bazel --version \
+ && BAZELISK_BASE_URL=$GITHUB_URL/bazelbuild/bazel/releases/download bazel --version \
  && rm -rf $HOME/.npmrc $HOME/.pip \
  && zypper clean -a \
  && if [ -n "$SUSE_REPO" ]; then \

--- a/ci/images/Dockerfile.python36
+++ b/ci/images/Dockerfile.python36
@@ -109,7 +109,7 @@ RUN set -e; \
  && curl -L --output /usr/bin/bazel \
       $GITHUB_URL/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-${GOBIN_VERSION} \
  && chmod +x /usr/bin/bazel \
- && bazel --version \
+ && BAZELISK_BASE_URL=$GITHUB_URL/bazelbuild/bazel/releases/download bazel --version \
  && npm install -g \
       corepack \
  && rm -rf $HOME/.npmrc $HOME/.pip \

--- a/ci/images/opensuse/Dockerfile.python310
+++ b/ci/images/opensuse/Dockerfile.python310
@@ -116,7 +116,7 @@ RUN set -e; \
  && curl -L --output /usr/bin/bazel \
       $GITHUB_URL/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-${GOBIN_VERSION} \
  && chmod +x /usr/bin/bazel \
- && bazel --version \
+ && BAZELISK_BASE_URL=$GITHUB_URL/bazelbuild/bazel/releases/download bazel --version \
  && rm -rf $HOME/.npmrc $HOME/.pip \
  && zypper clean -a \
  && if [ -n "$OPENSUSE_REPO" ]; then \

--- a/ci/images/opensuse/Dockerfile.python39
+++ b/ci/images/opensuse/Dockerfile.python39
@@ -105,7 +105,7 @@ RUN set -e; \
  && curl -L --output /usr/bin/bazel \
       $GITHUB_URL/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-${GOBIN_VERSION} \
  && chmod +x /usr/bin/bazel \
- && bazel --version \
+ && BAZELISK_BASE_URL=$GITHUB_URL/bazelbuild/bazel/releases/download bazel --version \
  && rm -rf $HOME/.npmrc $HOME/.pip \
  && zypper clean -a \
  && if [ -n "$OPENSUSE_REPO" ]; then \

--- a/ci/images/opensuse/Dockerfile.rolling
+++ b/ci/images/opensuse/Dockerfile.rolling
@@ -144,7 +144,7 @@ RUN set -e; \
  && curl -L --output /usr/bin/bazel \
       $GITHUB_URL/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-${GOBIN_VERSION} \
  && chmod +x /usr/bin/bazel \
- && bazel --version \
+ && BAZELISK_BASE_URL=$GITHUB_URL/bazelbuild/bazel/releases/download bazel --version \
  && rm -rf $HOME/.npmrc $HOME/.pip \
  && zypper clean -a \
  && if [ -n "$OPENSUSE_REPO" ]; then \


### PR DESCRIPTION
Bazelisk installs itself as the binary `bazel` and will download the actual bazel when called. The default URL is on GitHub, which we already had proxied in Nexus.