### PR TITLE
[images] Removed dependency on YUM packages for Node.js

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -77,5 +77,5 @@ jobs:
           dockerfile: ${{ matrix.imagefile }}
           docker-args: |
             ${{ steps.versions.outputs.docker-args }}
-          platforms: ${{ matrix.platform }}
+          platforms: linux/${{ matrix.platform }}
           target: cdxgen

--- a/ci/images/opensuse/Dockerfile.python3.10
+++ b/ci/images/opensuse/Dockerfile.python3.10
@@ -1,12 +1,17 @@
 # Base-image
 FROM registry.opensuse.org/opensuse/bci/python:3.10@sha256:391f2259cc0b729e790f8328592c266188b6bad6af92f987ae024e1f28ef8b8a AS base
 
+ARG GITHUB_RAW_URL=https://raw.githubusercontent.com
 ARG GITHUB_URL=https://github.com
 # renovate: datasource=golang-version depName=golang
 ARG GO_VERSION=1.26.0
 ARG GOOGLE_URL=https://dl.google.com
+ARG NODE_22
+ARG NODE_VERSION=${NODE_22}
 ARG NODEJS_DIST_URL
 ARG NPM_REPO
+ARG NVM
+ARG NVM_VERSION=${NVM}
 ARG OPENSUSE_CODECS_REPO
 ARG OPENSUSE_REPO
 ARG PIP_CONFIG
@@ -16,9 +21,10 @@ ENV CC=gcc \
     LANG=en_US.UTF-8 \
     LANGUAGE=en_US.UTF-8 \
     LC_ALL=en_US.UTF-8 \
+    NVM_DIR="/root/.nvm" \
     PYTHONPATH=/opt/pypi \
     npm_config_python=/usr/bin/python3.10
-ENV PATH=${PATH}:/usr/local/bin:${PYTHONPATH}/bin:${GOPATH}/bin:/usr/local/go/bin
+ENV PATH=${PATH}:/usr/local/bin:${NVM_DIR}/versions/node/v${NODE_VERSION}/bin:${PYTHONPATH}/bin:${GOPATH}/bin:/usr/local/go/bin
 
 RUN set -e; \
     if [ -n "$NODEJS_DIST_URL" ]; then \
@@ -70,9 +76,6 @@ RUN set -e; \
           java-25-openjdk-devel \
           libxml2-devel \
           make \
-          nodejs22 \
-          nodejs22-devel \
-          npm22 \
           python310 \
           python310-devel \
           python310-pip \
@@ -104,14 +107,15 @@ RUN set -e; \
  && tar -C /usr/local -xzf go${GO_VERSION}.linux-${GOBIN_VERSION}.tar.gz \
  && rm go${GO_VERSION}.linux-${GOBIN_VERSION}.tar.gz \
  && go telemetry off \
- && npm install -g \
-      npm \
+ && curl -o- $GITHUB_RAW_URL/nvm-sh/nvm/$NVM_VERSION/install.sh | bash \
+ && source ${NVM_DIR}/nvm.sh \
+ && nvm install ${NODE_VERSION} \
+ && node -v \
+ && npm -v \
  && npm install -g \
       corepack \
       node-gyp \
  && npx node-gyp install \
- && node -v \
- && npm -v \
  && poetry --version \
  && pipenv --version \
  && gcc --version \

--- a/ci/images/opensuse/Dockerfile.python3.9
+++ b/ci/images/opensuse/Dockerfile.python3.9
@@ -1,9 +1,14 @@
 # Base-image
 FROM registry.opensuse.org/opensuse/bci/python:3.9@sha256:47094e244334645440158a27e3e1dcebccd6bcb18d973d168eb3cdfc649632a3 AS base
 
+ARG GITHUB_RAW_URL=https://raw.githubusercontent.com
 ARG GITHUB_URL=https://github.com
+ARG NODE_22
+ARG NODE_VERSION=${NODE_22}
 ARG NODEJS_DIST_URL
 ARG NPM_REPO
+ARG NVM
+ARG NVM_VERSION=${NVM}
 ARG OPENSUSE_CODECS_REPO
 ARG OPENSUSE_REPO
 ARG PIP_CONFIG
@@ -12,9 +17,10 @@ ENV CC=gcc \
     LANG=en_US.UTF-8 \
     LANGUAGE=en_US.UTF-8 \
     LC_ALL=en_US.UTF-8 \
+    NVM_DIR="/root/.nvm" \
     PYTHONPATH=/opt/pypi \
     npm_config_python=/usr/bin/python3.9
-ENV PATH=${PATH}:/usr/local/bin:${PYTHONPATH}/bin
+ENV PATH=${PATH}:/usr/local/bin:${NVM_DIR}/versions/node/v${NODE_VERSION}/bin:${PYTHONPATH}/bin
 
 RUN set -e; \
     if [ -n "$NODEJS_DIST_URL" ]; then \
@@ -66,9 +72,6 @@ RUN set -e; \
           java-25-openjdk-devel \
           libxml2-devel \
           make \
-          nodejs22 \
-          nodejs22-devel \
-          npm22 \
           python39 \
           python39-devel \
           python39-pip \
@@ -95,10 +98,15 @@ RUN set -e; \
         pipenv \
         poetry \
         uv \
- && npm install -g npm \
+ && curl -o- $GITHUB_RAW_URL/nvm-sh/nvm/$NVM_VERSION/install.sh | bash \
+ && source ${NVM_DIR}/nvm.sh \
+ && nvm install ${NODE_VERSION} \
  && node -v \
  && npm -v \
- && npm install -g corepack \
+ && npm install -g \
+      corepack \
+      node-gyp \
+ && npx node-gyp install \
  && poetry --version \
  && pipenv --version \
  && gcc --version \

--- a/ci/images/opensuse/Dockerfile.rolling
+++ b/ci/images/opensuse/Dockerfile.rolling
@@ -150,7 +150,6 @@ RUN set -e; \
       corepack \
       node-gyp \
  && npx node-gyp install \
- && npm install -g corepack \
  && poetry --version \
  && pipenv --version \
  && blint --help \


### PR DESCRIPTION
OpenSUSE keeps removing packages from their repo. This PR removes our usage of their packages for Node.js and instead installs it using NVM.

Reverted the changes made to build OpenSUSE images on hosted runners as they are not needed anymore and were *ALWAYS* running the OpenSUSE images.