### PR TITLE
config(renovate): remove enabled managers

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,13 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "enabledManagers": [
-    "dockerfile",
-    "github-actions",
-    "jsonata",
-    "npm",
-    "nvm",
-    "custom.regex"
-  ],
   "extends": [
     "config:recommended",
     ":separateMultipleMajorReleases",


### PR DESCRIPTION
Now that we've gradually migrated across, this shouldn't be required now