### PR TITLE
Add arguments to prevent trivy telemetry and version check (#3499)

### DIFF
--- a/lib/managers/binary.js
+++ b/lib/managers/binary.js
@@ -464,6 +464,8 @@ export async function getOSPackages(src, imageConfig) {
       "--skip-db-update",
       "--skip-java-db-update",
       "--offline-scan",
+      "--disable-telemetry",
+      "--skip-version-check",
       "--skip-files",
       "**/*.jar,**/*.war,**/*.par,**/*.ear",
       "--no-progress",


### PR DESCRIPTION
This adds the arguments `--disable-telemetry` and `--skip-version-check` to the call to trivy to prevent it from sending request to check.trivy.dev as reported in #3499.
It has been tested with a local HTTP proxy to make sure that `cdxgen` runs completely offline while scanning a Docker image.
The argument `--disable-telemetry` does not have to have any affect regarding requests to check.trivy.dev but has been added for completeness to prevent those requests in the future.