### PR TITLE
Support Ruby lockfile generation on Alpine image

### DIFF
--- a/ci/images/alpine/Dockerfile.ruby3.4
+++ b/ci/images/alpine/Dockerfile.ruby3.4
@@ -49,6 +49,7 @@ RUN set -e; \
       py3-pip \
       py3-virtualenv \
       tar \
+ && apk add --no-cache ruby-dev build-base \
  && npm install -g corepack \
  && /usr/bin/python --version \
  && /usr/bin/python -m pip install \


### PR DESCRIPTION
This MR updates the cdxgen-alpine-ruby34 Docker image by adding the ruby-dev and build-base packages.

Motivation:
Previously, running bundle install or generating a Gemfile.lock inside the Alpine-based image would fail due to missing build tools and development headers. This prevented accurate dependency scanning for Ruby projects, especially when a Gemfile.lock is not present.

Changes:
Added ruby-dev and build-base to the Alpine image.
This enables proper compilation of native extensions required by gems like date, nio4r, and websocket-driver.
Allows cdxgen to scan Ruby projects and generate SBOMs reliably, even in projects without an existing lock file.

Impact:
Users can now run CDXGen on Ruby projects in the Alpine image without encountering build failures.
Ruby dependency resolution and SBOM generation are accurate and complete.
Minimal change to the existing image: only the required development packages are added.

Testing:
Verified bundle install runs successfully inside the updated image.
Generated SBOMs include all Ruby dependencies, including those that require native compilation.