### PR TITLE
[maven] Save mvn tree when DEBUG_MODE is set

### DIFF
--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -1721,9 +1721,8 @@ export async function createJavaBom(path, options) {
         result?.status !== 0 ||
         result?.error
       ) {
-        const tempDir = mkdtempSync(join(getTmpDir(), "cdxmvn-"));
-        const tempMvnTree = join(tempDir, "mvn-tree.txt");
-        const tempMvnParentTree = join(tempDir, "mvn-parent-tree.txt");
+        const tempMvnTree = join("target", "cdxgen-mvn-tree.txt");
+        const tempMvnParentTree = join("target", "cdxgen-mvn-parent-tree.txt");
         let mvnTreeArgs = ["dependency:tree", `-DoutputFile=${tempMvnTree}`];
         let addArgs = "";
         if (process.env.MVN_ARGS) {
@@ -1889,7 +1888,9 @@ export async function createJavaBom(path, options) {
                 );
               }
             }
-            unlinkSync(tempMvnTree);
+            if (!DEBUG_MODE) {
+              unlinkSync(tempMvnTree);
+            }
           }
         }
       }


### PR DESCRIPTION
To be able to debug issues with the maven tree, the following changes where made:
- Write output to 'target' directory instead of system temp -- this is a dir maven also uses, so should be deleted whenever `mvn clean` is called
- Do not delete the file when `CDXGEN_DEBUG_MODE` is set