### PR TITLE
config: renovate ignore github action as author

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -18,6 +18,7 @@
   ],
   "labels": ["dependency"],
   "minimumReleaseAge": "3 days",
+  "gitignoreUnstable": ["github-actions[bot]@users.noreply.github.com"],
   "packageRules": [
     {
       "matchDepTypes": ["engines"],


### PR DESCRIPTION
Recognize github actions bot as ignore author, so that Renovate continues with subsequent updates