### PR TITLE
Run java11 on hosted runner

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -114,6 +114,7 @@ jobs:
             distro: temurin
 
           - lang: java11
+            runner: macos-hosted
             base-image:
               additional-image: java11-slim
             cdxgen-image:


### PR DESCRIPTION
GH's runners are having issues building this image, so I moved to to our hosted runner.