### PR TITLE
config(renovate): docker pin digest

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,6 +14,7 @@
     ":enableVulnerabilityAlerts",
     "customManagers:biomeVersions",
     "customManagers:dockerfileVersions",
+    "docker:pinDigests",
     "helpers:pinGitHubActionDigestsToSemver"
   ],
   "labels": ["dependency"],


### PR DESCRIPTION
Best practice to pin docker image digests.  We are already doing this for GitHub action versions