### PR TITLE
[Maven] Multi-module was broken after tree-file debug changes

### DIFF
--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -1721,8 +1721,12 @@ export async function createJavaBom(path, options) {
         result?.status !== 0 ||
         result?.error
       ) {
-        const tempMvnTree = join("target", "cdxgen-mvn-tree.txt");
-        const tempMvnParentTree = join("target", "cdxgen-mvn-parent-tree.txt");
+        const tempMvnTree = join(basePath, "target", "cdxgen-mvn-tree.txt");
+        const tempMvnParentTree = join(
+          basePath,
+          "target",
+          "cdxgen-mvn-parent-tree.txt",
+        );
         let mvnTreeArgs = ["dependency:tree", `-DoutputFile=${tempMvnTree}`];
         let addArgs = "";
         if (process.env.MVN_ARGS) {


### PR DESCRIPTION
Tree-file was being read from the root-path, which was reading the wrong file for sub-modules.

This should fix #3027 & #3075.