### PR TITLE
fix(ruby): set metadata.component.name from root gemspec

### DIFF
--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -6511,6 +6511,7 @@ export async function createRubyBom(path, options) {
     }
   }
   // Parsing .gemspec files would help us get more metadata such as description, authors, licenses etc
+  let rootGemspecComponent;
   if (gemspecFiles.length) {
     if (!gemLockFiles.length && !hasAnyProjectType(["oci"], options, false)) {
       console.log(
@@ -6524,7 +6525,32 @@ export async function createRubyBom(path, options) {
       if (gpkgList.length) {
         pkgList = pkgList.concat(gpkgList);
         pkgList = trimComponents(pkgList);
+        if (
+          !rootGemspecComponent &&
+          dirname(resolve(f)) === resolve(path) &&
+          gpkgList[0]?.name
+        ) {
+          rootGemspecComponent = gpkgList[0];
+        }
       }
+    }
+    if (
+      rootGemspecComponent &&
+      !("project-name" in options) &&
+      options.projectName === undefined
+    ) {
+      parentComponent.name = rootGemspecComponent.name;
+      parentComponent.version = rootGemspecComponent.version || "latest";
+      const parentPurl = new PackageURL(
+        "gem",
+        parentComponent.group,
+        parentComponent.name,
+        parentComponent.version,
+        null,
+        null,
+      ).toString();
+      parentComponent["bom-ref"] = decodeURIComponent(parentPurl);
+      parentComponent["purl"] = parentPurl;
     }
   }
   if (rootList.length) {


### PR DESCRIPTION
## Summary
- detect the root-level `.gemspec` component while building Ruby SBOMs
- when `--project-name` is not explicitly provided, use that root gemspec name/version for `metadata.component`
- keep existing behavior for explicit project naming and dependency parsing unchanged

## Testing
- `pnpm test lib/cli/index.poku.js --sequential`
- `pnpm test lib/helpers/utils.poku.js --sequential`

## Related
Fixes #1844