### PR TITLE
OpenSuse removed java24 and updated to 25

### DIFF
--- a/ci/images/opensuse/Dockerfile.python310
+++ b/ci/images/opensuse/Dockerfile.python310
@@ -67,7 +67,7 @@ RUN set -e; \
           gcc13-c++ \
           gcc13-fortran \
           git-core \
-          java-24-openjdk-devel \
+          java-25-openjdk-devel \
           libxml2-devel \
           make \
           nodejs22 \

--- a/ci/images/opensuse/Dockerfile.python39
+++ b/ci/images/opensuse/Dockerfile.python39
@@ -63,7 +63,7 @@ RUN set -e; \
           gcc13-c++ \
           gcc13-fortran \
           git-core \
-          java-24-openjdk-devel \
+          java-25-openjdk-devel \
           libxml2-devel \
           make \
           nodejs22 \


### PR DESCRIPTION
Both OpenSuse Python images also include java.