### PR TITLE
Set explicit versions for older Node

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -103,7 +103,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ['20', '21', '22', '23', '24.7.0']
+        node-version: ['20.19.5', '21.7.3', '22.19.0', '23.11.1', '24.7.0']
         os: ['ubuntu-22.04', 'ubuntu-24.04', 'windows-latest', 'windows-11-arm', 'ubuntu-22.04-arm', 'ubuntu-24.04-arm', 'macos-15', 'macos-latest']
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
For Node <24 we didn't set explicit versions. Set these to the current latest, so we know what we are using exactly -- for easier troubleshooting on errors.