### PR TITLE
Fix: handle objects in dependency-groups (PEP 735)

### DIFF
--- a/lib/helpers/utils.js
+++ b/lib/helpers/utils.js
@@ -5762,11 +5762,15 @@ export function parsePyProjectTomlFile(tomlFile) {
   if (tomlData["dependency-groups"]) {
     for (const agroup of Object.keys(tomlData["dependency-groups"])) {
       tomlData["dependency-groups"][agroup].forEach((p) => {
-        const pname = p.split(/(==|<=|~=|>=)/)[0].split(" ")[0];
-        if (!groupDepsKeys[pname]) {
-          groupDepsKeys[pname] = [];
+        if (typeof p === "string" || p instanceof String) {
+          const pname = p.split(/(==|<=|~=|>=)/)[0].split(" ")[0];
+          if (!groupDepsKeys[pname]) {
+            groupDepsKeys[pname] = [];
+          }
+          groupDepsKeys[pname].push(agroup);
+        } else {
+          return;
         }
-        groupDepsKeys[pname].push(agroup);
       });
     }
   }

--- a/test/data/pyproject_uv-workspace.toml
+++ b/test/data/pyproject_uv-workspace.toml
@@ -13,6 +13,9 @@ dev = [
     "ruff >= 0.8.1",
     "pytest >= 8.3.4",
 ]
+all = [
+    { include-group = "dev" },
+]
 
 [tool.uv.sources]
 my-lib = { workspace = true }

--- a/test/data/pyproject_uv.toml
+++ b/test/data/pyproject_uv.toml
@@ -30,6 +30,9 @@ dev = [
     "requests>=2.32.3",
     "ruff>=0.7.1",
 ]
+all = [
+    { include-group = "dev" },
+]
 
 [project.urls]
 Repository = "https://github.com/rednafi/fastapi-nano.git"


### PR DESCRIPTION
Hello! I have problems with pyproject.toml file, generated by `pip-compile / uv pip compile` commands.

If `[dependency-groups]` have section with object, like `all = [
    { include-group = "dev" },` [docs](https://packaging.python.org/en/latest/specifications/dependency-groups/#dependency-groups)
], an error occurred:
```
file:///opt/homebrew/lib/node_modules/@cyclonedx/cdxgen/lib/helpers/utils.js:5761
const pname = p.split(/(==|<=|~=|>=)/)[0].split(" ")[0];
^
TypeError: p.split is not a function
at file:///opt/homebrew/lib/node_modules/@cyclonedx/cdxgen/lib/helpers/utils.js:5761:25
at Array.forEach (<anonymous>)
```

This error leads to not creating bom.json file.  I tried to fix this exception and update test data for python.