### PR TITLE
Remove insecure npm install -g references from documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ Sections include:
 
 ## For Contributors / Developers
 ```shell
-npm install
-npx cdxgen
+pnpm install
+pnpm dlx cdxgen
 ```
 
 ## Installing
@@ -356,13 +356,13 @@ sudo npm install -g @cyclonedx/cdxgen-plugins-bin
 ```
 
 
-## Plugins (npx)
+## Plugins (pnpm)
 
 `cdxgen` can be extended with external binary plugins to support more SBOM use cases.  
 These are now installed as optional dependencies and can be used without a global install.
 
 ```shell
-npx @cyclonedx/cdxgen-plugins-bin
+pnpm dlx @cyclonedx/cdxgen-plugins-bin
 ```
 
 
@@ -448,14 +448,14 @@ cdx-verify -i bom.json --public-key public.key
 ```
 
 
-### Verifying the signature (npx)
+### Verifying the signature (pnpm)
 
 Use the bundled `cdx-verify` command, which supports verifying a single signature added at the BOM level.
 
-You can run it directly using npx (no global install needed):
+You can run it directly using pnpm (no global install needed):
 
 ```shell
-npx @cyclonedx/cdxgen cdx-verify -i bom.json --public-key public.key
+pnpm dlx @cyclonedx/cdxgen cdx-verify -i bom.json --public-key public.key
 ```
 
 
@@ -578,7 +578,7 @@ To quickly test the latest main branch without installing globally, you can use 
 ```shell
 corepack enable
 pnpm install --prefer-offline
-pnpm exec cdxgen --help
+pnpm dlx cdxgen --help
 ```
 
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,8 +8,8 @@ cdxgen is available as an npm package, container image, and single application e
 
 ## For Contributors / Developers
 ```shell
-npm install
-npx cdxgen
+pnpm install
+pnpm dlx cdxgen
 ```
 
 ## Installation
@@ -73,8 +73,8 @@ cdxgen -t c -o bom.json
 
 ## For Contributors / Developers
 ```shell
-npm install
-npx cdxgen
+pnpm install
+pnpm dlx cdxgen
 ```
 
 
@@ -259,14 +259,14 @@ npm install -g @cyclonedx/cdxgen
 cdx-verify -i bom.json --public-key public.key
 ```
 
-### Verifying the signature (npx)
+### Verifying the signature (pnpm)
 
 Use the bundled `cdx-verify` command, which supports verifying a single signature added at the BOM level.
 
-You can run it directly using npx (no global install needed):
+You can run it directly using pnpm (no global install needed):
 
 ```shell
-npx @cyclonedx/cdxgen cdx-verify -i bom.json --public-key public.key
+pnpm dlx @cyclonedx/cdxgen cdx-verify -i bom.json --public-key public.key
 ```
 
 ### Custom verification tool (Node.js example)


### PR DESCRIPTION
Fixes #2259

This pull request updates all documentation references that previously suggested installing @cyclonedx/cdxgen globally with npm install -g.

Global installations are discouraged due to security risks and versioning issues. The recommended approach is now to use npx or local project installs via package.json.

Changes made:

Replaced all npm install -g @cyclonedx/cdxgen commands with npx @cyclonedx/cdxgen

Updated plugin installation examples to use pnpm add instead of sudo npm install -g

Reworded “Testing main branch” section to clarify safer testing instructions without global installs

Ensured consistency across all README files

Why:

This improves security, avoids version conflicts, and aligns documentation with modern npm and pnpm practices.