### PR TITLE
Excluding amd64 for darwin

### DIFF
--- a/.github/workflows/binary-builds.yml
+++ b/.github/workflows/binary-builds.yml
@@ -51,6 +51,9 @@ jobs:
         arch: [ amd64, arm64]
         libc: [ gnu, musl ]
         exclude:
+          # No more intel on macos
+          - os: darwin
+            arch: amd64
           # musl can only be built on linux
           - os: darwin
             libc: musl
@@ -58,9 +61,6 @@ jobs:
             libc: musl
         include:
           # Set all the runners
-          - os: darwin
-            arch: amd64
-            runner: macos-14-large
           - os: darwin
             arch: arm64
             runner: macos-14


### PR DESCRIPTION
It seems the intel runners are not working anymore and therefore failing all our PRs. So, we're not excluding amd64 architecture for darwin.