### PR TITLE
Elasticsearch can no longer be cloned on Windows

### DIFF
--- a/.github/workflows/repotests.yml
+++ b/.github/workflows/repotests.yml
@@ -495,6 +495,7 @@ jobs:
           ref: 'main'
           path: 'repotests/cocoapods-test'
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        if: runner.os != 'Windows'
         with:
           persist-credentials: false
           repository: 'elastic/elasticsearch'
@@ -857,6 +858,7 @@ jobs:
                                                            COCOA_INCLUDED_TARGETS="cdxgenexpotest copy 2/deep" bin/cdxgen.js -p repotests/cocoapods-test -o bomresults/bom-cocoapods-target-deep.json
         shell: bash
       - name: repotests elasticsearch
+        if: runner.os != 'Windows'
         run: |
           bin/cdxgen.js -t gradle repotests/elasticsearch -o bomresults/bom-elasticsearch.json
         shell: bash


### PR DESCRIPTION
New files have been added that combine into a path(-name) that is too long for Windows.
Disabled elasticsearch build on Windows.