### PR TITLE
Added minimum release age for dependencies in pnpm

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,1 @@
+minimumReleaseAge: '4320'


### PR DESCRIPTION
This fixes #2290. Minimum release age set to 3 days.