### PR TITLE
Update `engines > pnpm` to allow future pnpm versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -298,7 +298,7 @@
   "packageManager": "pnpm@10.17.1",
   "engines": {
     "node": ">=20",
-    "pnpm": "10.17.1"
+    "pnpm": ">=10.17.1"
   },
   "pnpm": {
     "onlyBuiltDependencies": [


### PR DESCRIPTION
Currently, the pnpm version installed on developer machines must match exactly, leading to failure otherwise.

Update `engines > pnpm` in the `package.json` file to be permissive, i.e. enforce a minimum version *but also allow later versions* to be used. (Matching how `engines > node` is set up.)

Fixes https://github.com/CycloneDX/cdxgen/issues/2385