### PR TITLE
[build] Do not run 'pnpm test' in these workflows

### DIFF
--- a/.github/workflows/dockertests.yml
+++ b/.github/workflows/dockertests.yml
@@ -38,10 +38,9 @@ jobs:
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
           node-version-file: .nvmrc
-      - name: pnpm install, build and test
+      - name: pnpm install
         run: |
           pnpm install --config.strict-dep-builds=true --package-import-method copy
-          pnpm test
           mkdir -p bomresults
         env:
           CI: true
@@ -99,10 +98,9 @@ jobs:
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
           node-version-file: .nvmrc
-      - name: pnpm install, build and test
+      - name: pnpm install
         run: |
           pnpm install --config.strict-dep-builds=true --package-import-method copy
-          pnpm test
           mkdir -p bomresults repotests
         env:
           CI: true

--- a/.github/workflows/repotests.yml
+++ b/.github/workflows/repotests.yml
@@ -12,6 +12,7 @@ on:
       - 'lib/**'
       - 'package.json'
       - 'pnpm-lock.yaml'
+      - '!**.poku.js'
   workflow_dispatch:
 
 concurrency:
@@ -232,10 +233,9 @@ jobs:
       - name: Setup Nexus usage
         if: matrix.os == 'self-hosted-ubuntu'
         run: echo "registry=$NEXUS_URL" > .npmrc
-      - name: pnpm install, build and test
+      - name: pnpm install
         run: |
           pnpm install --config.strict-dep-builds=true --package-import-method copy
-          pnpm test
           mkdir -p repotests
           mkdir -p bomresults
           mkdir -p denoresults


### PR DESCRIPTION
Let the `nodejs`-workflow handle unit tests and not have all other tests fail on unit-tests as well.