### PR TITLE
Using a Keyv-instance as cache

### DIFF
--- a/lib/helpers/utils.js
+++ b/lib/helpers/utils.js
@@ -35,6 +35,7 @@ import { parseEDNString } from "edn-data";
 import { globSync } from "glob";
 import got from "got";
 import iconv from "iconv-lite";
+import Keyv from "keyv";
 import StreamZip from "node-stream-zip";
 import { PackageURL } from "packageurl-js";
 import propertiesReader from "properties-reader";
@@ -672,7 +673,9 @@ export function isPackageManagerAllowed(name, conflictingManagers, options) {
 }
 
 // HTTP cache
-const gotHttpCache = new Map();
+const gotHttpCache = new Keyv();
+// Don't complain when there's lots of parallel requests
+gotHttpCache.setMaxListeners(10000);
 
 function isCacheDisabled() {
   return (

--- a/package.json
+++ b/package.json
@@ -466,6 +466,7 @@
     "iconv-lite": "0.7.0",
     "json-stringify-nice": "1.1.4",
     "jws": "4.0.0",
+    "keyv": "5.5.4",
     "node-stream-zip": "1.15.0",
     "npm-package-arg": "13.0.2",
     "packageurl-js": "1.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -408,6 +408,9 @@ importers:
       jws:
         specifier: 4.0.0
         version: 4.0.0
+      keyv:
+        specifier: 5.5.4
+        version: 5.5.4
       node-stream-zip:
         specifier: 1.15.0
         version: 1.15.0


### PR DESCRIPTION
The update to a newer version of `got`(and therefore `keyv`) a while back, added a lot of output because of parallel requests and the listeners these create.
This PR should fix this by using a Keyv-instance as the cache instead of a normal map, because on the instance we can configure when to start logging the message about the amount of listeners.

Should hopefully fix #2960