### PR TITLE
build(renovate): disable digest pins for cyclonedx/cdxgen-ruby-builder

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/cyclonedx/cdxgen-ruby-builder:master@sha256:fdb82fbf1834e4610e57aa426c441f05c82a1193e8b6434abddf40b485fb6561 AS base
+FROM ghcr.io/cyclonedx/cdxgen-ruby-builder:master AS base
 
 ARG SWIFT_SIGNING_KEY=52BB7E3DE28A71BE22EC05FFEF80A866B47A981F
 ARG SWIFT_PLATFORM=ubi9

--- a/ci/Dockerfile-deno
+++ b/ci/Dockerfile-deno
@@ -1,4 +1,4 @@
-FROM ghcr.io/cyclonedx/cdxgen-ruby-builder:master@sha256:fdb82fbf1834e4610e57aa426c441f05c82a1193e8b6434abddf40b485fb6561
+FROM ghcr.io/cyclonedx/cdxgen-ruby-builder:master
 
 LABEL maintainer="cyclonedx" \
       org.opencontainers.image.authors="Prabhu Subramanian <prabhu@appthreat.com>" \

--- a/renovate.json
+++ b/renovate.json
@@ -69,6 +69,13 @@
       "automergeType": "branch"
     },
     {
+      "description": "Disable digest pins for cyclonedx/cdxgen-ruby-builder",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["cyclonedx/cdxgen-ruby-builder"],
+      "matchUpdateTypes": ["digest"],
+      "enabled": false
+    },
+    {
       "description": "Wait 14 days before updating Node.js versions",
       "matchPackageNames": ["/(?:^|/)node$/"],
       "minimumReleaseAge": "14 days"


### PR DESCRIPTION
As per https://github.com/CycloneDX/cdxgen/pull/2420#issuecomment-3374168126