### PR TITLE
Fix issue 2388: spawnSync npm ENOENT error

### DIFF
--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -2960,6 +2960,7 @@ export async function createNodejsBom(path, options) {
       );
       const result = safeSpawnSync(pkgMgr, installArgs, {
         cwd: basePath,
+        shell: isWin,
       });
       if (result.status !== 0 || result.error) {
         console.error(


### PR DESCRIPTION
This seems to fix the issue with spawnSync npm install: https://github.com/CycloneDX/cdxgen/issues/2388

<img width="2797" height="1172" alt="495271581-92ed028f-d96b-4bac-8c1f-bc0e08f98271" src="https://github.com/user-attachments/assets/38796aef-6504-4468-af94-8389c2d6ee8d" />


