### PR TITLE
[docker, ruby2.x] Added '.' at the wrong place

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -186,13 +186,13 @@ jobs:
           - lang: python3.13
             distro: alpine
 
-          - lang: ruby.25
+          - lang: ruby2.5
             fix-qemu: true
             skip-arm: true
             base-image:
               name: sle
 
-          - lang: ruby.26
+          - lang: ruby2.6
             distro: debian
             skip-arm: true
 


### PR DESCRIPTION
With the changes for renovate update patterns, the '.' in the version was put in the wrong place for the ruby 2.x images.