### PR TITLE
upx compression for sea binaries

### DIFF
--- a/.github/workflows/binary-builds.yml
+++ b/.github/workflows/binary-builds.yml
@@ -112,7 +112,7 @@ jobs:
               # Prepare workspace
               rm -rf ADVANCED.md ci contrib devenv.* pyproject.toml renovate.json semicolon_delimited_script test tools_config uv.lock pnpm-workspace.yaml .versions upx-5.1.0*
               pnpm install:prod --config.node-linker=hoisted
-              
+              rm -rf .pnpm-store
               # Set UPX flag based on uname (Works in Docker and on Host)
               UPX_FLAG=""
               if [ "$(uname -s)" = "Linux" ]; then


### PR DESCRIPTION
Enable the upx feature in caxa v2. Seeing around a 10MB reduction in the binary size.