### PR TITLE
Updated all images to use semver tags

### DIFF
--- a/ci/images/Dockerfile.dotnet7
+++ b/ci/images/Dockerfile.dotnet7
@@ -1,5 +1,5 @@
 # Base-image
-FROM registry.suse.com/bci/dotnet-sdk:7.0@sha256:87340d120fe0981cd0d54e86a1136bc59609201f50398d4c16801edc0121a619 AS base
+FROM registry.suse.com/bci/dotnet-sdk:7.0.18 AS base
 
 ARG GITHUB_URL=https://github.com
 ARG NODEJS_DIST_URL

--- a/ci/images/alpine/Dockerfile.python313
+++ b/ci/images/alpine/Dockerfile.python313
@@ -1,5 +1,5 @@
 # Base-image
-FROM python:3.13-alpine3.22@sha256:e5fa639e49b85986c4481e28faa2564b45aa8021413f31026c3856e5911618b1 AS base
+FROM python:3.13.8-alpine AS base
 
 ARG ALPINE_REPO
 ARG NODEJS_DIST_URL

--- a/ci/images/alpine/Dockerfile.rust1
+++ b/ci/images/alpine/Dockerfile.rust1
@@ -1,5 +1,5 @@
 # Base-image
-FROM rust:1.91.0-alpine3.22@sha256:a3e3d30122c08c0ed85dcd8867d956f066be23c32ed67a0453bc04ce478ad69b AS base
+FROM rust:1.91.0-alpine AS base
 
 ARG ALPINE_REPO
 ARG NODEJS_DIST_URL

--- a/ci/images/debian/Dockerfile.dotnet6
+++ b/ci/images/debian/Dockerfile.dotnet6
@@ -1,5 +1,5 @@
 # Base-image
-FROM mcr.microsoft.com/dotnet/sdk:6.0-bookworm-slim@sha256:43b7b0469f4565201bc18bae6a8bb49a0336181c7dee7d7747b86ffe0fa63986 AS base
+FROM mcr.microsoft.com/dotnet/sdk:6.0.427-1-bookworm-slim AS base
 
 ARG DEBIAN_REPO
 ARG GITHUB_RAW_URL=https://raw.githubusercontent.com

--- a/ci/images/debian/Dockerfile.dotnet8
+++ b/ci/images/debian/Dockerfile.dotnet8
@@ -1,5 +1,5 @@
 # Base-image
-FROM mcr.microsoft.com/dotnet/sdk:8.0.416@sha256:a87db299d259cec53210df406cd5e51f900a0c6d938fe56d5f392629c0505d75 AS base
+FROM mcr.microsoft.com/dotnet/sdk:8.0.415-bookworm-slim AS base
 
 ARG DEBIAN_REPO
 ARG GITHUB_RAW_URL=https://raw.githubusercontent.com

--- a/ci/images/debian/Dockerfile.dotnet9
+++ b/ci/images/debian/Dockerfile.dotnet9
@@ -1,5 +1,5 @@
 # Base-image
-FROM mcr.microsoft.com/dotnet/sdk:9.0.307@sha256:1ea5b7f2154cbd1e20a336cb56957dba30a7ce30ef5c1c032a37c42801594713 AS base
+FROM mcr.microsoft.com/dotnet/sdk:9.0.306-bookworm-slim AS base
 
 ARG DEBIAN_REPO
 ARG GITHUB_RAW_URL=https://raw.githubusercontent.com

--- a/ci/images/debian/Dockerfile.ruby26
+++ b/ci/images/debian/Dockerfile.ruby26
@@ -1,5 +1,5 @@
 # Base-image
-FROM ruby:2.6.10-slim@sha256:3d641979a7dc819b4c253dc62d2f74800817053247005f72b871d164498109df AS base
+FROM ruby:2.6.9-slim-bullseye AS base
 
 ARG ATOM_RUBY_VERSION=3.4.5
 ARG DEBIAN_REPO

--- a/ci/images/debian/Dockerfile.ruby33
+++ b/ci/images/debian/Dockerfile.ruby33
@@ -1,5 +1,5 @@
 # Base-image
-FROM ruby:3.3.10-slim@sha256:89e42af4e20259d2ff292ddca0e88344c15c01133dcd70d4e422a648887ee00e AS base
+FROM ruby:3.3.9-slim-trixie AS base
 
 ARG ATOM_RUBY_VERSION=3.4.5
 ARG DEBIAN_REPO

--- a/ci/images/debian/Dockerfile.ruby34
+++ b/ci/images/debian/Dockerfile.ruby34
@@ -1,5 +1,5 @@
 # Base-image
-FROM ruby:3.4.7-slim@sha256:2de50c072bed1bdaf5e6b6c132fb2bc56f03700046ad95a515b4111203bf5034 AS base
+FROM ruby:3.4.6-slim-trixie AS base
 
 ARG DEBIAN_REPO
 ARG GITHUB_RAW_URL=https://raw.githubusercontent.com

--- a/ci/images/opensuse/Dockerfile.python310
+++ b/ci/images/opensuse/Dockerfile.python310
@@ -1,5 +1,5 @@
 # Base-image
-FROM registry.opensuse.org/opensuse/bci/python:3.10@sha256:391f2259cc0b729e790f8328592c266188b6bad6af92f987ae024e1f28ef8b8a AS base
+FROM registry.opensuse.org/opensuse/bci/python:3.10.16 AS base
 
 ARG GITHUB_URL=https://github.com
 # renovate: datasource=golang-version depName=golang

--- a/ci/images/ubuntu/Dockerfile.dotnet10
+++ b/ci/images/ubuntu/Dockerfile.dotnet10
@@ -1,5 +1,5 @@
 # Base-image
-FROM mcr.microsoft.com/dotnet/sdk:10.0@sha256:c7445f141c04f1a6b454181bd098dcfa606c61ba0bd213d0a702489e5bd4cd71 AS base
+FROM mcr.microsoft.com/dotnet/sdk:10.0.100-noble AS base
 
 ARG GITHUB_RAW_URL=https://raw.githubusercontent.com
 ARG GITHUB_URL=https://github.com


### PR DESCRIPTION
Updated all images to use semver tags, where possible.

Exception is the dotnet alpine image, since microsoft doesn't tag semver with non-versioned alpine-suffix!