### PR TITLE
Added auto-merge by PR for Docker and GitHub Actions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -25,7 +25,10 @@
       "description": "cdxgen images: separate minor and patch releases, required for the following rules to work correctly",
       "matchDatasources": ["docker"],
       "matchFileNames": ["ci/**/Dockerfile.*"],
-      "extends": [":separatePatchReleases"]
+      "extends": [":separatePatchReleases"],
+      "automerge": "true",
+      "automergeType": "pr",
+      "minimumReleaseAge": "1 day"
     },
     {
       "description": "cdxgen images: exclude major version updates for images pinned to a specific major version by filename convention",
@@ -78,7 +81,10 @@
       "extends": ["helpers:pinGitHubActionDigests"],
       "matchPackageNames": ["addnab/docker-run-action"],
       "extractVersion": "^(?<version>v?\\d+)$",
-      "versioning": "regex:^v?(?<major>\\d+)(\\.(?<minor>\\d+)\\.(?<patch>\\d+))?$"
+      "versioning": "regex:^v?(?<major>\\d+)(\\.(?<minor>\\d+)\\.(?<patch>\\d+))?$",
+      "automerge": "true",
+      "automergeType": "pr",
+      "minimumReleaseAge": "1 day"
     },
     {
       "description": "Automerge digest pins for latest tags",
@@ -86,7 +92,8 @@
       "matchUpdateTypes": ["digest"],
       "matchCurrentValue": "latest",
       "automerge": true,
-      "automergeType": "branch",
+      "automergeType": "pr",
+      "minimumReleaseAge": "1 day",
       "minimumReleaseAgeBehaviour": "timestamp-optional"
     },
     {


### PR DESCRIPTION
Allowing Renovate to auto-merge updates to the base images in the Dockerfile and updates to GH actions after creating a PR and all workflows have succeeded.