### PR TITLE
Added back amd64 build on MacOS

### DIFF
--- a/.github/workflows/binary-builds.yml
+++ b/.github/workflows/binary-builds.yml
@@ -48,9 +48,6 @@ jobs:
         arch: [ amd64, arm64]
         libc: [ gnu, musl ]
         exclude:
-          # No more intel on macos
-          - os: darwin
-            arch: amd64
           # musl can only be built on linux
           - os: darwin
             libc: musl
@@ -58,6 +55,9 @@ jobs:
             libc: musl
         include:
           # Set all the runners
+          - os: darwin
+            arch: amd64
+            runner: macos-14-large
           - os: darwin
             arch: arm64
             runner: macos-14


### PR DESCRIPTION
The problems with the GitHub runners for MacOS amd64 seem to have been temporary. Adding them back until they are officially no longer supported.