### PR TITLE
Refined output of the 'jq' queries

### DIFF
--- a/.github/workflows/fix-renovate-pnpm-checksum.yml
+++ b/.github/workflows/fix-renovate-pnpm-checksum.yml
@@ -46,12 +46,12 @@ jobs:
             echo "\`\`\`" >> _tree.txt
             echo "Output of \`jq\` on components:" >> _tree.txt
             echo "\`\`\`" >> _tree.txt
-            jq --arg dep "${array[3]}" '.components[] | select(."bom-ref" | test($dep))' bom.json >> _tree.txt
+            jq --arg dep "${array[3]}@" '.components[] | select(."bom-ref" | test($dep)) | { group, name, version, purl, licenses }' bom.json >> _tree.txt
             echo "\`\`\`" >> _tree.txt
             echo "Output of \`jq\` on dependencies:" >> _tree.txt
             echo "\`\`\`" >> _tree.txt
-            jq --arg dep "${array[3]}" '.dependencies[] | select(.ref | test($dep))' bom.json >> _tree.txt
-            jq --arg dep "${array[3]}" '.dependencies[] | select(.dependsOn | any(test($dep)))' bom.json >> _tree.txt
+            jq --arg dep "${array[3]}@" '.dependencies[] | select(.ref | test($dep))' bom.json >> _tree.txt
+            jq --arg dep "${array[3]}@" '.dependencies[] | select(.dependsOn | any(test($dep)))' bom.json >> _tree.txt
             echo "\`\`\`" >> _tree.txt
           fi
         env:


### PR DESCRIPTION
Refined the output of the `jq` queries in the workflow that is triggered by renovate updates of our dependencies:
- Appended a '@' to the name of the dependency, so that other dependencies that start with the same name or not included
- Outputting only the import parts of the component so the comment doesn't get too long