### PR TITLE
Updated deno to latest 2.6.x

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -192,7 +192,7 @@ jobs:
           node-version-file: .nvmrc
       - uses: denoland/setup-deno@e95548e56dfa95d4e1a28d6f422fafe75c4c26fb # v2.0.3
         with:
-          deno-version: 2.6.8
+          deno-version: 2.6.10
       - name: pnpm install, build and test
         run: |
           pnpm install:frozen

--- a/.github/workflows/repotests.yml
+++ b/.github/workflows/repotests.yml
@@ -202,7 +202,7 @@ jobs:
           node-version-file: .nvmrc
       - uses: denoland/setup-deno@e95548e56dfa95d4e1a28d6f422fafe75c4c26fb # v2.0.3
         with:
-          deno-version: 2.6.8
+          deno-version: 2.6.10
       - uses: oven-sh/setup-bun@ecf28ddc73e819eb6fa29df6b34ef8921c743461 # v2.1.3
         with:
           bun-version: 1.3.10

--- a/package.json
+++ b/package.json
@@ -815,7 +815,7 @@
       },
       {
         "name": "deno",
-        "version": "2.6.8",
+        "version": "2.6.10",
         "onFail": "ignore"
       }
     ]


### PR DESCRIPTION
The renovate update to deno 2.7.x doesn't work -- let's update to the latest 2.6.x first and go from there.