### PR TITLE
Commented out 'pixi', main branch isn't working anymore

### DIFF
--- a/.github/workflows/repotests.yml
+++ b/.github/workflows/repotests.yml
@@ -648,15 +648,15 @@ jobs:
         run: |
           bin/cdxgen.js -t python repotests/impacket -o bomresults/impacket.json --fail-on-error
         shell: bash
-      - name: repotests pixi
-        run: |
-          mkdir pixi-sample
-          cd pixi-sample
-          curl -LO https://raw.githubusercontent.com/prefix-dev/pixi/main/pixi.lock
-          curl -LO https://raw.githubusercontent.com/prefix-dev/pixi/main/pixi.toml
-          cd ..
-          bin/cdxgen.js -t python pixi-sample -o bomresults/bom-pixi.json -p --fail-on-error
-        shell: bash
+#      - name: repotests pixi
+#        run: |
+#          mkdir pixi-sample
+#          cd pixi-sample
+#          curl -LO https://raw.githubusercontent.com/prefix-dev/pixi/main/pixi.lock
+#          curl -LO https://raw.githubusercontent.com/prefix-dev/pixi/main/pixi.toml
+#          cd ..
+#          bin/cdxgen.js -t python pixi-sample -o bomresults/bom-pixi.json -p --fail-on-error
+#        shell: bash
       - name: repotests shiftleft-java-example
         run: |
           bin/cdxgen.js -p -r -t java repotests/shiftleft-java-example -o bomresults/bom-java.json --generate-key-and-sign


### PR DESCRIPTION
We are checkout out files from the main branch, was just received an update that broke our tests.

We need to analyze the issue -- do we have a bug or is their file broken? For now though, I commented out this test because all PRs are failing because of it!