### PR TITLE
Tumbleweed replaced java24 with 25

### DIFF
--- a/ci/images/opensuse/Dockerfile.rolling
+++ b/ci/images/opensuse/Dockerfile.rolling
@@ -92,7 +92,7 @@ RUN set -e; \
           gcc15-c++ \
           gcc15-fortran \
           git-core \
-          java-24-openjdk-devel \
+          java-25-openjdk-devel \
           libicu-devel \
           make \
           python313 \


### PR DESCRIPTION
OpenSuse just dropped java24 from the tumbleweed repos and replaced it with 25.