### PR TITLE
MacOS 13 is being phased out

### DIFF
--- a/.github/workflows/binary-builds.yml
+++ b/.github/workflows/binary-builds.yml
@@ -60,10 +60,10 @@ jobs:
           # Set all the runners
           - os: darwin
             arch: amd64
-            runner: macos-13
+            runner: macos-14-large
           - os: darwin
             arch: arm64
-            runner: macos-13-xlarge
+            runner: macos-14
           - os: linux
             arch: amd64
             runner: ubuntu-24.04


### PR DESCRIPTION
MacOS 13 is being phased out, so we have to update to 14 for the binary builds.
https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/