### PR TITLE
Removed the removal of transitive dependencies for @npmcli/query

### DIFF
--- a/.pnpmfile.cjs
+++ b/.pnpmfile.cjs
@@ -24,9 +24,6 @@ function readPackage(pkg) {
       }
     }
   }
-  if (pkg.name === "@npmcli/query") {
-    delete pkg.dependencies["postcss-selector-parser"];
-  }
   return pkg;
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -314,7 +314,7 @@ overrides:
   yargs-parser: 22.0.0
   yoctocolors: 2.1.2
 
-pnpmfileChecksum: sha256-xIqrTZsTrApDEZEhj31pihm0V6JkRY3/J80/kO0sGFM=
+pnpmfileChecksum: sha256-nfOeuxPm0PLhmHqhdzVKpjFk27e1GEgHAqcQJ7ot+gg=
 
 importers:
 


### PR DESCRIPTION
After removing unused dependencies in #3099, the dependency-removal for its transitives is also no longer needed.