### PR TITLE
Bandersnatch removed swift

### DIFF
--- a/.github/workflows/python-atom-tests.yml
+++ b/.github/workflows/python-atom-tests.yml
@@ -118,7 +118,7 @@ jobs:
           source venv/bin/activate
           pip install -r repotests/bandersnatch/requirements.txt
           pip install -r repotests/bandersnatch/requirements_s3.txt
-          pip install -r repotests/bandersnatch/requirements_swift.txt
+          # pip install -r repotests/bandersnatch/requirements_swift.txt
           pip install -r repotests/bandersnatch/requirements_test.txt
           pip install -r repotests/bandersnatch/requirements_docs.txt
           bin/cdxgen.js --no-install-deps -r -t python repotests/bandersnatch -o bomresults/bom-bandersnatch.json --validate


### PR DESCRIPTION
Bandersnatch has removed swift, so our workflow wasn't working anymore.
Commented out the problematic line -- in case we want to put it back in when we start using branches/tags in our workflows.